### PR TITLE
Fix web shell for piet change allowing to cloning PietText instances

### DIFF
--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -466,7 +466,7 @@ impl WindowHandle {
             .upgrade()
             .unwrap_or_else(|| panic!("Failed to produce a text context"));
 
-        Text::new(s.context.clone(), s.window.clone())
+        Text::new(s.context.clone())
     }
 
     pub fn request_timer(&self, deadline: Instant) -> TimerToken {


### PR DESCRIPTION
This is the minor change I mentioned to handle the changes in https://github.com/linebender/piet/pull/208