### PR TITLE
X11 present

### DIFF
--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -78,4 +78,4 @@ features = ["Window", "MouseEvent", "CssStyleDeclaration", "WheelEvent", "KeyEve
 
 [dev-dependencies]
 piet-common = { version = "0.1.1", features = ["png"] }
-env_logger = "0.7.1"
+simple_logger = { version = "1.6.0", default-features = false }

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -39,7 +39,7 @@ gtk = { version = "0.8.1", optional = true }
 glib = { version = "0.9.3", optional = true }
 glib-sys = { version = "0.9.1", optional = true }
 gtk-sys = { version = "0.9.2", optional = true }
-x11rb = { version = "0.6.0", features = ["allow-unsafe-code", "randr"], optional = true }
+x11rb = { version = "0.6.0", features = ["allow-unsafe-code", "present", "randr", "xfixes"], optional = true }
 
 [target.'cfg(target_os="windows")'.dependencies]
 wio = "0.2.2"
@@ -78,3 +78,4 @@ features = ["Window", "MouseEvent", "CssStyleDeclaration", "WheelEvent", "KeyEve
 
 [dev-dependencies]
 piet-common = { version = "0.1.1", features = ["png"] }
+env_logger = "0.7.1"

--- a/druid-shell/examples/invalidate.rs
+++ b/druid-shell/examples/invalidate.rs
@@ -84,6 +84,7 @@ impl WinHandler for InvalidateTest {
 }
 
 fn main() {
+    simple_logger::init().expect("Failed to init simple logger");
     let app = Application::new().unwrap();
     let mut builder = WindowBuilder::new(app.clone());
     let inv_test = InvalidateTest {

--- a/druid-shell/examples/perftest.rs
+++ b/druid-shell/examples/perftest.rs
@@ -133,7 +133,7 @@ impl WinHandler for PerfTest {
 }
 
 fn main() {
-    env_logger::init();
+    simple_logger::init().expect("Failed to init simple logger");
     let app = Application::new().unwrap();
     let mut builder = WindowBuilder::new(app.clone());
     let perf_test = PerfTest {

--- a/druid-shell/examples/perftest.rs
+++ b/druid-shell/examples/perftest.rs
@@ -133,6 +133,7 @@ impl WinHandler for PerfTest {
 }
 
 fn main() {
+    env_logger::init();
     let app = Application::new().unwrap();
     let mut builder = WindowBuilder::new(app.clone());
     let perf_test = PerfTest {

--- a/druid-shell/examples/shello.rs
+++ b/druid-shell/examples/shello.rs
@@ -105,6 +105,7 @@ impl WinHandler for HelloState {
 }
 
 fn main() {
+    simple_logger::init().expect("Failed to init simple logger");
     let mut file_menu = Menu::new();
     file_menu.add_item(
         0x100,

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -17,6 +17,14 @@
 //! `druid-shell` is an abstraction around a given platform UI & application
 //! framework. It provides common types, which then defer to a platform-defined
 //! implementation.
+//!
+//! # Env
+//!
+//! For testing and debugging, `druid-shell` can change its behavior based on environment
+//! variables. Here is a list of environment variables that `druid-shell` supports:
+//!
+//! - `DRUID_SHELL_DISABLE_X11_PRESENT`: if this is set and `druid-shell` is using the `x11`
+//! backend, it will avoid using the Present extension.
 
 #![deny(intra_doc_link_resolution_failure)]
 #![allow(clippy::new_without_default)]

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -21,6 +21,8 @@ use std::rc::Rc;
 
 use anyhow::{anyhow, Context, Error};
 use x11rb::connection::Connection;
+use x11rb::protocol::present::ConnectionExt as _;
+use x11rb::protocol::xfixes::ConnectionExt as _;
 use x11rb::protocol::xproto::{ConnectionExt, CreateWindowAux, EventMask, WindowClass};
 use x11rb::protocol::Event;
 use x11rb::xcb_ffi::XCBConnection;
@@ -60,6 +62,8 @@ pub(crate) struct Application {
     window_id: u32,
     /// The mutable `Application` state.
     state: Rc<RefCell<State>>,
+    /// The major opcode of the Present extension, if it is supported.
+    present_opcode: Option<u8>,
 }
 
 /// The mutable `Application` state.
@@ -87,12 +91,67 @@ impl Application {
             quitting: false,
             windows: HashMap::new(),
         }));
+        let present_opcode = match Application::query_present_opcode(&connection) {
+            Ok(p) => p,
+            Err(e) => {
+                log::info!("failed to find Present extension: {}", e);
+                None
+            }
+        };
         Ok(Application {
             connection,
             screen_num: screen_num as i32,
             window_id,
             state,
+            present_opcode,
         })
+    }
+
+    // Check if the Present extension is supported, returning its opcode if it is.
+    fn query_present_opcode(conn: &Rc<XCBConnection>) -> Result<Option<u8>, Error> {
+        let query = conn
+            .query_extension(b"Present")?
+            .reply()
+            .context("query Present extension")?;
+
+        if !query.present {
+            return Ok(None);
+        }
+
+        let opcode = Some(query.major_opcode);
+
+        // If Present is there at all, version 1.0 should be supported. This code
+        // shouldn't have a real effect; it's just a sanity check.
+        let version = conn
+            .present_query_version(1, 0)?
+            .reply()
+            .context("query Present version")?;
+        log::info!(
+            "X server supports Present version {}.{}",
+            version.major_version,
+            version.minor_version,
+        );
+
+        // We need the XFIXES extension to use regions. This code looks like it's just doing a
+        // sanity check but it is *necessary*: XFIXES doesn't work until we've done version
+        // negotiation
+        // (https://www.x.org/releases/X11R7.7/doc/fixesproto/fixesproto.txt)
+        let version = conn
+            .xfixes_query_version(5, 0)?
+            .reply()
+            .context("query XFIXES version")?;
+        log::info!(
+            "X server supports XFIXES version {}.{}",
+            version.major_version,
+            version.minor_version,
+        );
+
+        Ok(opcode)
+    }
+
+    #[inline]
+    pub(crate) fn present_opcode(&self) -> Option<u8> {
+        self.present_opcode
     }
 
     fn create_event_window(conn: &Rc<XCBConnection>, screen_num: i32) -> Result<u32, Error> {
@@ -249,6 +308,27 @@ impl Application {
                     self.finalize_quit();
                 }
             }
+            Event::PresentCompleteNotify(ev) => {
+                let w = self
+                    .window(ev.window)
+                    .context("COMPLETE_NOTIFY - failed to get window")?;
+                w.handle_complete_notify(ev)
+                    .context("COMPLETE_NOTIFY - failed to handle")?;
+            }
+            Event::PresentIdleNotify(ev) => {
+                let w = self
+                    .window(ev.window)
+                    .context("IDLE_NOTIFY - failed to get window")?;
+                w.handle_idle_notify(ev)
+                    .context("IDLE_NOTIFY - failed to handle")?;
+            }
+            // In XCB, errors are reported asynchronously by default, by sending them to the event
+            // loop. You can opt-out of this by using ..._checked variants of a function, and then
+            // getting the error synchronously. We use this in window initialization, but otherwise
+            // we take the async route.
+            Event::Error(e) => {
+                return Err(x11rb::errors::ReplyError::from(e.clone()).into());
+            }
             _ => {}
         }
         Ok(false)
@@ -264,7 +344,7 @@ impl Application {
                         }
                     }
                     Err(e) => {
-                        log::error!("Error handling event: {}", e);
+                        log::error!("Error handling event: {:#}", e);
                     }
                 }
             }

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -91,13 +91,20 @@ impl Application {
             quitting: false,
             windows: HashMap::new(),
         }));
-        let present_opcode = match Application::query_present_opcode(&connection) {
-            Ok(p) => p,
-            Err(e) => {
-                log::info!("failed to find Present extension: {}", e);
-                None
+
+        let present_opcode = if std::env::var_os("DRUID_SHELL_DISABLE_X11_PRESENT").is_some() {
+            // Allow disabling Present with an environment variable.
+            None
+        } else {
+            match Application::query_present_opcode(&connection) {
+                Ok(p) => p,
+                Err(e) => {
+                    log::info!("failed to find Present extension: {}", e);
+                    None
+                }
             }
         };
+
         Ok(Application {
             connection,
             screen_num: screen_num as i32,

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -309,11 +309,13 @@ impl Application {
                 }
             }
             Event::ConfigureNotify(ev) => {
-                let w = self
-                    .window(ev.window)
-                    .context("CONFIGURE_NOTIFY - failed to get window")?;
-                w.handle_configure_notify(ev)
-                    .context("CONFIGURE_NOTIFY - failed to handle")?;
+                if ev.window != self.window_id {
+                    let w = self
+                        .window(ev.window)
+                        .context("CONFIGURE_NOTIFY - failed to get window")?;
+                    w.handle_configure_notify(ev)
+                        .context("CONFIGURE_NOTIFY - failed to handle")?;
+                }
             }
             Event::PresentCompleteNotify(ev) => {
                 let w = self

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -327,6 +327,13 @@ impl Application {
             // getting the error synchronously. We use this in window initialization, but otherwise
             // we take the async route.
             Event::Error(e) => {
+                if let x11rb::protocol::Error::Request(req) = e {
+                    if self.present_opcode == Some(req.major_opcode) {
+                        for window in borrow!(self.state)?.windows.values() {
+                            window.disable_present()?;
+                        }
+                    }
+                }
                 return Err(x11rb::errors::ReplyError::from(e.clone()).into());
             }
             _ => {}

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -116,11 +116,6 @@ impl Application {
 
     // Check if the Present extension is supported, returning its opcode if it is.
     fn query_present_opcode(conn: &Rc<XCBConnection>) -> Result<Option<u8>, Error> {
-        // When checking for X11 errors synchronously, there are two places where the error could
-        // happen. An error on the request means the connection is broken. There's no need for
-        // extra error context here, because the fact that the connection broke has nothing to do
-        // with what we're trying to do. An error on the reply means there was something wrong with
-        // the request, and so we add context. This convention is used throughout the x11 backend.
         let query = conn
             .query_extension(b"Present")?
             .reply()
@@ -344,9 +339,6 @@ impl Application {
                 w.handle_idle_notify(ev)
                     .context("IDLE_NOTIFY - failed to handle")?;
             }
-            // In XCB, errors are reported asynchronously by default, by sending them to the event
-            // loop. You can also request a synchronous error for a given call; we use this in
-            // window initialization, but otherwise we take the async route.
             Event::Error(e) => {
                 // TODO: if an error is caused by the present extension, disable it and fall back
                 // to copying pixels. This is blocked on

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -308,6 +308,13 @@ impl Application {
                     self.finalize_quit();
                 }
             }
+            Event::ConfigureNotify(ev) => {
+                let w = self
+                    .window(ev.window)
+                    .context("CONFIGURE_NOTIFY - failed to get window")?;
+                w.handle_configure_notify(ev)
+                    .context("CONFIGURE_NOTIFY - failed to handle")?;
+            }
             Event::PresentCompleteNotify(ev) => {
                 let w = self
                     .window(ev.window)

--- a/druid-shell/src/platform/x11/error.rs
+++ b/druid-shell/src/platform/x11/error.rs
@@ -15,16 +15,30 @@
 //! Errors at the application shell level.
 
 use std::fmt;
+use std::sync::Arc;
 
-/// The X11 backend doesn't currently define any platform-specific errors;
-/// it uses the `crate::error::Other` variant instead.
 #[derive(Debug, Clone)]
-pub enum Error {}
+pub enum Error {
+    XError(Arc<x11rb::errors::ReplyError>),
+}
 
 impl fmt::Display for Error {
-    fn fmt(&self, _: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        Ok(())
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        let Error::XError(e) = self;
+        e.fmt(f)
     }
 }
 
 impl std::error::Error for Error {}
+
+impl From<x11rb::protocol::Error> for Error {
+    fn from(err: x11rb::protocol::Error) -> Error {
+        Error::XError(Arc::new(x11rb::errors::ReplyError::X11Error(err)))
+    }
+}
+
+impl From<x11rb::errors::ReplyError> for Error {
+    fn from(err: x11rb::errors::ReplyError) -> Error {
+        Error::XError(Arc::new(err))
+    }
+}

--- a/druid-shell/src/platform/x11/mod.rs
+++ b/druid-shell/src/platform/x11/mod.rs
@@ -18,6 +18,18 @@
 //     Might be related to the "sleep scheduler" in XWindow::render()?
 // TODO(x11/render_improvements): double-buffering / present strategies / etc?
 
+// # Notes on error handling in X11
+//
+// In XCB, errors are reported asynchronously by default, by sending them to the event
+// loop. You can also request a synchronous error for a given call; we use this in
+// window initialization, but otherwise we take the async route.
+//
+// When checking for X11 errors synchronously, there are two places where the error could
+// happen. An error on the request means the connection is broken. There's no need for
+// extra error context here, because the fact that the connection broke has nothing to do
+// with what we're trying to do. An error on the reply means there was something wrong with
+// the request, and so we add context. This convention is used throughout the x11 backend.
+
 #[macro_use]
 mod util;
 

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -886,6 +886,7 @@ impl Window {
             buffers.idle_pixmaps.push(event.pixmap);
         } else {
             // We must have reallocated the buffers while this pixmap was busy, so free it now.
+            // Regular freeing happens in `Buffers::free_pixmaps`.
             self.app.connection().free_pixmap(event.pixmap)?;
         }
         Ok(())

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -579,6 +579,8 @@ impl Window {
             // We aren't using the present extension, so fall back to sleeping for scheduling
             // redraws. Sleeping is a terrible way to schedule redraws, but hopefully we don't
             // have to fall back to this very often.
+            // TODO: once we have an idle handler, we should use that. Sleeping causes lots of
+            // problems when windows are dragged to resize.
             if anim && self.refresh_rate.is_some() {
                 let sleep_amount_ms = (1000.0 / self.refresh_rate.unwrap()) as u64;
                 std::thread::sleep(std::time::Duration::from_millis(sleep_amount_ms));

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -436,7 +436,7 @@ struct Buffers {
 /// The state involved in using X's Present extension.
 #[derive(Debug)]
 struct PresentData {
-    /// A monotonically increasing request counter.
+    /// A monotonically increasing present request counter.
     serial: u32,
     /// The region that we use for telling X what to present.
     region: Region,

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -863,8 +863,6 @@ impl Window {
     }
 
     /// Frees all resources used for the Present extension, and falls back to just using EXPOSE.
-    // FIXME: figure out if we need this
-    #[allow(dead_code)]
     pub fn disable_present(&self) -> Result<(), Error> {
         if let Some(present) = borrow_mut!(self.present_data)?.as_mut() {
             present.destroy_x_resources(self.app.connection());

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -652,11 +652,8 @@ impl Window {
     }
 
     fn invalidate_rect(&self, rect: Rect) {
-        match self.enlarge_invalid_rect(rect) {
-            Ok(rect) => rect,
-            Err(err) => {
-                log::error!("Window::invalidate_rect - failed to enlarge rect: {}", err);
-            }
+        if let Err(err) =  self.enlarge_invalid_rect(rect) {
+            log::error!("Window::invalidate_rect - failed to enlarge rect: {}", err);
         }
 
         // See: http://rtbo.github.io/rust-xcb/xcb/ffi/xproto/struct.xcb_expose_event_t.html

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -942,7 +942,7 @@ impl Buffers {
     /// Frees all the X pixmaps that we hold.
     fn free_pixmaps(&mut self, conn: &Rc<XCBConnection>) {
         // We can't touch pixmaps if the present extension is waiting on them, so only free the
-        // idle ones. We'll free the busy ones when we get notified that they're idle.
+        // idle ones. We'll free the busy ones when we get notified that they're idle in `Window::handle_idle_notify`.
         for &p in &self.idle_pixmaps {
             log_x11!(conn.free_pixmap(p));
         }

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -201,8 +201,7 @@ impl WindowBuilder {
                 | EventMask::KeyRelease
                 | EventMask::ButtonPress
                 | EventMask::ButtonRelease
-                | EventMask::PointerMotion
-                | EventMask::StructureNotify,
+                | EventMask::PointerMotion,
         );
 
         // Create the actual window


### PR DESCRIPTION
Fixes #932 

This adds support for the X11 Present extension, for scheduling drawing, falling back to the old sleep-based method if Present is absent or causes errors.

The main showstopper for now is a bug in [rust-xcb](https://github.com/rtbo/rust-xcb/issues/81) that breaks the present extension. Unfortunately, that project doesn't seem very active -- I see that @xStrom has a PR that's been sitting for a while...