### PR TITLE
Add more ctx.set_handled() to build-in widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - `SHOW_WINDOW` and `CLOSE_WINDOW` commands now only use `Target` to determine the affected window. ([#928] by [@finnerale])
 - Replaced `NEW_WINDOW`, `SET_MENU` and `SHOW_CONTEXT_MENU` commands with methods on `EventCtx` and `DelegateCtx`. ([#931] by [@finnerale])
 - Replaced `Command::one_shot` and `::take_object` with a `SingleUse` payload wrapper type. ([#959] by [@finnerale])
+- `is_handled` now returns true on `MouseDown` or `KeyDown` events if already handled by a built-in widget. ([#976] by [@Azorlogh])
 
 ### Deprecated
 
@@ -213,6 +214,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 [#954]: https://github.com/xi-editor/druid/pull/954
 [#959]: https://github.com/xi-editor/druid/pull/959
 [#961]: https://github.com/xi-editor/druid/pull/961
+[#976]: https://github.com/xi-editor/druid/pull/976
 
 ## [0.5.0] - 2020-04-01
 
@@ -245,6 +247,7 @@ Last release without a changelog :(
 [@yrns]: https://github.com/yrns
 [@jrmuizel]: https://github.com/jrmuizel
 [@scholtzan]: https://github.com/scholtzan
+[@Azorlogh]: https://github.com/Azorlogh
 
 [Unreleased]: https://github.com/xi-editor/druid/compare/v0.5.0...master
 [0.5.0]: https://github.com/xi-editor/druid/compare/v0.4.0...v0.5.0

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -73,6 +73,7 @@ impl<T: Data> Widget<T> for Button<T> {
                 if ctx.is_active() {
                     ctx.set_active(false);
                     ctx.request_paint();
+                    ctx.set_handled();
                 }
             }
             _ => (),

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -67,6 +67,7 @@ impl<T: Data> Widget<T> for Button<T> {
             Event::MouseDown(_) => {
                 ctx.set_active(true);
                 ctx.request_paint();
+                ctx.set_handled();
             }
             Event::MouseUp(_) => {
                 if ctx.is_active() {

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -43,6 +43,7 @@ impl Widget<bool> for Checkbox {
             Event::MouseDown(_) => {
                 ctx.set_active(true);
                 ctx.request_paint();
+                ctx.set_handled();
             }
             Event::MouseUp(_) => {
                 if ctx.is_active() {

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -56,6 +56,7 @@ impl Widget<bool> for Checkbox {
                         }
                     }
                     ctx.request_paint();
+                    ctx.set_handled();
                 }
             }
             _ => (),

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -71,6 +71,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
                         *data = self.variant.clone();
                     }
                     ctx.request_paint();
+                    ctx.set_handled();
                 }
             }
             _ => (),

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -62,6 +62,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
             Event::MouseDown(_) => {
                 ctx.set_active(true);
                 ctx.request_paint();
+                ctx.set_handled();
             }
             Event::MouseUp(_) => {
                 if ctx.is_active() {

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -372,11 +372,13 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                         self.scrollbars.held = BarHeldState::Vertical(
                             pos.y - self.calc_vertical_bar_bounds(viewport, env).y0,
                         );
+                        ctx.set_handled();
                     } else if self.point_hits_horizontal_bar(viewport, pos, env) {
                         ctx.set_active(true);
                         self.scrollbars.held = BarHeldState::Horizontal(
                             pos.x - self.calc_horizontal_bar_bounds(viewport, env).x0,
                         );
+                        ctx.set_handled();
                     }
                 }
                 // if the mouse was downed elsewhere, moved over a scroll bar and released: noop.

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -349,6 +349,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                 }
                 _ => (), // other events are a noop
             }
+            ctx.set_handled();
         } else if scrollbar_is_hovered {
             // if we're over a scrollbar but not dragging
             match event {

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -96,12 +96,14 @@ impl Widget<f64> for Slider {
                     ctx.set_active(false);
                     *data = self.calculate_value(mouse.pos.x, knob_size, slider_width);
                     ctx.request_paint();
+                    ctx.set_handled();
                 }
             }
             Event::MouseMove(mouse) => {
                 if ctx.is_active() {
                     *data = self.calculate_value(mouse.pos.x, knob_size, slider_width);
                     ctx.request_paint();
+                    ctx.set_handled();
                 }
                 if ctx.is_hot() {
                     let knob_hover = self.knob_hit_test(knob_size, mouse.pos);

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -89,6 +89,7 @@ impl Widget<f64> for Slider {
                     *data = self.calculate_value(mouse.pos.x, knob_size, slider_width);
                 }
                 ctx.request_paint();
+                ctx.set_handled();
             }
             Event::MouseUp(mouse) => {
                 if ctx.is_active() {

--- a/druid/src/widget/stepper.rs
+++ b/druid/src/widget/stepper.rs
@@ -213,6 +213,7 @@ impl Widget<f64> for Stepper {
                 self.timer_id = ctx.request_timer(STEPPER_REPEAT_DELAY);
 
                 ctx.request_paint();
+                ctx.set_handled();
             }
             Event::MouseUp(_) => {
                 ctx.set_active(false);

--- a/druid/src/widget/stepper.rs
+++ b/druid/src/widget/stepper.rs
@@ -223,6 +223,7 @@ impl Widget<f64> for Stepper {
                 self.timer_id = TimerToken::INVALID;
 
                 ctx.request_paint();
+                ctx.set_handled();
             }
             Event::Timer(id) if *id == self.timer_id => {
                 if self.increase_active {

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -125,6 +125,7 @@ impl Widget<bool> for Switch {
             Event::MouseDown(_) => {
                 ctx.set_active(true);
                 ctx.request_paint();
+                ctx.set_handled();
             }
             Event::MouseUp(_) => {
                 if self.knob_dragged {

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -131,9 +131,11 @@ impl Widget<bool> for Switch {
                 if self.knob_dragged {
                     // toggle value when dragging if knob has been moved far enough
                     *data = self.knob_pos.x > switch_width / 2.;
+                    ctx.set_handled();
                 } else if ctx.is_active() {
                     // toggle value on click
                     *data = !*data;
+                    ctx.set_handled();
                 }
 
                 ctx.set_active(false);
@@ -146,6 +148,7 @@ impl Widget<bool> for Switch {
                 if ctx.is_active() {
                     self.knob_pos.x = mouse.pos.x.min(on_pos).max(off_pos);
                     self.knob_dragged = true;
+                    ctx.set_handled();
                 }
                 if ctx.is_hot() {
                     self.knob_hovered = self.knob_hit_test(knob_size, mouse.pos)

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -265,12 +265,14 @@ impl Widget<String> for TextBox {
                         mods: mouse.mods,
                     }));
                     ctx.request_paint();
+                    ctx.set_handled();
                 }
             }
             Event::MouseUp(_) => {
                 if ctx.is_active() {
                     ctx.set_active(false);
                     ctx.request_paint();
+                    ctx.set_handled();
                 }
             }
             Event::Timer(id) => {

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -253,6 +253,7 @@ impl Widget<String> for TextBox {
                 }
 
                 ctx.request_paint();
+                ctx.set_handled();
             }
             Event::MouseMove(mouse) => {
                 ctx.set_cursor(&Cursor::IBeam);
@@ -330,6 +331,7 @@ impl Widget<String> for TextBox {
                 }
 
                 ctx.request_paint();
+                ctx.set_handled();
             }
             _ => (),
         }


### PR DESCRIPTION
Adds calls to `set_handled` to build-in widgets when they handle `MouseDown` and `KeyDown` (for `TextBox`).
This is so that custom widgets can store a `WidgetPod`, and choose to process events themselves if their children didn't.

Let me know if I missed anything or if changes are needed.