### PR TITLE
Immediate mode widget

### DIFF
--- a/druid/src/widget/immediate.rs
+++ b/druid/src/widget/immediate.rs
@@ -1,11 +1,39 @@
+// Copyright 2020 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::{widget::prelude::*, Data};
 
+/// A widget that allows writing parts of the ui in an immediate-mode style.
+///
+/// The primary usecase for this is displaying data that doesn't fit into druids model, such as
+/// enums you have no control over.
+///
+/// Whenever the state represented by the `Immediate` changes,
+/// it will reconstruct its content for the new data.
+///
+/// While this is not the most efficient thing to do, it is very simple and performs perfectly fine
+/// for small or rarely changed data.
+///
+/// Note that this is more like a last resort when the data to be represented is in a for druid particularly
+/// unfitting format.
 pub struct Immediate<D, W: Widget<()>> {
     constructor: Box<dyn Fn(&D) -> W>,
     content: Option<W>,
 }
 
 impl<D, W: Widget<()>> Immediate<D, W> {
+    /// Takes a constructor for a stateless widget
     pub fn new(constructor: impl Fn(&D) -> W + 'static) -> Self {
         Self {
             constructor: Box::new(constructor),

--- a/druid/src/widget/immediate.rs
+++ b/druid/src/widget/immediate.rs
@@ -1,0 +1,58 @@
+use crate::{widget::prelude::*, Data};
+
+pub struct Immediate<D, W: Widget<()>> {
+    constructor: Box<dyn Fn(&D) -> W>,
+    content: Option<W>,
+}
+
+impl<D, W: Widget<()>> Immediate<D, W> {
+    pub fn new(constructor: impl Fn(&D) -> W + 'static) -> Self {
+        Self {
+            constructor: Box::new(constructor),
+            content: None,
+        }
+    }
+}
+
+impl<D: Data, W: Widget<()>> Widget<D> for Immediate<D, W> {
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, _data: &mut D, env: &Env) {
+        if let Some(content) = &mut self.content {
+            content.event(ctx, event, &mut (), env);
+        }
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &D, env: &Env) {
+        if let LifeCycle::WidgetAdded = event {
+            self.content = Some((self.constructor)(data));
+        }
+        if let Some(content) = &mut self.content {
+            content.lifecycle(ctx, event, &(), env);
+        }
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &D, data: &D, env: &Env) {
+        if !old_data.same(data) {
+            self.content = Some((self.constructor)(data));
+            ctx.children_changed();
+        } else {
+            // This can happen when env changes, right?
+            if let Some(content) = &mut self.content {
+                content.update(ctx, &(), &(), env);
+            }
+        }
+    }
+
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, _data: &D, env: &Env) -> Size {
+        if let Some(content) = &mut self.content {
+            content.layout(ctx, bc, &(), env)
+        } else {
+            Size::ZERO
+        }
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, _data: &D, env: &Env) {
+        if let Some(content) = &mut self.content {
+            content.paint(ctx, &(), env);
+        }
+    }
+}

--- a/druid/src/widget/immediate.rs
+++ b/druid/src/widget/immediate.rs
@@ -26,7 +26,7 @@ use crate::{widget::prelude::*, Data};
 /// for small or rarely changed data.
 ///
 /// You should only use `Immediate` if your data format can't be reasonably used with other widgets.
-pub struct Immediate<D, W: Widget<()>> {
+pub struct Immediate<D, W> {
     constructor: Box<dyn Fn(&D) -> W>,
     content: Option<W>,
 }
@@ -70,11 +70,10 @@ impl<D: Data, W: Widget<()>> Widget<D> for Immediate<D, W> {
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, _data: &D, env: &Env) -> Size {
-        if let Some(content) = &mut self.content {
-            content.layout(ctx, bc, &(), env)
-        } else {
-            Size::ZERO
-        }
+        self.content
+            .as_mut()
+            .map(|c| c.layout(ctx, bc, &(), env))
+            .unwrap_or_default()
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, _data: &D, env: &Env) {

--- a/druid/src/widget/immediate.rs
+++ b/druid/src/widget/immediate.rs
@@ -16,7 +16,7 @@ use crate::{widget::prelude::*, Data};
 
 /// A widget that allows writing parts of the ui in an immediate-mode style.
 ///
-/// The primary usecase for this is displaying data that doesn't fit into druids model, such as
+/// The primary use case for this is displaying data that doesn't fit into druid's model, such as
 /// enums you have no control over.
 ///
 /// Whenever the state represented by the `Immediate` changes,
@@ -25,8 +25,7 @@ use crate::{widget::prelude::*, Data};
 /// While this is not the most efficient thing to do, it is very simple and performs perfectly fine
 /// for small or rarely changed data.
 ///
-/// Note that this is more like a last resort when the data to be represented is in a for druid particularly
-/// unfitting format.
+/// You should only use `Immediate` if your data format can't be reasonably used with other widgets.
 pub struct Immediate<D, W: Widget<()>> {
     constructor: Box<dyn Fn(&D) -> W>,
     content: Option<W>,

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -28,6 +28,7 @@ mod identity_wrapper;
 #[cfg(feature = "image")]
 #[cfg_attr(docsrs, doc(cfg(feature = "image")))]
 mod image;
+mod immediate;
 mod label;
 mod list;
 mod padding;
@@ -62,6 +63,7 @@ pub use either::Either;
 pub use env_scope::EnvScope;
 pub use flex::{CrossAxisAlignment, Flex, FlexParams, MainAxisAlignment};
 pub use identity_wrapper::IdentityWrapper;
+pub use immediate::Immediate;
 pub use label::{Label, LabelText};
 pub use list::{List, ListIter};
 pub use padding::Padding;


### PR DESCRIPTION
This will add a widget that allows writing parts of the ui in an immediate-mode style.

The reason I wrote this was for an event logger which should display events which look like this:
```rust
pub enum Event {
    WindowConnected,
    Size(Size),
    MouseDown(MouseEvent),
    MouseUp(MouseEvent),
    MouseMoved(MouseEvent),
    KeyDown(KeyEvent),
    KeyUp(KeyEvent),
    Paste(Clipboard),
    Wheel(WheelEvent),
    Zoom(f64),
    Timer(TimerToken),
    Command(Command),
    TargetedCommand(Target, Command),
}
```

There are two problems with representing this in druid:
- As of now, druid has no good way to represent enums
- The enum in question is not meant to be displayed

The latter means it does not derive `Data`, nor does any of its variants and even when druid had support for enums using some sort of proc-macro derive it still would be no use as such a derive would not be part of an `Event`.

The solution I came up with is this `Immediate` widget. Immediate mode fits Rust really well and makes this (mostly) a trivial, standard Rust `match` statement:
```rust
#[derive(Data)]
struct UiEvent {
    #[druid(same_fn = "PartialEq::eq")]
    inner: Event
}

Immediate::new(|event: &UiEvent| {
    match event.inner {
        Event::Size(size) => Label::new(format!("w: {}, h: {}", size.width, size.height)),
        _ => Label::new("Unhandled Event"),
    }
});
```
And such a wrapper is probably not necessary in most cases as the data in question would already be inside some other `Data` deriving structure of the ui state.

The `Immediate::new` function expects a function `&Data -> impl Widget<()>`.

I chose `Widget<()>` because it prevents one from using anything that depends on data, such as `Label::dynamic`. Using `Label::dynamic` does not make any sens in immediate-mode as the `Label` will be reconstructed anyway when the data changes.

A limitation of this design as of now is that there is no way to mutate the app state from the immediate-mode code, for example if a `Button` was in there. In order to do mutations such a `Button` would have to issue a command using `EventCtx` to do so.

I have not yet had the need to do state mutation inside `Immediate` but was wondering if there could be a nicer way to allow mutations. (One way to do so could be using `Widget<Data>` instead of `Widget<()>`, but that feels wrong as well, for the reason above)