### PR TITLE
Propagate mouse down event to hot widgets.

### DIFF
--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -569,7 +569,9 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                     child_ctx.base_state.is_hot = true;
                     hot_changed = Some(true);
                 }
-                recurse = had_active || !ctx.had_active && now_hot;
+                // Always recurse when hot to prevent active widgets from dominating.
+                // See: https://github.com/xi-editor/druid/pull/396
+                recurse = had_active || now_hot;
                 let mut mouse_event = mouse_event.clone();
                 mouse_event.pos -= rect.origin().to_vec2();
                 Event::MouseDown(mouse_event)

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -80,8 +80,10 @@ impl<T: Data> Widget<T> for Button<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         match event {
             Event::MouseDown(_) => {
-                ctx.set_active(true);
-                ctx.invalidate();
+                if ctx.is_active() != ctx.is_hot() {
+                    ctx.set_active(ctx.is_hot());
+                    ctx.invalidate();
+                }
             }
             Event::MouseUp(_) => {
                 if ctx.is_active() {

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -36,8 +36,10 @@ impl Widget<bool> for Checkbox {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut bool, _env: &Env) {
         match event {
             Event::MouseDown(_) => {
-                ctx.set_active(true);
-                ctx.invalidate();
+                if ctx.is_active() != ctx.is_hot() {
+                    ctx.set_active(ctx.is_hot());
+                    ctx.invalidate();
+                }
             }
             Event::MouseUp(_) => {
                 if ctx.is_active() {

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -66,8 +66,10 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, _env: &Env) {
         match event {
             Event::MouseDown(_) => {
-                ctx.set_active(true);
-                ctx.invalidate();
+                if ctx.is_active() != ctx.is_hot() {
+                    ctx.set_active(ctx.is_hot());
+                    ctx.invalidate();
+                }
             }
             Event::MouseUp(_) => {
                 if ctx.is_active() {

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -56,7 +56,7 @@ impl Widget<f64> for Slider {
 
         match event {
             Event::MouseDown(mouse) => {
-                ctx.set_active(true);
+                ctx.set_active(ctx.is_hot());
                 if self.knob_hit_test(knob_size, mouse.pos) {
                     self.x_offset = self.knob_pos.x - mouse.pos.x
                 } else {

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -140,11 +140,13 @@ impl<T: Data> Widget<T> for Split<T> {
         if self.draggable {
             match event {
                 Event::MouseDown(mouse) => {
-                    if mouse.button.is_left()
-                        && self.splitter_hit_test(ctx.base_state.size(), mouse.pos)
-                    {
-                        ctx.set_active(true);
-                        ctx.set_handled();
+                    if mouse.button.is_left() {
+                        if self.splitter_hit_test(ctx.base_state.size(), mouse.pos) {
+                            ctx.set_active(true);
+                            ctx.set_handled();
+                        } else {
+                            ctx.set_active(false);
+                        }
                     }
                 }
                 Event::MouseUp(mouse) => {

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -222,6 +222,8 @@ impl TextBox {
 }
 
 impl Widget<String> for TextBox {
+    // TODO: Refactor the event function to please clippy
+    #[allow(clippy::cognitive_complexity)]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut String, env: &Env) {
         // Guard against external changes in data
         self.selection = self.selection.constrain_to(data);
@@ -229,16 +231,21 @@ impl Widget<String> for TextBox {
         let mut text_layout = self.get_layout(ctx.text(), data, env);
         match event {
             Event::MouseDown(mouse) => {
-                ctx.request_focus();
-                ctx.set_active(true);
-                let cursor_off = self.offset_for_point(mouse.pos, &text_layout);
-                if mouse.mods.shift {
-                    self.selection.end = cursor_off;
+                if ctx.is_hot() {
+                    ctx.request_focus();
+                    ctx.set_active(true);
+                    let cursor_off = self.offset_for_point(mouse.pos, &text_layout);
+                    if mouse.mods.shift {
+                        self.selection.end = cursor_off;
+                    } else {
+                        self.cursor_to(cursor_off);
+                    }
+                    ctx.invalidate();
+                    self.reset_cursor_blink(ctx);
                 } else {
-                    self.cursor_to(cursor_off);
+                    ctx.set_active(false);
+                    ctx.invalidate();
                 }
-                ctx.invalidate();
-                self.reset_cursor_blink(ctx);
             }
             Event::MouseMoved(mouse) => {
                 ctx.set_cursor(&Cursor::IBeam);


### PR DESCRIPTION
### Summary

This PR removes a check that prevented mouse down events propagating to hot widgets if some other widget was active.

### Event flow change

Consider a scenario where we have a window with two buttons A & B.

* Click on button A and its MouseDown handler sets the button as active and opens a modal dialog.
* The MouseUp event gets consumed by the new modal dialog and never reaches druid.
* When the modal is finally closed, click on button B. Button B never gets the event because button A is still active. Button A gets the MouseDown event instead and sets itself active once again, plus it opens the modal dialog again which prevents the MouseUp event from being sent.

After clicking button A, whatever you click later will act as a click on button A.

A workaround would be to never do anything in a MouseDown handler that could impact OS event flow. That seems like a big ask though and when you do, it's not clear what's going on, as I was confused by this during my testing. 

It's not just about what the druid app is doing either. There may be other apps running on the computer that suddenly steal focus, just after a user clicked the mouse but before they released it. It would end up in the same scenario.

Thus to make druid more robust, this PR propagates the MouseDown event to hot widgets regardless of whether any other widget is active.

### Widget improvements

I also improved the widgets to work better under circumstances where every MouseDown event doesn't have a buddy MouseUp event.

The button widget now realizes it's no longer active if a MouseDown event happens when the button isn't hot. This allows it to restore it's non-active state sooner.

Similarly the switch widget now animates to its final state already during a MouseDown elsewhere, without waiting for a MouseUp, which may never come.
