### PR TITLE
Added multi-line option to textbox and changed painting to match any text size

### DIFF
--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -37,6 +37,7 @@ unicode-segmentation = "1.6.0"
 xi-unicode = "0.2.0"
 fnv = "1.0.7"
 instant = { version = "0.1.4", features = ["wasm-bindgen"] }
+bytecount = "0.6.0"
 
 # Optional dependencies
 im = { version = "15.0.0", optional = true }


### PR DESCRIPTION
This pull request adds a option to allow multi-line instance of textbox.
It only checks for '\n' line-breaks so '\r' alone might be a issue.

I also changed the painting of different elements so it should fit text of any size. (Old painting code had hard numbers that just happened to work with the default text size of 15.0)

I would like to have text_size as a member but I am unsure how to give it a default value as I cant access env.get() in the TextBox::new()

Shift+Enter does not trigger 'KeyCode::Return' should it be add it to that or to a new KeyCode?