### PR TITLE
Add more file dialog configuration and macOS support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - `im` feature, with `Data` support for the [`im` crate](https://docs.rs/im/) collections. ([#924] by [@cmyr])
 - `im::Vector` support for the `List` widget. ([#940] by [@xStrom])
 - `LifeCycle::Size` event to inform widgets that their size changed. ([#953] by [@xStrom])
+- `FileDialogOptions` methods `default_name`, `name_label`, `title`, `button_text`, `force_starting_directory`. ([#960] by [@xStrom])
 - `Button::dynamic` constructor. ([#963] by [@totsteps])
 - `set_menu` method on `UpdateCtx` and `LifeCycleCtx` ([#970] by [@cmyr])
 
@@ -112,6 +113,8 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - Built-in open and save menu items now show the correct label and submit the right commands. ([#930] by [@finnerale])
 - Focus request handling is now predictable with the last request overriding earlier ones. ([#948] by [@xStrom])
 - Wheel events now properly update hot state. ([#951] by [@xStrom])
+- macOS: Support `FileDialogOptions::default_type`. ([#960] by [@xStrom])
+- macOS: Show the save dialog even with `FileDialogOptions` `select_directories` and `multi_selection` set. ([#960] by [@xStrom])
 - X11: Support mouse scrolling. ([#961] by [@jneem])
 - `Painter` now properly repaints on data change in `Container`. ([#991] by [@cmyr])
 
@@ -232,6 +235,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 [#953]: https://github.com/xi-editor/druid/pull/953
 [#954]: https://github.com/xi-editor/druid/pull/954
 [#959]: https://github.com/xi-editor/druid/pull/959
+[#960]: https://github.com/xi-editor/druid/pull/960
 [#961]: https://github.com/xi-editor/druid/pull/961
 [#963]: https://github.com/xi-editor/druid/pull/963
 [#964]: https://github.com/xi-editor/druid/pull/964

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - `im` feature, with `Data` support for the [`im` crate](https://docs.rs/im/) collections. ([#924] by [@cmyr])
 - `im::Vector` support for the `List` widget. ([#940] by [@xStrom])
 - `LifeCycle::Size` event to inform widgets that their size changed. ([#953] by [@xStrom])
-- `FileDialogOptions` methods `default_name`, `name_label`, `title`, `button_text`, `force_starting_directory`. ([#960] by [@xStrom])
+- `FileDialogOptions` methods `default_name`, `name_label`, `title`, `button_text`, `packages_as_directories`, `force_starting_directory`. ([#960] by [@xStrom])
 - `Button::dynamic` constructor. ([#963] by [@totsteps])
 - `set_menu` method on `UpdateCtx` and `LifeCycleCtx` ([#970] by [@cmyr])
 

--- a/druid-shell/src/dialog.rs
+++ b/druid-shell/src/dialog.rs
@@ -33,19 +33,17 @@ pub enum FileDialogType {
 
 /// Options for file dialogs.
 #[derive(Debug, Clone, Default)]
-pub struct FileDialogOptions<'a> {
-    pub show_hidden: bool,
-    pub allowed_types: Option<Vec<FileSpec<'a>>>,
-    pub default_type: Option<FileSpec<'a>>,
-    pub select_directories: bool,
-    pub multi_selection: bool,
-    pub default_name: Option<&'a str>,
-    pub name_label: Option<&'a str>,
-    pub title: Option<&'a str>,
-    pub button_text: Option<&'a str>,
-    pub starting_directory: Option<&'a Path>,
-    // we don't want a library user to be able to construct this type directly
-    __non_exhaustive: (),
+pub struct FileDialogOptions {
+    pub(crate) show_hidden: bool,
+    pub(crate) allowed_types: Option<Vec<FileSpec>>,
+    pub(crate) default_type: Option<FileSpec>,
+    pub(crate) select_directories: bool,
+    pub(crate) multi_selection: bool,
+    pub(crate) default_name: Option<String>,
+    pub(crate) name_label: Option<String>,
+    pub(crate) title: Option<String>,
+    pub(crate) button_text: Option<String>,
+    pub(crate) starting_directory: Option<PathBuf>,
 }
 
 /// A description of a filetype, for specifiying allowed types in a file dialog.
@@ -57,7 +55,7 @@ pub struct FileDialogOptions<'a> {
 ///
 /// [`COMDLG_FILTERSPEC`]: https://docs.microsoft.com/en-ca/windows/win32/api/shtypes/ns-shtypes-comdlg_filterspec
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct FileSpec<'a> {
+pub struct FileSpec {
     /// A human readable name, describing this filetype.
     ///
     /// This is used in the Windows file dialog, where the user can select
@@ -66,11 +64,11 @@ pub struct FileSpec<'a> {
     /// This should not include the file extensions; they will be added automatically.
     /// For instance, if we are describing Word documents, the name would be "Word Document",
     /// and the displayed string would be "Word Document (*.doc)".
-    pub name: &'a str,
+    pub name: &'static str,
     /// The file extensions used by this file type.
     ///
     /// This should not include the leading '.'.
-    pub extensions: &'a [&'a str],
+    pub extensions: &'static [&'static str],
 }
 
 impl FileInfo {
@@ -80,23 +78,19 @@ impl FileInfo {
     }
 }
 
-impl<'a> FileDialogOptions<'a> {
+impl FileDialogOptions {
     /// Create a new set of options.
-    pub fn new() -> FileDialogOptions<'static> {
+    pub fn new() -> FileDialogOptions {
         FileDialogOptions::default()
     }
 
-    /// Set whether hidden files and folders are shown.
-    ///
-    /// # macOS
-    ///
-    /// This option only shows hidden files, folders remain hidden.
+    /// Set hidden files and directories to be visible.
     pub fn show_hidden(mut self) -> Self {
         self.show_hidden = true;
         self
     }
 
-    /// Set whether folders should be selectable instead of files.
+    /// Set directories to be selectable instead of files.
     ///
     /// This is only relevant for open dialogs.
     pub fn select_directories(mut self) -> Self {
@@ -104,7 +98,7 @@ impl<'a> FileDialogOptions<'a> {
         self
     }
 
-    /// Set whether multiple items can be selected.
+    /// Set multiple items to be selectable.
     ///
     /// This is only relevant for open dialogs.
     pub fn multi_selection(mut self) -> Self {
@@ -115,7 +109,7 @@ impl<'a> FileDialogOptions<'a> {
     /// Set the file types the user is allowed to select.
     ///
     /// An empty collection is treated as no filter.
-    pub fn allowed_types(mut self, types: Vec<FileSpec<'a>>) -> Self {
+    pub fn allowed_types(mut self, types: Vec<FileSpec>) -> Self {
         // An empty vector can cause platform issues, so treat it as no filter
         if types.is_empty() {
             self.allowed_types = None;
@@ -127,61 +121,61 @@ impl<'a> FileDialogOptions<'a> {
 
     /// Set the default file type.
     ///
-    /// The provided `FileSpec` must be also present in [`allowed_types`].
+    /// The provided `default_type` must also be present in [`allowed_types`].
     ///
     /// If it's `None` then the first entry in [`allowed_types`] will be used as the default.
     ///
     /// [`allowed_types`]: #method.allowed_types
-    pub fn default_type(mut self, default_type: FileSpec<'a>) -> Self {
+    pub fn default_type(mut self, default_type: FileSpec) -> Self {
         self.default_type = Some(default_type);
         self
     }
 
     /// Set the default filename that appears in the dialog.
-    pub fn default_name(mut self, default_name: &'a str) -> Self {
-        self.default_name = Some(default_name);
+    pub fn default_name(mut self, default_name: impl Into<String>) -> Self {
+        self.default_name = Some(default_name.into());
         self
     }
 
     /// Set the text in the label next to the filename editbox.
-    pub fn name_label(mut self, name_label: &'a str) -> Self {
-        self.name_label = Some(name_label);
+    pub fn name_label(mut self, name_label: impl Into<String>) -> Self {
+        self.name_label = Some(name_label.into());
         self
     }
 
     /// Set the title text of the dialog.
-    pub fn title(mut self, title: &'a str) -> Self {
-        self.title = Some(title);
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
         self
     }
 
     /// Set the text of the Open/Save button.
-    pub fn button_text(mut self, text: &'a str) -> Self {
-        self.button_text = Some(text);
+    pub fn button_text(mut self, text: impl Into<String>) -> Self {
+        self.button_text = Some(text.into());
         self
     }
 
-    /// Force the starting folder to the specified `Path`.
+    /// Force the starting directory to the specified `path`.
     ///
     /// # User experience
     ///
     /// This should almost never be used because it overrides the OS choice,
-    /// which will usually be a folder that the user recently visited.
-    pub fn force_starting_directory(mut self, path: &'a Path) -> Self {
-        self.starting_directory = Some(path);
+    /// which will usually be a directory that the user recently visited.
+    pub fn force_starting_directory(mut self, path: impl Into<PathBuf>) -> Self {
+        self.starting_directory = Some(path.into());
         self
     }
 }
 
-impl<'a> FileSpec<'a> {
-    pub const TEXT: FileSpec<'a> = FileSpec::new("Text", &["txt"]);
-    pub const JPG: FileSpec<'a> = FileSpec::new("Jpeg", &["jpg", "jpeg"]);
-    pub const GIF: FileSpec<'a> = FileSpec::new("Gif", &["gif"]);
-    pub const PDF: FileSpec<'a> = FileSpec::new("PDF", &["pdf"]);
-    pub const HTML: FileSpec<'a> = FileSpec::new("Web Page", &["htm", "html"]);
+impl FileSpec {
+    pub const TEXT: FileSpec = FileSpec::new("Text", &["txt"]);
+    pub const JPG: FileSpec = FileSpec::new("Jpeg", &["jpg", "jpeg"]);
+    pub const GIF: FileSpec = FileSpec::new("Gif", &["gif"]);
+    pub const PDF: FileSpec = FileSpec::new("PDF", &["pdf"]);
+    pub const HTML: FileSpec = FileSpec::new("Web Page", &["htm", "html"]);
 
     /// Create a new `FileSpec`.
-    pub const fn new(name: &'a str, extensions: &'a [&'a str]) -> Self {
+    pub const fn new(name: &'static str, extensions: &'static [&'static str]) -> Self {
         FileSpec { name, extensions }
     }
 }

--- a/druid-shell/src/dialog.rs
+++ b/druid-shell/src/dialog.rs
@@ -47,10 +47,24 @@ pub enum FileDialogType {
 ///
 /// # Cross-platform compatibility
 ///
-/// If you don't want to write platform specific code then your application should avoid
-/// having to deal with directories that have extensions in their name, e.g. `my_stuff.pkg`.
-/// This clashes with [packages] on macOS and you will either need platform specific code
-/// or a degraded user experience on macOS via [`packages_as_directories`].
+/// You could write platform specific code that really makes the best use of each platform.
+/// However if you want to write universal code that will work on all platforms then
+/// you have to keep some restrictions in mind.
+///
+/// ## Don't depend on directories with extensions
+///
+/// Your application should avoid having to deal with directories that have extensions
+/// in their name, e.g. `my_stuff.pkg`. This clashes with [packages] on macOS and you
+/// will either need platform specific code or a degraded user experience on macOS
+/// via [`packages_as_directories`].
+///
+/// ## Use the save dialog only for new paths
+///
+/// Don't direct the user to choose an existing file with the save dialog.
+/// Selecting existing files for overwriting is possible but extremely cumbersome on macOS.
+/// The much more optimized flow is to have the user select a file with the open dialog
+/// and then keep saving to that file without showing a save dialog.
+/// Use the save dialog only for selecting a new location.
 ///
 /// # macOS
 ///
@@ -83,7 +97,7 @@ pub enum FileDialogType {
 /// then you can change the default behavior via [`packages_as_directories`]
 /// to force macOS to behave like other platforms and not give special treatment to packages.
 ///
-/// ## Use the save dialog only for new paths
+/// ## Selecting files for overwriting in the save dialog is cumbersome
 ///
 /// Existing files can be clicked on in the save dialog, but that only copies their base file name.
 /// If the clicked file's extension is different than the first extension of the default type
@@ -93,11 +107,6 @@ pub enum FileDialogType {
 /// and then clicks on an existing file `/Users/Joe/old.txt` in another directory then the returned
 /// path will actually be `/Users/Joe/foo/old.rtf` if the default type's first extension is `rtf`.
 ///
-/// Thus it's not a good idea to direct the user to choose an existing file with the save dialog.
-/// The much more optimized flow is to have the user select a file with the open dialog
-/// and then keep saving to that file without showing a save dialog.
-/// Use the save dialog only for selecting a new location.
-///
 /// ## Have a really good save dialog default type
 ///
 /// There is no way for the user to choose which extension they want to save a file as via the UI.
@@ -106,7 +115,7 @@ pub enum FileDialogType {
 /// *Hopefully it's a temporary problem and we can find a way to show the file formats in the UI.
 /// This is being tracked in [druid#998].*
 ///
-/// [clickable]: #use-the-save-dialog-only-for-new-paths
+/// [clickable]: #selecting-files-for-overwriting-in-the-save-dialog-is-cumbersome
 /// [packages]: #packages
 /// [`select_directories`]: #method.select_directories
 /// [`allowed_types`]: #method.allowed_types

--- a/druid-shell/src/dialog.rs
+++ b/druid-shell/src/dialog.rs
@@ -60,8 +60,8 @@ pub enum FileDialogType {
 /// Open file | Selectable. Not traversable. | Not selectable. Traversable.
 /// Save file | OS packages [clickable] but not traversable.<br/>Dialog packages traversable but not selectable. | Not selectable. Traversable.
 ///
-/// Keep in mind that the file dialog may start inside any package if the user had traversed
-/// into one previously. The user might also manually specify a path inside a package.
+/// Keep in mind that the file dialog may start inside any package if the user has traversed
+/// into one just recently. The user might also manually specify a path inside a package.
 ///
 /// Generally this behavior should be kept, because it's least surprising to macOS users.
 /// However if your application requires selecting directories with extensions as directories

--- a/druid-shell/src/dialog.rs
+++ b/druid-shell/src/dialog.rs
@@ -45,6 +45,13 @@ pub enum FileDialogType {
 ///
 /// The open dialog can also be switched to *directories mode* via [`select_directories`].
 ///
+/// # Cross-platform compatibility
+///
+/// If you don't want to write platform specific code then your application should avoid
+/// having to deal with directories that have extensions in their name, e.g. `my_stuff.pkg`.
+/// This clashes with [packages] on macOS and you will either need platform specific code
+/// or a degraded user experience on macOS via [`packages_as_directories`].
+///
 /// # macOS
 ///
 /// The file dialog works a bit differently on macOS. For a lot of applications this doesn't matter
@@ -53,11 +60,12 @@ pub enum FileDialogType {
 ///
 /// ## Packages
 ///
-/// On macOS directories with known extensions are considered to be packages.
+/// On macOS directories with known extensions are considered to be packages, e.g. `app_files.pkg`.
 /// Furthermore the packages are divided into two groups based on their extension.
 /// First there are packages that have been defined at the OS level, and secondly there are
 /// packages that are defined at the file dialog level based on [`allowed_types`].
-/// A package behaves similarly to a regular file in many contexts, including the file dialogs.
+/// These two types have slightly different behavior in the file dialogs. Generally packages
+/// behave similarly to regular files in many contexts, including the file dialogs.
 /// This package concept can be turned off in the file dialog via [`packages_as_directories`].
 ///
 /// &#xFEFF; | Packages as files. File filters apply to packages. | Packages as directories.

--- a/druid-shell/src/dialog.rs
+++ b/druid-shell/src/dialog.rs
@@ -39,13 +39,19 @@ pub enum FileDialogType {
 ///
 /// By default the file dialogs operate in *files mode* where the user can only choose files.
 /// Importantly these are files from the user's perspective, but technically the returned path
-/// will be a directory when the user chooses a package. Read more about [packages] below.
+/// will be a directory when the user chooses a package. You can read more about [packages] below.
 /// It's also possible for users to manually specify a path which they might otherwise not be able
 /// to choose. Thus it is important to verify that all the returned paths match your expectations.
 ///
 /// The open dialog can also be switched to *directories mode* via [`select_directories`].
 ///
-/// # Packages
+/// # macOS
+///
+/// The file dialog works a bit differently on macOS. For a lot of applications this doesn't matter
+/// and you don't need to know the details. However if your application makes extensive use
+/// of file dialogs and you target macOS then you should understand the macOS specifics.
+///
+/// ## Packages
 ///
 /// On macOS directories with known extensions are considered to be packages.
 /// Furthermore the packages are divided into two groups based on their extension.
@@ -69,15 +75,14 @@ pub enum FileDialogType {
 /// then you can change the default behavior via [`packages_as_directories`]
 /// to force macOS to behave like other platforms and not give special treatment to packages.
 ///
-/// # macOS
-///
-/// **Use the save dialog only for new paths**
+/// ## Use the save dialog only for new paths
 ///
 /// Existing files can be clicked on in the save dialog, but that only copies their base file name.
 /// If the clicked file's extension is different than the first extension of the default type
 /// then the returned path does not actually match the path of the file that was clicked on.
-/// Clicking on a file doesn't change the base path either. So if a user has traversed into
-/// `/Users/Joe/foo/` and then clicks on an existing file `/Users/Joe/old.txt` then the returned
+/// Clicking on a file doesn't change the base path either. Keep in mind that the macOS file dialog
+/// can have several directories open at once. So if a user has traversed into `/Users/Joe/foo/`
+/// and then clicks on an existing file `/Users/Joe/old.txt` in another directory then the returned
 /// path will actually be `/Users/Joe/foo/old.rtf` if the default type's first extension is `rtf`.
 ///
 /// Thus it's not a good idea to direct the user to choose an existing file with the save dialog.
@@ -85,7 +90,7 @@ pub enum FileDialogType {
 /// and then keep saving to that file without showing a save dialog.
 /// Use the save dialog only for selecting a new location.
 ///
-/// **Have a really good save dialog default type**
+/// ## Have a really good save dialog default type
 ///
 /// There is no way for the user to choose which extension they want to save a file as via the UI.
 /// They have no way of knowing which extensions are even supported and must manually type it out.
@@ -93,7 +98,7 @@ pub enum FileDialogType {
 /// *Hopefully it's a temporary problem and we can find a way to show the file formats in the UI.
 /// This is being tracked in [druid#998].*
 ///
-/// [Clickable]: #macos
+/// [clickable]: #use-the-save-dialog-only-for-new-paths
 /// [packages]: #packages
 /// [`select_directories`]: #method.select_directories
 /// [`allowed_types`]: #method.allowed_types

--- a/druid-shell/src/dialog.rs
+++ b/druid-shell/src/dialog.rs
@@ -51,13 +51,13 @@ pub enum FileDialogType {
 /// First there are packages that have been defined at the OS level, and secondly there are
 /// packages that are defined at the file dialog level based on [`allowed_types`].
 /// A package behaves similarly to a regular file in many contexts, including the file dialogs.
-/// This means that it can be chosen in the file open dialog when operating in *files mode*
-/// and all the file filters will apply to it. It won't be selectable in *directories mode*
-/// and the user won't be able to traverse into the package. In the file save dialog
-/// packages that are only defined in [`allowed_types`] can be traversed into. However
-/// packages that are defined at the OS level can't be traversed into even if they are also
-/// defined in [`allowed_types`]. Keep in mind though that the file dialog may start
-/// inside any package if the user had traversed into one previously.
+/// This means that it can be chosen in the file open dialog when operating in *files mode*,
+/// all the file filters will apply to it, and the user won't be able to traverse into the package.
+/// It won't be selectable in *directories mode* and the user won't be able to traverse into the
+/// package. In the file save dialog packages that are only defined in [`allowed_types`] can be
+/// traversed into. However packages that are defined at the OS level can't be traversed into
+/// even if they are also defined in [`allowed_types`]. Keep in mind though that the file dialog
+/// may start inside any package if the user had traversed into one previously.
 ///
 /// Generally this behavior should be kept, because it's least surprising to macOS users.
 /// However if your application requires selecting directories with extensions as directories

--- a/druid-shell/src/platform/mac/dialog.rs
+++ b/druid-shell/src/platform/mac/dialog.rs
@@ -67,23 +67,23 @@ pub(crate) fn get_file_dialog_path(
             let () = msg_send![panel, setShowsHiddenFiles: YES];
         }
 
-        if let Some(default_name) = options.default_name {
+        if let Some(default_name) = &options.default_name {
             let () = msg_send![panel, setNameFieldStringValue: make_nsstring(default_name)];
         }
 
-        if let Some(name_label) = options.name_label {
+        if let Some(name_label) = &options.name_label {
             let () = msg_send![panel, setNameFieldLabel: make_nsstring(name_label)];
         }
 
-        if let Some(title) = options.title {
+        if let Some(title) = &options.title {
             let () = msg_send![panel, setTitle: make_nsstring(title)];
         }
 
-        if let Some(text) = options.button_text {
+        if let Some(text) = &options.button_text {
             let () = msg_send![panel, setPrompt: make_nsstring(text)];
         }
 
-        if let Some(path) = options.starting_directory {
+        if let Some(path) = &options.starting_directory {
             if let Some(path) = path.to_str() {
                 let url = NSURL::alloc(nil)
                     .initFileURLWithPath_isDirectory_(make_nsstring(path), YES)
@@ -95,13 +95,16 @@ pub(crate) fn get_file_dialog_path(
         if set_type_filter {
             // If a default type was specified, then we must reorder the allowed types,
             // because there's no way to specify the default type other than having it be first.
-            if let Some(allowed_types) = options.allowed_types.as_mut() {
-                if let Some(dt) = options.default_type {
-                    if let Some(idx) = allowed_types.iter().position(|t| *t == dt) {
+            if let Some(dt) = &options.default_type {
+                let mut present = false;
+                if let Some(allowed_types) = options.allowed_types.as_mut() {
+                    if let Some(idx) = allowed_types.iter().position(|t| t == dt) {
+                        present = true;
                         allowed_types.swap(idx, 0);
-                    } else {
-                        log::warn!("The default type {:?} is not present in allowed types.", dt);
                     }
+                }
+                if !present {
+                    log::warn!("The default type {:?} is not present in allowed types.", dt);
                 }
             }
 

--- a/druid-shell/src/platform/mac/dialog.rs
+++ b/druid-shell/src/platform/mac/dialog.rs
@@ -18,8 +18,8 @@
 
 use std::ffi::OsString;
 
-use cocoa::base::{id, nil, YES};
-use cocoa::foundation::{NSArray, NSInteger};
+use cocoa::base::{id, nil, NO, YES};
+use cocoa::foundation::{NSArray, NSAutoreleasePool, NSInteger, NSURL};
 use objc::{class, msg_send, sel, sel_impl};
 
 use super::util::{from_nsstring, make_nsstring};
@@ -28,9 +28,10 @@ use crate::dialog::{FileDialogOptions, FileDialogType};
 const NSModalResponseOK: NSInteger = 1;
 const NSModalResponseCancel: NSInteger = 0;
 
+#[allow(clippy::cognitive_complexity)]
 pub(crate) fn get_file_dialog_path(
     ty: FileDialogType,
-    options: FileDialogOptions,
+    mut options: FileDialogOptions,
 ) -> Option<OsString> {
     unsafe {
         let panel: id = match ty {
@@ -38,32 +39,81 @@ pub(crate) fn get_file_dialog_path(
             FileDialogType::Save => msg_send![class!(NSSavePanel), savePanel],
         };
 
-        // set options
+        // Set open dialog specific options
+        // NSOpenPanel inherits from NSSavePanel and thus has more options.
+        let mut set_type_filter = true;
+        if let FileDialogType::Open = ty {
+            if options.select_directories {
+                let () = msg_send![panel, setCanChooseDirectories: YES];
+                // Disable the selection of files in directory selection mode,
+                // because other platforms like Windows have no support for it,
+                // and expecting it to work will lead to buggy cross-platform behavior.
+                let () = msg_send![panel, setCanChooseFiles: NO];
+                // Because we're choosing only directories, file filters don't make sense.
+                set_type_filter = false;
+            }
+            if options.multi_selection {
+                let () = msg_send![panel, setAllowsMultipleSelection: YES];
+            }
+        }
+
+        // Set universal options
         if options.show_hidden {
             let () = msg_send![panel, setShowsHiddenFiles: YES];
         }
 
-        if options.select_directories {
-            let () = msg_send![panel, setCanChooseDirectories: YES];
+        if let Some(default_name) = options.default_name {
+            let () = msg_send![panel, setNameFieldStringValue: make_nsstring(default_name)];
         }
 
-        if options.multi_selection {
-            let () = msg_send![panel, setAllowsMultipleSelection: YES];
+        if let Some(name_label) = options.name_label {
+            let () = msg_send![panel, setNameFieldLabel: make_nsstring(name_label)];
         }
 
-        // A vector of NSStrings. this must outlive `nsarray_allowed_types`.
-        let allowed_types = options.allowed_types.as_ref().map(|specs| {
-            specs
-                .iter()
-                .flat_map(|spec| spec.extensions.iter().map(|s| make_nsstring(s)))
-                .collect::<Vec<_>>()
-        });
+        if let Some(title) = options.title {
+            let () = msg_send![panel, setTitle: make_nsstring(title)];
+        }
 
-        let nsarray_allowed_types = allowed_types
-            .as_ref()
-            .map(|types| NSArray::arrayWithObjects(nil, types.as_slice()));
-        if let Some(nsarray) = nsarray_allowed_types {
-            let () = msg_send![panel, setAllowedFileTypes: nsarray];
+        if let Some(text) = options.button_text {
+            let () = msg_send![panel, setPrompt: make_nsstring(text)];
+        }
+
+        if let Some(path) = options.starting_directory {
+            if let Some(path) = path.to_str() {
+                let url = NSURL::alloc(nil)
+                    .initFileURLWithPath_isDirectory_(make_nsstring(path), YES)
+                    .autorelease();
+                let () = msg_send![panel, setDirectoryURL: url];
+            }
+        }
+
+        if set_type_filter {
+            // If a default type was specified, then we must reorder the allowed types,
+            // because there's no way to specify the default type other than having it be first.
+            if let Some(allowed_types) = options.allowed_types.as_mut() {
+                if let Some(dt) = options.default_type {
+                    if let Some(idx) = allowed_types.iter().position(|t| *t == dt) {
+                        allowed_types.swap(idx, 0);
+                    } else {
+                        log::warn!("The default type {:?} is not present in allowed types.", dt);
+                    }
+                }
+            }
+
+            // A vector of NSStrings. this must outlive `nsarray_allowed_types`.
+            let allowed_types = options.allowed_types.as_ref().map(|specs| {
+                specs
+                    .iter()
+                    .flat_map(|spec| spec.extensions.iter().map(|s| make_nsstring(s)))
+                    .collect::<Vec<_>>()
+            });
+
+            let nsarray_allowed_types = allowed_types
+                .as_ref()
+                .map(|types| NSArray::arrayWithObjects(nil, types.as_slice()));
+            if let Some(nsarray) = nsarray_allowed_types {
+                let () = msg_send![panel, setAllowedFileTypes: nsarray];
+            }
         }
 
         let result: NSInteger = msg_send![panel, runModal];

--- a/druid-shell/src/platform/mac/dialog.rs
+++ b/druid-shell/src/platform/mac/dialog.rs
@@ -39,6 +39,10 @@ pub(crate) fn get_file_dialog_path(
             FileDialogType::Save => msg_send![class!(NSSavePanel), savePanel],
         };
 
+        // Directories with extensions need to be treated as directories.
+        // File packages are a macOS concept and don't translate in a cross-platform way.
+        let () = msg_send![panel, setTreatsFilePackagesAsDirectories: YES];
+
         // Set open dialog specific options
         // NSOpenPanel inherits from NSSavePanel and thus has more options.
         let mut set_type_filter = true;
@@ -49,7 +53,8 @@ pub(crate) fn get_file_dialog_path(
                 // because other platforms like Windows have no support for it,
                 // and expecting it to work will lead to buggy cross-platform behavior.
                 let () = msg_send![panel, setCanChooseFiles: NO];
-                // Because we're choosing only directories, file filters don't make sense.
+                // Because we're choosing only directories, file filters need to be disabled.
+                // Otherwise macOS will still allow selecting those files which match the filter.
                 set_type_filter = false;
             }
             if options.multi_selection {

--- a/druid-shell/src/platform/mac/dialog.rs
+++ b/druid-shell/src/platform/mac/dialog.rs
@@ -39,6 +39,11 @@ pub(crate) fn get_file_dialog_path(
             FileDialogType::Save => msg_send![class!(NSSavePanel), savePanel],
         };
 
+        // Enable the user to choose whether file extensions are hidden in the dialog.
+        // This defaults to off, but is recommended to be turned on by Apple.
+        // https://developer.apple.com/design/human-interface-guidelines/macos/user-interaction/file-handling/
+        let () = msg_send![panel, setCanSelectHiddenExtension: YES];
+
         // Set open dialog specific options
         // NSOpenPanel inherits from NSSavePanel and thus has more options.
         let mut set_type_filter = true;

--- a/druid/examples/open_save.rs
+++ b/druid/examples/open_save.rs
@@ -37,8 +37,17 @@ fn ui_builder() -> impl Widget<String> {
     let other = FileSpec::new("Bogus file", &["foo", "bar", "baz"]);
     let save_dialog_options = FileDialogOptions::new()
         .allowed_types(vec![rs, txt, other])
-        .default_type(txt);
-    let open_dialog_options = save_dialog_options.clone();
+        .default_type(txt)
+        .default_name("MyFile.txt")
+        .name_label("Target")
+        .title("Choose a target for this lovely file")
+        .button_text("Export");
+    let open_dialog_options = save_dialog_options
+        .clone()
+        .default_name("MySavedFile.txt")
+        .name_label("Source")
+        .title("Where did you put that file?")
+        .button_text("Import");
 
     let input = TextBox::new();
     let save = Button::new("Save").on_click(move |ctx, _, _| {

--- a/druid/examples/open_save.rs
+++ b/druid/examples/open_save.rs
@@ -35,10 +35,11 @@ fn ui_builder() -> impl Widget<String> {
     let rs = FileSpec::new("Rust source", &["rs"]);
     let txt = FileSpec::new("Text file", &["txt"]);
     let other = FileSpec::new("Bogus file", &["foo", "bar", "baz"]);
+    let default_target = String::from("MyFile.txt");
     let save_dialog_options = FileDialogOptions::new()
         .allowed_types(vec![rs, txt, other])
         .default_type(txt)
-        .default_name("MyFile.txt")
+        .default_name(&default_target)
         .name_label("Target")
         .title("Choose a target for this lovely file")
         .button_text("Export");

--- a/druid/examples/open_save.rs
+++ b/druid/examples/open_save.rs
@@ -35,11 +35,13 @@ fn ui_builder() -> impl Widget<String> {
     let rs = FileSpec::new("Rust source", &["rs"]);
     let txt = FileSpec::new("Text file", &["txt"]);
     let other = FileSpec::new("Bogus file", &["foo", "bar", "baz"]);
-    let default_target = String::from("MyFile.txt");
+    // The options can also be generated at runtime,
+    // so to show that off we create a String for the default save name.
+    let default_save_name = String::from("MyFile.txt");
     let save_dialog_options = FileDialogOptions::new()
         .allowed_types(vec![rs, txt, other])
         .default_type(txt)
-        .default_name(&default_target)
+        .default_name(default_save_name)
         .name_label("Target")
         .title("Choose a target for this lovely file")
         .button_text("Export");

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -173,13 +173,16 @@ pub mod sys {
     pub const NEW_FILE: Selector = Selector::new("druid-builtin.menu-file-new");
 
     /// When submitted by the application, a file picker dialog will be shown to the user,
-    /// and an [`OPEN_FILE`] command will be sent if a file is chosen.
+    /// and an [`OPEN_FILE`] command will be sent if a path is chosen.
     ///
     /// [`OPEN_FILE`]: constant.OPEN_FILE.html
     pub const SHOW_OPEN_PANEL: Selector<FileDialogOptions> =
         Selector::new("druid-builtin.menu-file-open");
 
-    /// Open a file, must be handled by the application.
+    /// Open a path, must be handled by the application.
+    ///
+    /// The path might be a file or a directory,
+    /// so always check whether it matches your expectations.
     ///
     /// [`FileInfo`]: ../struct.FileInfo.html
     pub const OPEN_FILE: Selector<FileInfo> = Selector::new("druid-builtin.open-file-path");
@@ -192,11 +195,14 @@ pub mod sys {
     pub const SHOW_SAVE_PANEL: Selector<FileDialogOptions> =
         Selector::new("druid-builtin.menu-file-save-as");
 
-    /// Save the current file, must be handled by the application.
+    /// Save the current path, must be handled by the application.
     ///
     /// How this should be handled depends on the payload:
-    /// `Some(handle)`: the app should save to that file and store the `handle` for future use.
+    /// `Some(handle)`: the app should save to that path and store the `handle` for future use.
     /// `None`: the app should have received `Some` before and use the stored `FileInfo`.
+    ///
+    /// The path might be a file or a directory,
+    /// so always check whether it matches your expectations.
     pub const SAVE_FILE: Selector<Option<FileInfo>> = Selector::new("druid-builtin.menu-file-save");
 
     /// Show the print-setup window.


### PR DESCRIPTION
This PR adds a bunch of stuff to the `FileDialogOptions` struct.
- `default_name` to specify the file name that should be pre-filled.
- `name_label` to specify text that should appear next to the file name textbox.
- `title` to set the title of the dialog.
- `button_text` to set the text on the main save/open button.
- `force_starting_directory` to support niche use cases where the app wants to override the OS chosen starting directory in the dialog.

To get things going I started with the macOS implementation. However these are all things that can also be supported on Windows, and most if not all also on GTK.

I updated the `select_directories` documentation to specify that this means that only folders are being selected. There is no way to select both folders and files on Windows. So for a cross-platform API that doesn't make sense. If there is some use case where you want both folders and files to be selected then that should be a new mode called `select_files_and_directories` or something and have clear documentation about being available only on macOS (and..?).

I also made some macOS specific changes in relation to the existing API:
- File packages (directories with known extensions) are now treated as plain directories. File packages are a macOS concept and don't translate in a cross-platform way. This is related to [runebender#108](https://github.com/linebender/runebender/issues/108) because runebender expects directories to be treated as files when they have an extension, but that's a macOS-only behavior. The cross-platform way to do it would be to enable `select_directories`.
- Implemented `default_type` which will be used e.g. in the save dialog when you don't type in an extension.
- Fixed the save dialog not showing up at all when `select_directories` or `multi_selection` are set.

Miscellaneous:
- Changed `FileSpec` to use a non-static lifetime. It works the same way with `'static` but now also supports non-static use cases.

Fixes #390.
Fixes #902.