### PR TITLE
Add alerts and their macOS implementation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ You can find its changes [documented below](#060---2020-06-01).
 
 ### Added
 
+- Alert dialogs for time sensetive notifications. ([#1039] by [@xStrom])
+
 ### Changed
 
 - `Image` and `ImageData` exported by default. ([#1011] by [@covercash2])
@@ -334,6 +336,7 @@ Last release without a changelog :(
 [#1018]: https://github.com/xi-editor/druid/pull/1018
 [#1025]: https://github.com/xi-editor/druid/pull/1025
 [#1028]: https://github.com/xi-editor/druid/pull/1028
+[#1039]: https://github.com/xi-editor/druid/pull/1039
 [#1042]: https://github.com/xi-editor/druid/pull/1042
 [#1043]: https://github.com/xi-editor/druid/pull/1043
 [#1050]: https://github.com/xi-editor/druid/pull/1050

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -46,7 +46,7 @@ wio = "0.2.2"
 
 [target.'cfg(target_os="windows")'.dependencies.winapi]
 version = "0.3.8"
-features = ["d2d1_1", "dwrite", "winbase", "libloaderapi", "errhandlingapi", "winuser",
+features = ["commctrl", "d2d1_1", "dwrite", "winbase", "libloaderapi", "errhandlingapi", "winuser",
             "shellscalingapi", "shobjidl", "combaseapi", "synchapi", "dxgi1_3", "dcomp",
             "d3d11", "dwmapi", "wincon", "fileapi", "processenv", "winbase", "handleapi"]
 

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -55,6 +55,7 @@ cocoa = "0.20.1"
 objc = "0.2.7"
 core-graphics = "0.19.0"
 foreign-types = "0.3.2"
+block = "0.1.6"
 bitflags = "1.2.1"
 
 # TODO(x11/dependencies): only use feature "xcb" if using X11

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -46,7 +46,7 @@ wio = "0.2.2"
 
 [target.'cfg(target_os="windows")'.dependencies.winapi]
 version = "0.3.8"
-features = ["commctrl", "d2d1_1", "dwrite", "winbase", "libloaderapi", "errhandlingapi", "winuser",
+features = ["d2d1_1", "dwrite", "winbase", "libloaderapi", "errhandlingapi", "winuser",
             "shellscalingapi", "shobjidl", "combaseapi", "synchapi", "dxgi1_3", "dcomp",
             "d3d11", "dwmapi", "wincon", "fileapi", "processenv", "winbase", "handleapi"]
 

--- a/druid-shell/src/alert.rs
+++ b/druid-shell/src/alert.rs
@@ -1,0 +1,386 @@
+// Copyright 2020 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Alert dialogs.
+
+use crate::util::ConstString;
+
+/// A token that uniquely identifies an alert dialog.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
+pub struct AlertToken(usize);
+
+/// Contains the result of the alert after it was closed.
+#[derive(Debug, Clone)]
+pub struct AlertResponse {
+    token: AlertToken,
+    button: AlertButton,
+}
+
+/// Options for alert dialogs.
+///
+/// An alert dialog is a modal dialog that provides the user with some information
+/// and optionally asks the user to make some decision.
+///
+/// # User experience
+///
+/// You should try to minimize the use of alerts. Alerts interrupt whatever task
+/// the user is currently doing. Only use alerts for time sensitive information.
+/// If there is some piece of information that the user must know immediately,
+/// e.g. that storage space is running very low and will soon cause a critical error,
+/// or if the storage space has already depleted and the critcial error has happened.
+/// Alerts are also useful when there is some decision that the user must make
+/// and the application can't continue without making that decision. Even so
+/// you should think hard when designing your application whether you can have
+/// reasonable default behavior which can happen without alerts. It's better to
+/// offer an *undo* feature than to ask for confirmation on deletion.
+///
+/// The fewer alerts the user encounters, the better their experience.
+///
+/// # Modality
+///
+/// While an alert dialog is open it takes interaction priority and the user won't be
+/// able to continue interacting with the parent window while the alert is open.
+///
+/// Multiple alert dialogs can be open at once, but only the most recent one will be interactable.
+/// When that alert dialog is closed, the next most recent will become interactive.
+#[derive(Debug, Clone, Default)]
+pub struct AlertOptions {
+    /// The context of the alert.
+    pub(crate) context: String,
+    /// The primary message of the alert.
+    pub(crate) message: String,
+    /// The supplemental text of the alert.
+    pub(crate) description: String,
+    /// The icon of the alert.
+    pub(crate) icon: Option<AlertIcon>,
+    /// The buttons to be shown on the alert.
+    pub(crate) buttons: Vec<AlertButton>,
+}
+
+/// Alert dialog icon.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum AlertIcon {
+    /// The alert dialog is providing important time sensitive information.
+    Information,
+    /// The alert dialog is warning about a potential future problem.
+    Warning,
+    /// The alert dialog is informing of a critical problem that has already happened.
+    Error,
+}
+
+/// Alert dialog button type.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum AlertButtonType {
+    /// Positive buttons are used for choices that agree with the primary alert message.
+    Positive,
+    /// Negative buttons are used for choices that disagree with the primary alert message.
+    Negative,
+    /// Cancel buttons reflect the user's desire to not answer at all
+    /// and instead cancel the task which initiated the alert.
+    Cancel,
+}
+
+/// A specific button for the alert dialog.
+///
+/// There are three types of buttons:
+/// - **Positive** - for choices that agree with the primary alert message.
+/// - **Negative** - for choices that disagree with the primary alert message.
+/// - **Cancel** - used by the user to show a desire to not answer at all
+///   and instead cancel the task which initiated the alert.
+///
+/// If the alert is just reporting information and it only needs a single button,  
+/// then you should use a positive button with the label **OK** or a translation of it.
+///
+/// The cancel button should always be labeled **Cancel** or a translation of it.
+///
+/// In all other cases you should give a short but descriptive label that includes a verb.
+/// The label should let the user know what will happen when they click the button.
+/// Assume that the user didn't actually read the alert message. This assumption ends up
+/// true more often than not, because alerts by design appear unexpectedly while the user
+/// is trying to accomplish some other task.
+///
+/// Labels like **Send message**, **View all**, **Reconnect**, **Remind me tomorrow**, and
+/// **Delete file** make it much more clear what will happen compared to a generic **OK**,
+/// **Confirm**, or **Yes**.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AlertButton {
+    pub(crate) button_type: AlertButtonType,
+    pub(crate) label: ConstString,
+}
+
+impl AlertToken {
+    /// A token that does not correspond to any alert.
+    pub const INVALID: AlertToken = AlertToken(0);
+
+    /// Create a new token with the specified `id`.
+    pub(crate) const fn new(id: usize) -> AlertToken {
+        AlertToken(id)
+    }
+}
+
+impl AlertResponse {
+    /// Create a new alert response.
+    pub(crate) fn new(token: AlertToken, button: AlertButton) -> AlertResponse {
+        AlertResponse { token, button }
+    }
+
+    /// Returns the [`AlertToken`] that identifies the alert.
+    ///
+    /// [`AlertToken`]: struct.AlertToken.html
+    #[inline]
+    pub fn token(&self) -> AlertToken {
+        self.token
+    }
+
+    /// Returns the [`AlertButton`] that closed the alert.
+    ///
+    /// # Canceled by the platform
+    ///
+    /// If the platform cancels the alert, e.g. when the parent window gets closed,
+    /// then this will return a cancel button that was defined in [`AlertOptions`].
+    /// If no cancel button was provided then this will be [`AlertButton::CANCEL`].
+    ///
+    /// [`AlertButton`]: struct.AlertButton.html
+    /// [`AlertOptions`]: struct.AlertOptions.html
+    /// [`AlertButton::CANCEL`]: struct.AlertButton.html#associatedconstant.CANCEL
+    #[inline]
+    pub fn button(&self) -> &AlertButton {
+        &self.button
+    }
+}
+
+impl AlertButton {
+    /// A positive button with the English label **OK**.
+    pub const OK: AlertButton = AlertButton::const_positive("OK");
+    /// A cancel button with the English label **Cancel**.
+    pub const CANCEL: AlertButton = AlertButton::const_cancel("Cancel");
+
+    /// Create a new positive button with the specified `label`.
+    ///
+    /// If this is the only button of the alert, use **OK** or a translation of it as the `label`.
+    /// Otherwise you should give a short but descriptive label like **Save the draft** that lets
+    /// the user know what will happen when they click the button.
+    ///
+    /// See [`AlertButton`] for more information.
+    ///
+    /// [`AlertButton`]: struct.AlertButton.html
+    pub fn positive(label: impl Into<String>) -> AlertButton {
+        AlertButton {
+            button_type: AlertButtonType::Positive,
+            label: ConstString::new(label),
+        }
+    }
+
+    /// Create a new negative button with the specified `label`.
+    ///
+    /// You should give a short but descriptive label like **Delete the draft** that lets the user
+    /// know what will happen when they click the button.
+    ///
+    /// See [`AlertButton`] for more information.
+    ///
+    /// [`AlertButton`]: struct.AlertButton.html
+    pub fn negative(label: impl Into<String>) -> AlertButton {
+        AlertButton {
+            button_type: AlertButtonType::Negative,
+            label: ConstString::new(label),
+        }
+    }
+
+    /// Create a new cancel button with the specified `label`.
+    ///
+    /// The cancel button `label` should always be **Cancel** or a translation of it.
+    ///
+    /// See [`AlertButton`] for more information.
+    ///
+    /// [`AlertButton`]: struct.AlertButton.html
+    pub fn cancel(label: impl Into<String>) -> AlertButton {
+        AlertButton {
+            button_type: AlertButtonType::Cancel,
+            label: ConstString::new(label),
+        }
+    }
+
+    /// Create a new `const` positive button with the specified `label`.
+    ///
+    /// This is a specialized `const` version of the [`positive`] function.
+    ///
+    /// See [`AlertButton`] for more information.
+    ///
+    /// [`positive`]: #method.positive
+    /// [`AlertButton`]: struct.AlertButton.html
+    pub const fn const_positive(label: &'static str) -> AlertButton {
+        AlertButton {
+            button_type: AlertButtonType::Positive,
+            label: ConstString::from_static(label),
+        }
+    }
+
+    /// Create a new `const` negative button with the specified `label`.
+    ///
+    /// This is a specialized `const` version of the [`negative`] function.
+    ///
+    /// See [`AlertButton`] for more information.
+    ///
+    /// [`negative`]: #method.negative
+    /// [`AlertButton`]: struct.AlertButton.html
+    pub const fn const_negative(label: &'static str) -> AlertButton {
+        AlertButton {
+            button_type: AlertButtonType::Negative,
+            label: ConstString::from_static(label),
+        }
+    }
+
+    /// Create a new `const` cancel button with the specified `label`.
+    ///
+    /// This is a specialized `const` version of the [`cancel`] function.
+    ///
+    /// See [`AlertButton`] for more information.
+    ///
+    /// [`cancel`]: #method.cancel
+    /// [`AlertButton`]: struct.AlertButton.html
+    pub const fn const_cancel(label: &'static str) -> AlertButton {
+        AlertButton {
+            button_type: AlertButtonType::Cancel,
+            label: ConstString::from_static(label),
+        }
+    }
+}
+
+impl AlertOptions {
+    /// Create a new set of alert options.
+    pub fn new() -> AlertOptions {
+        AlertOptions {
+            buttons: vec![AlertButton::OK],
+            ..Default::default()
+        }
+    }
+
+    /// Set the context of the alert.
+    ///
+    /// This should be the name of the task that this alert is related to,
+    /// or a related component name, or at the very least your application name.
+    ///
+    /// This gets shown in the alert dialog title bar.
+    pub fn context(mut self, context: impl Into<String>) -> Self {
+        self.context = context.into();
+        self
+    }
+
+    /// Set the primary message of the alert.
+    ///
+    /// This should be the key statement or question to the user.
+    /// Keep it short and to the point. For more details use [`description`].
+    ///
+    /// This is the most visually emphasized text of the alert.
+    ///
+    /// [`description`]: #method.description
+    pub fn message(mut self, message: impl Into<String>) -> Self {
+        self.message = message.into();
+        self
+    }
+
+    /// Set the supplemental text of the alert.
+    ///
+    /// This should explain your primary message in more detail.
+    ///
+    /// This is shown as regular text under the primary message.
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = description.into();
+        self
+    }
+
+    /// Set the icon of the alert.
+    ///
+    /// This should accurately represent your primary message.
+    /// Read [`AlertIcon`] for more information about icons.
+    ///
+    /// This is shown on the alert dialog next to your primary message.
+    ///
+    /// Setting this to `None` means there will not be any icon.
+    ///
+    /// [`AlertIcon`]: enum.AlertIcon.html
+    pub fn icon(mut self, icon: impl Into<Option<AlertIcon>>) -> Self {
+        self.icon = icon.into();
+        self
+    }
+
+    /// Set the icon of the alert to [`AlertIcon::Information`].
+    ///
+    /// Use this when the alert dialog is providing important time sensitive information.
+    ///
+    /// This method is equivalent to calling [`icon`] with [`AlertIcon::Information`].
+    ///
+    /// [`icon`]: #method.icon
+    /// [`AlertIcon::Information`]: enum.AlertIcon.html#variant.Information
+    pub fn information(mut self) -> Self {
+        self.icon = Some(AlertIcon::Information);
+        self
+    }
+
+    /// Set the icon of the alert to [`AlertIcon::Warning`].
+    ///
+    /// Use this when the alert dialog is warning about a potential future problem.
+    ///
+    /// This method is equivalent to calling [`icon`] with [`AlertIcon::Warning`].
+    ///
+    /// [`icon`]: #method.icon
+    /// [`AlertIcon::Warning`]: enum.AlertIcon.html#variant.Warning
+    pub fn warning(mut self) -> Self {
+        self.icon = Some(AlertIcon::Warning);
+        self
+    }
+
+    /// Set the icon of the alert to [`AlertIcon::Error`].
+    ///
+    /// Use this when the alert dialog is informing of a critical problem that has already happened.
+    ///
+    /// This method is equivalent to calling [`icon`] with [`AlertIcon::Error`].
+    ///
+    /// [`icon`]: #method.icon
+    /// [`AlertIcon::Error`]: enum.AlertIcon.html#variant.Error
+    pub fn error(mut self) -> Self {
+        self.icon = Some(AlertIcon::Error);
+        self
+    }
+
+    /// Set the buttons to be shown on the alert.
+    ///
+    /// There are three types of buttons - positive, negative, and cancel.
+    /// Read [`AlertButton`] for more information about buttons.
+    ///
+    /// Keep the number of buttons low, almost never showing more than three.
+    ///
+    /// The order of buttons in this collection matters only in relation to the same button type,
+    /// e.g. the order of positive buttons determines their location
+    /// only in regards to other positive buttons.
+    ///
+    /// The order of buttons across button types is determined automatically
+    /// based on the guidelines of the specific platform.
+    ///
+    /// This defaults to a single button - the English [`AlertButton::OK`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the provided `buttons` collection is empty.
+    ///
+    /// [`AlertButton`]: struct.AlertButton.html
+    /// [`AlertButton::OK`]: struct.AlertButton.html#associatedconstant.OK
+    pub fn buttons(mut self, buttons: Vec<AlertButton>) -> Self {
+        if buttons.is_empty() {
+            panic!("Empty alert button collection specified!");
+        }
+        self.buttons = buttons;
+        self
+    }
+}

--- a/druid-shell/src/alert.rs
+++ b/druid-shell/src/alert.rs
@@ -80,6 +80,26 @@ pub struct AlertResponse {
 /// If the modality scopes don't overlap, i.e. when multiple alerts are originating
 /// from different windows and they are all window scoped, all the alerts can be
 /// interacted with and they won't block eachother.
+///
+/// # More information
+///
+/// If you wish to dive deeper into platform specifics and learn more then you can
+/// check out Apple guidelines for
+/// [alerts](https://developer.apple.com/design/human-interface-guidelines/macos/windows-and-views/alerts/)
+/// and
+/// [dialogs](https://developer.apple.com/design/human-interface-guidelines/macos/windows-and-views/dialogs/);
+/// Microsoft guidelines for
+/// [dialogs](https://docs.microsoft.com/en-us/windows/win32/uxguide/win-dialog-box),
+/// [confirmations](https://docs.microsoft.com/en-us/windows/win32/uxguide/mess-confirm),
+/// [warnings](https://docs.microsoft.com/en-us/windows/win32/uxguide/mess-warn), and
+/// [errors](https://docs.microsoft.com/en-us/windows/win32/uxguide/mess-error);
+/// Gnome guidelines for
+/// [dialogs](https://developer.gnome.org/hig/stable/dialogs.html.en)
+/// and
+/// [buttons](https://developer.gnome.org/hig/stable/buttons.html.en).
+///
+/// Keep in mind that unless you are writing platform specific code you should
+/// only follow guidelines that all the platforms agree on.
 #[derive(Debug, Clone)]
 pub struct AlertOptions {
     /// Whether the alert is app-modal.

--- a/druid-shell/src/alert.rs
+++ b/druid-shell/src/alert.rs
@@ -101,6 +101,10 @@ pub struct AlertOptions {
 }
 
 /// Alert dialog icon.
+///
+/// # macOS
+///
+/// On macOS the information and warning icons are the same.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum AlertIcon {
     /// The alert dialog is providing important time sensitive information.
@@ -287,7 +291,12 @@ impl AlertOptions {
     ///
     /// Setting this to `None` means there will not be any icon.
     ///
+    /// # macOS
+    ///
+    /// On macOS `None` defaults to [`AlertIcon::Warning`].
+    ///
     /// [`AlertIcon`]: enum.AlertIcon.html
+    /// [`AlertIcon::Warning`]: enum.AlertIcon.html#variant.Warning
     pub fn icon(mut self, icon: impl Into<Option<AlertIcon>>) -> Self {
         self.icon = icon.into();
         self
@@ -299,6 +308,10 @@ impl AlertOptions {
     /// or a related component name, or at the very least your application name.
     ///
     /// This gets shown in the alert dialog title bar.
+    ///
+    /// # macOS
+    ///
+    /// This is not relevant or visible on macOS.
     pub fn context(mut self, context: impl Into<String>) -> Self {
         self.context = context.into();
         self

--- a/druid-shell/src/alert.rs
+++ b/druid-shell/src/alert.rs
@@ -125,7 +125,7 @@ pub struct AlertOptions {
 /// # macOS
 ///
 /// On macOS the information and warning icons are the same.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub enum AlertIcon {
     /// The alert dialog is providing important time sensitive information.
     Information,
@@ -198,11 +198,11 @@ impl AlertResponse {
 
 impl AlertButton {
     /// A primary button with the English label **OK**.
-    pub const OK: AlertButton = AlertButton::new("OK");
+    pub const OK: AlertButton = AlertButton::constant("OK");
     /// A cancel button with the English label **Cancel**.
-    pub const CANCEL: AlertButton = AlertButton::new("Cancel");
+    pub const CANCEL: AlertButton = AlertButton::constant("Cancel");
 
-    /// Create a new `const` button with the specified `label`.
+    /// Create a new button with the specified `label`.
     ///
     /// You should give a short but descriptive label like **Send message** that lets
     /// the user know what will happen when they click the button.
@@ -210,16 +210,16 @@ impl AlertButton {
     /// See [`AlertButton`] for more information.
     ///
     /// [`AlertButton`]: struct.AlertButton.html
-    pub const fn new(label: &'static str) -> AlertButton {
+    pub fn new(label: impl Into<String>) -> AlertButton {
         AlertButton {
-            label: Cow::Borrowed(label),
+            label: Cow::Owned(label.into()),
         }
     }
 
-    /// Create a new button with the specified `label` at runtime.
+    /// Create a new `const` button with the specified `label`.
     ///
-    /// This is the runtime version of [`new`] that allows you to use
-    /// runtime generated labels, e.g. dynamic personalization or translation.
+    /// This is the `const` version of [`new`] that allows you to create
+    /// `const` buttons at compile time.
     ///
     /// You should give a short but descriptive label like **Send message** that lets
     /// the user know what will happen when they click the button.
@@ -228,9 +228,9 @@ impl AlertButton {
     ///
     /// [`new`]: #method.new
     /// [`AlertButton`]: struct.AlertButton.html
-    pub fn dynamic(label: impl Into<String>) -> AlertButton {
+    pub const fn constant(label: &'static str) -> AlertButton {
         AlertButton {
-            label: Cow::Owned(label.into()),
+            label: Cow::Borrowed(label),
         }
     }
 }

--- a/druid-shell/src/alert.rs
+++ b/druid-shell/src/alert.rs
@@ -237,6 +237,10 @@ impl AlertButton {
 
 impl Default for AlertOptions {
     /// Create a default set of alert options.
+    ///
+    /// The default options contain only [`AlertButton::OK`] as the primary button.
+    ///
+    /// [`AlertButton::OK`]: struct.AlertButton.html#associatedconstant.OK
     fn default() -> AlertOptions {
         AlertOptions {
             app_modal: false,
@@ -253,6 +257,10 @@ impl Default for AlertOptions {
 
 impl AlertOptions {
     /// Create a new set of alert options.
+    ///
+    /// The default options contain only [`AlertButton::OK`] as the primary button.
+    ///
+    /// [`AlertButton::OK`]: struct.AlertButton.html#associatedconstant.OK
     pub fn new() -> Self {
         AlertOptions::default()
     }

--- a/druid-shell/src/alert.rs
+++ b/druid-shell/src/alert.rs
@@ -420,9 +420,9 @@ impl AlertOptions {
     ///
     /// An app-modal alert will prevent the user from interacting with
     /// any window of the application.
-    /// 
+    ///
     /// [Read more about modality.]
-    /// 
+    ///
     /// [Read more about modality.]: #modality
     pub fn app_modal(mut self) -> Self {
         self.app_modal = true;

--- a/druid-shell/src/alert.rs
+++ b/druid-shell/src/alert.rs
@@ -118,7 +118,7 @@ pub enum AlertIcon {
 /// A specific button for the alert dialog.
 ///
 /// If the alert is just reporting information and it only needs a single button,  
-/// then you should use a positive button with the label **OK** or a translation of it.
+/// then you should use a primary button with the label **OK** or a translation of it.
 ///
 /// The cancel button should always be labeled **Cancel** or a translation of it.
 ///

--- a/druid-shell/src/alert.rs
+++ b/druid-shell/src/alert.rs
@@ -20,6 +20,13 @@ use std::borrow::Cow;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
 pub struct AlertToken(usize);
 
+/// All the info needed to show and respond to an alert.
+#[derive(Debug, Clone)]
+pub(crate) struct AlertRequest {
+    pub(crate) token: AlertToken,
+    pub(crate) options: AlertOptions,
+}
+
 /// Contains the result of the alert after it was closed.
 #[derive(Debug, Clone)]
 pub struct AlertResponse {

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -28,6 +28,7 @@ pub use piet_common as piet;
 #[macro_use]
 mod util;
 
+mod alert;
 mod application;
 mod clipboard;
 mod common_util;
@@ -42,6 +43,7 @@ mod platform;
 mod scale;
 mod window;
 
+pub use alert::{AlertButton, AlertIcon, AlertOptions, AlertResponse, AlertToken};
 pub use application::{AppHandler, Application};
 pub use clipboard::{Clipboard, ClipboardFormat, FormatId};
 pub use common_util::Counter;

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -34,6 +34,7 @@ use gtk::{AccelGroup, ApplicationWindow, DrawingArea};
 use crate::kurbo::{Point, Rect, Size, Vec2};
 use crate::piet::{Piet, RenderContext};
 
+use crate::alert::{AlertOptions, AlertResponse, AlertToken};
 use crate::common_util::IdleCallback;
 use crate::dialog::{FileDialogOptions, FileDialogType, FileInfo};
 use crate::error::Error as ShellError;
@@ -584,6 +585,15 @@ impl WindowHandle {
 
     pub fn text(&self) -> Text {
         Text::new()
+    }
+
+    /// Show an alert dialog.
+    pub fn alert(&self, _options: AlertOptions) -> AlertToken {
+        {
+            // Just shutting up clippy until the real implementation arrives
+            AlertResponse::new(AlertToken::new(1), None);
+        }
+        AlertToken::INVALID
     }
 
     pub fn request_timer(&self, deadline: Instant) -> TimerToken {

--- a/druid-shell/src/platform/mac/alert.rs
+++ b/druid-shell/src/platform/mac/alert.rs
@@ -1,0 +1,120 @@
+// Copyright 2020 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! macOS alert dialog implementation.
+
+#![allow(non_upper_case_globals)]
+
+use std::ffi::c_void;
+
+use cocoa::base::{id, nil};
+use cocoa::foundation::{NSAutoreleasePool, NSInteger};
+use objc::rc::WeakPtr;
+use objc::runtime::Object;
+use objc::{msg_send, sel, sel_impl};
+
+use crate::alert::{AlertIcon, AlertRequest, AlertResponse};
+
+use super::appkit::{
+    NSAlert, NSAlertFirstButtonReturn, NSAlertSecondButtonReturn, NSAlertStyle,
+    NSAlertThirdButtonReturn, NSButton, NSControl, NSModalResponseAbort, NSModalResponseCancel,
+    NSModalResponseStop,
+};
+use super::util::make_nsstring;
+use super::window::ViewState;
+
+// Derive our own constants to allow for clearer code, especially without a cancel button.
+const BUTTON_ID_PRIMARY: NSInteger = NSAlertFirstButtonReturn;
+const BUTTON_ID_CANCEL: NSInteger = NSAlertSecondButtonReturn;
+const BUTTON_ID_ALT_START: NSInteger = NSAlertThirdButtonReturn;
+
+pub(crate) unsafe fn show(view: &mut Object, request: AlertRequest) {
+    let alert = NSAlert::alloc(nil).init().autorelease();
+
+    alert.setMessageText(make_nsstring(&request.options.message));
+    alert.setInformativeText(make_nsstring(&request.options.description));
+
+    match request.options.icon {
+        Some(AlertIcon::Information) => alert.setAlertStyle(NSAlertStyle::Informational),
+        Some(AlertIcon::Warning) => alert.setAlertStyle(NSAlertStyle::Warning),
+        Some(AlertIcon::Error) => alert.setAlertStyle(NSAlertStyle::Critical),
+        None => (), // The OS will default to NSAlertStyle::Warning
+    }
+
+    // The primary button is always first. (macOS alert buttons go from right to left)
+    let btn_primary = alert.addButtonWithTitle(make_nsstring(&request.options.primary.label));
+    // Set the primary button as the default which can be chosen via Enter.
+    btn_primary.setKeyEquivalent(make_nsstring("\r"));
+    btn_primary.setTag(BUTTON_ID_PRIMARY);
+
+    // If there's a cancel button, it is always second.
+    if let Some(cancel) = &request.options.cancel {
+        let btn_cancel = alert.addButtonWithTitle(make_nsstring(&cancel.label));
+        // Mark it as the cancel button by adding the Escape hotkey. This also activates Cmd+dot.
+        btn_cancel.setKeyEquivalent(make_nsstring("\u{1b}"));
+        btn_cancel.setTag(BUTTON_ID_CANCEL);
+    }
+
+    // Any alternative buttons are always last.
+    for (idx, alternative) in request.options.alternatives.iter().enumerate() {
+        let btn_alt = alert.addButtonWithTitle(make_nsstring(&alternative.label));
+        // Any hotkeys need to be explicit with custom buttons to avoid duplicates.
+        btn_alt.setKeyEquivalent(make_nsstring(""));
+        btn_alt.setTag(BUTTON_ID_ALT_START + idx as NSInteger);
+    }
+
+    if request.options.app_modal {
+        let tag = alert.runModal();
+        handle_result(view, &request, tag);
+    } else {
+        let window: id = msg_send![view, window];
+        let view_ptr = WeakPtr::new(view as *mut Object);
+
+        let alert_handler = block::ConcreteBlock::new(move |tag: NSInteger| {
+            let view = *view_ptr.load();
+            if !view.is_null() {
+                handle_result(&mut *view, &request, tag);
+            }
+        });
+        let alert_handler = alert_handler.copy(); // Force the block to live on the heap
+
+        alert.beginSheetModalForWindow_completionHandler(window, alert_handler);
+    }
+}
+
+unsafe fn handle_result(view: &mut Object, request: &AlertRequest, tag: NSInteger) {
+    let button = match tag {
+        BUTTON_ID_PRIMARY => Some(request.options.primary.clone()),
+        BUTTON_ID_CANCEL | NSModalResponseAbort | NSModalResponseStop | NSModalResponseCancel => {
+            None
+        }
+        id => {
+            if id >= BUTTON_ID_ALT_START
+                && id < BUTTON_ID_ALT_START + request.options.alternatives.len() as NSInteger
+            {
+                Some(request.options.alternatives[(id - BUTTON_ID_ALT_START) as usize].clone())
+            } else {
+                log::error!("Unexpected alert dialog result {}", id);
+                None
+            }
+        }
+    };
+    let view_state = {
+        let view_state: *mut c_void = *view.get_ivar("viewState");
+        &mut *(view_state as *mut ViewState)
+    };
+    (*view_state)
+        .handler
+        .alert_response(AlertResponse::new(request.token, button));
+}

--- a/druid-shell/src/platform/mac/appkit.rs
+++ b/druid-shell/src/platform/mac/appkit.rs
@@ -14,12 +14,14 @@
 
 //! macOS AppKit bindings.
 
+#![allow(dead_code)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 
 use bitflags::bitflags;
+use block::RcBlock;
 use cocoa::base::id;
-use cocoa::foundation::NSRect;
+use cocoa::foundation::{NSInteger, NSRect};
 use objc::{class, msg_send, sel, sel_impl};
 
 #[link(name = "AppKit", kind = "framework")]
@@ -76,5 +78,99 @@ pub trait NSView: Sized {
 impl NSView for id {
     unsafe fn addTrackingArea(self, trackingArea: id) -> id {
         msg_send![self, addTrackingArea: trackingArea]
+    }
+}
+
+pub trait NSButton: Sized {
+    unsafe fn setKeyEquivalent(self, key: id);
+}
+
+impl NSButton for id {
+    unsafe fn setKeyEquivalent(self, key: id) {
+        msg_send![self, setKeyEquivalent: key]
+    }
+}
+
+pub trait NSControl: Sized {
+    unsafe fn setTag(self, tag: NSInteger);
+}
+
+impl NSControl for id {
+    unsafe fn setTag(self, tag: NSInteger) {
+        msg_send![self, setTag: tag]
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum NSAlertStyle {
+    Warning,
+    Informational,
+    Critical,
+}
+
+pub const NSModalResponseContinue: NSInteger = -1002;
+pub const NSModalResponseAbort: NSInteger = -1001;
+pub const NSModalResponseStop: NSInteger = -1000;
+pub const NSModalResponseCancel: NSInteger = 0;
+pub const NSModalResponseOK: NSInteger = 1;
+
+pub const NSAlertFirstButtonReturn: NSInteger = 1000;
+pub const NSAlertSecondButtonReturn: NSInteger = 1001;
+pub const NSAlertThirdButtonReturn: NSInteger = 1002;
+
+pub trait NSAlert: Sized {
+    unsafe fn alloc(_: Self) -> id {
+        msg_send![class!(NSAlert), alloc]
+    }
+
+    unsafe fn init(self) -> id;
+    unsafe fn setAlertStyle(self, style: NSAlertStyle);
+    unsafe fn runModal(self) -> NSInteger;
+    unsafe fn beginSheetModalForWindow_completionHandler(
+        self,
+        window: id,
+        completionHandler: RcBlock<(NSInteger,), ()>,
+    );
+    unsafe fn setInformativeText(self, informativeText: id);
+    unsafe fn setMessageText(self, messageText: id);
+    unsafe fn addButtonWithTitle(self, title: id) -> id;
+    unsafe fn window(self) -> id;
+}
+
+impl NSAlert for id {
+    unsafe fn init(self) -> id {
+        msg_send![self, init]
+    }
+
+    unsafe fn setAlertStyle(self, alertStyle: NSAlertStyle) {
+        msg_send![self, setAlertStyle: alertStyle]
+    }
+
+    unsafe fn runModal(self) -> NSInteger {
+        msg_send![self, runModal]
+    }
+
+    unsafe fn beginSheetModalForWindow_completionHandler(
+        self,
+        window: id,
+        completionHandler: RcBlock<(NSInteger,), ()>,
+    ) {
+        msg_send![self, beginSheetModalForWindow: window completionHandler: completionHandler]
+    }
+
+    unsafe fn setInformativeText(self, informativeText: id) {
+        msg_send![self, setInformativeText: informativeText]
+    }
+
+    unsafe fn setMessageText(self, messageText: id) {
+        msg_send![self, setMessageText: messageText]
+    }
+
+    unsafe fn addButtonWithTitle(self, title: id) -> id {
+        msg_send![self, addButtonWithTitle: title]
+    }
+
+    unsafe fn window(self) -> id {
+        msg_send![self, window]
     }
 }

--- a/druid-shell/src/platform/mac/appkit.rs
+++ b/druid-shell/src/platform/mac/appkit.rs
@@ -24,11 +24,6 @@ use cocoa::base::id;
 use cocoa::foundation::{NSInteger, NSRect};
 use objc::{class, msg_send, sel, sel_impl};
 
-#[link(name = "AppKit", kind = "framework")]
-extern "C" {
-    pub static NSRunLoopCommonModes: id;
-}
-
 bitflags! {
     pub struct NSTrackingAreaOptions: i32 {
         const MouseEnteredAndExited = 1;

--- a/druid-shell/src/platform/mac/appkit.rs
+++ b/druid-shell/src/platform/mac/appkit.rs
@@ -24,12 +24,18 @@ use cocoa::base::id;
 use cocoa::foundation::{NSInteger, NSRect};
 use objc::{class, msg_send, sel, sel_impl};
 
+#[link(name = "AppKit", kind = "framework")]
+extern "C" {
+    pub static NSRunLoopCommonModes: id;
+}
+
+// Values can be found in AppKit NSTrackingArea.h
 bitflags! {
     pub struct NSTrackingAreaOptions: i32 {
         const MouseEnteredAndExited = 1;
         const MouseMoved = 1 << 1;
         const CursorUpdate = 1 << 2;
-        // What's 1 << 3?
+        // 1 << 3 is not used
         const ActiveWhenFirstResponder = 1 << 4;
         const ActiveInKeyWindow = 1 << 5;
         const ActiveInActiveApp = 1 << 6;
@@ -103,12 +109,16 @@ pub enum NSAlertStyle {
     Critical,
 }
 
+// Values can be found in AppKit NSApplication.h
 pub const NSModalResponseContinue: NSInteger = -1002;
 pub const NSModalResponseAbort: NSInteger = -1001;
 pub const NSModalResponseStop: NSInteger = -1000;
+
+// Values can be found in AppKit NSWindow.h
 pub const NSModalResponseCancel: NSInteger = 0;
 pub const NSModalResponseOK: NSInteger = 1;
 
+// Values can be found in AppKit NSAlert.h
 pub const NSAlertFirstButtonReturn: NSInteger = 1000;
 pub const NSAlertSecondButtonReturn: NSInteger = 1001;
 pub const NSAlertThirdButtonReturn: NSInteger = 1002;

--- a/druid-shell/src/platform/mac/mod.rs
+++ b/druid-shell/src/platform/mac/mod.rs
@@ -16,6 +16,7 @@
 
 #![allow(clippy::let_unit_value)]
 
+mod alert;
 pub mod appkit;
 pub mod application;
 pub mod clipboard;

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -21,28 +21,26 @@ use std::rc::{Rc, Weak};
 use std::sync::{Arc, Mutex};
 
 use instant::Instant;
-
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
+use crate::alert::{AlertOptions, AlertResponse, AlertToken};
+use crate::common_util::IdleCallback;
+use crate::dialog::{FileDialogOptions, FileDialogType, FileInfo};
+use crate::error::Error as ShellError;
+use crate::keyboard;
+use crate::keycodes::KeyCode;
 use crate::kurbo::{Point, Rect, Size, Vec2};
-
+use crate::mouse::{Cursor, MouseButton, MouseButtons, MouseEvent};
 use crate::piet::RenderContext;
+use crate::scale::{Scale, ScaledArea};
+use crate::window::{IdleToken, Text, TimerToken, WinHandler};
+use crate::KeyModifiers;
 
 use super::application::Application;
 use super::error::Error;
 use super::keycodes::key_to_text;
 use super::menu::Menu;
-use crate::common_util::IdleCallback;
-use crate::dialog::{FileDialogOptions, FileDialogType, FileInfo};
-use crate::error::Error as ShellError;
-use crate::scale::{Scale, ScaledArea};
-
-use crate::keyboard;
-use crate::keycodes::KeyCode;
-use crate::mouse::{Cursor, MouseButton, MouseButtons, MouseEvent};
-use crate::window::{IdleToken, Text, TimerToken, WinHandler};
-use crate::KeyModifiers;
 
 // This is a macro instead of a function since KeyboardEvent and MouseEvent has identical functions
 // to query modifier key states.
@@ -467,6 +465,15 @@ impl WindowHandle {
             .unwrap_or_else(|| panic!("Failed to produce a text context"));
 
         Text::new(s.context.clone(), s.window.clone())
+    }
+
+    /// Show an alert dialog.
+    pub fn alert(&self, _options: AlertOptions) -> AlertToken {
+        {
+            // Just shutting up clippy until the real implementation arrives
+            AlertResponse::new(AlertToken::new(1), None);
+        }
+        AlertToken::INVALID
     }
 
     pub fn request_timer(&self, deadline: Instant) -> TimerToken {

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -56,6 +56,7 @@ use super::paint;
 use super::timers::TimerSlots;
 use super::util::{self, as_result, FromWide, ToWide, OPTIONAL_FUNCTIONS};
 
+use crate::alert::{AlertOptions, AlertResponse, AlertToken};
 use crate::common_util::IdleCallback;
 use crate::dialog::{FileDialogOptions, FileDialogType, FileInfo};
 use crate::error::Error as ShellError;
@@ -1444,6 +1445,15 @@ impl WindowHandle {
 
     pub fn text(&self) -> Text {
         Text::new(&self.dwrite_factory)
+    }
+
+    /// Show an alert dialog.
+    pub fn alert(&self, _options: AlertOptions) -> AlertToken {
+        {
+            // Just shutting up clippy until the real implementation arrives
+            AlertResponse::new(AlertToken::new(1), None);
+        }
+        AlertToken::INVALID
     }
 
     /// Request a timer event.

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -28,6 +28,7 @@ use x11rb::protocol::xproto::{
 };
 use x11rb::wrapper::ConnectionExt as WrapperConnectionExt;
 
+use crate::alert::{AlertOptions, AlertResponse, AlertToken};
 use crate::dialog::{FileDialogOptions, FileInfo};
 use crate::error::Error as ShellError;
 use crate::keyboard::{KeyEvent, KeyModifiers};
@@ -800,6 +801,15 @@ impl WindowHandle {
     pub fn text(&self) -> Text {
         // I'm not entirely sure what this method is doing here, so here's a Text.
         Text::new()
+    }
+
+    /// Show an alert dialog.
+    pub fn alert(&self, _options: AlertOptions) -> AlertToken {
+        {
+            // Just shutting up clippy until the real implementation arrives
+            AlertResponse::new(AlertToken::new(1), None);
+        }
+        AlertToken::INVALID
     }
 
     pub fn request_timer(&self, _deadline: std::time::Instant) -> TimerToken {

--- a/druid-shell/src/util.rs
+++ b/druid-shell/src/util.rs
@@ -14,88 +14,9 @@
 
 //! Utility functions for determining the main thread.
 
-use std::fmt::{Debug, Display};
 use std::mem;
-use std::ops::Deref;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread;
-
-/// A convenience wrapper over `String` / `&'static str`.
-///
-/// This is useful for cases where you want to use a `String` but also
-/// want to be able to create the type at compile time via `const` functions.
-#[derive(Clone)]
-pub struct ConstString(ConstStringValue);
-
-#[derive(Clone)]
-enum ConstStringValue {
-    Owned(String),
-    Static(&'static str),
-}
-
-impl ConstString {
-    /// Create a new `ConstString` from a `&'static str`.
-    pub const fn from_static(value: &'static str) -> ConstString {
-        ConstString(ConstStringValue::Static(value))
-    }
-
-    /// Create a new `ConstString`.
-    pub fn new(value: impl Into<String>) -> ConstString {
-        ConstString(ConstStringValue::Owned(value.into()))
-    }
-}
-
-impl Eq for ConstString {}
-
-impl PartialEq for ConstString {
-    fn eq(&self, other: &ConstString) -> bool {
-        self.as_ref() == other.as_ref()
-    }
-}
-
-impl Deref for ConstString {
-    type Target = str;
-
-    fn deref(&self) -> &str {
-        match &self.0 {
-            ConstStringValue::Owned(s) => s,
-            ConstStringValue::Static(s) => *s,
-        }
-    }
-}
-
-impl AsRef<str> for ConstString {
-    fn as_ref(&self) -> &str {
-        match &self.0 {
-            ConstStringValue::Owned(s) => s,
-            ConstStringValue::Static(s) => *s,
-        }
-    }
-}
-
-impl Default for ConstString {
-    fn default() -> ConstString {
-        ConstString::from_static("")
-    }
-}
-
-impl Display for ConstString {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match &self.0 {
-            ConstStringValue::Owned(s) => Display::fmt(s, f),
-            ConstStringValue::Static(s) => Display::fmt(*s, f),
-        }
-    }
-}
-
-impl Debug for ConstString {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match &self.0 {
-            ConstStringValue::Owned(s) => Debug::fmt(s, f),
-            ConstStringValue::Static(s) => Debug::fmt(*s, f),
-        }
-    }
-}
 
 static MAIN_THREAD_ID: AtomicU64 = AtomicU64::new(0);
 

--- a/druid-shell/src/util.rs
+++ b/druid-shell/src/util.rs
@@ -14,9 +14,88 @@
 
 //! Utility functions for determining the main thread.
 
+use std::fmt::{Debug, Display};
 use std::mem;
+use std::ops::Deref;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread;
+
+/// A convenience wrapper over `String` / `&'static str`.
+///
+/// This is useful for cases where you want to use a `String` but also
+/// want to be able to create the type at compile time via `const` functions.
+#[derive(Clone)]
+pub struct ConstString(ConstStringValue);
+
+#[derive(Clone)]
+enum ConstStringValue {
+    Owned(String),
+    Static(&'static str),
+}
+
+impl ConstString {
+    /// Create a new `ConstString` from a `&'static str`.
+    pub const fn from_static(value: &'static str) -> ConstString {
+        ConstString(ConstStringValue::Static(value))
+    }
+
+    /// Create a new `ConstString`.
+    pub fn new(value: impl Into<String>) -> ConstString {
+        ConstString(ConstStringValue::Owned(value.into()))
+    }
+}
+
+impl Eq for ConstString {}
+
+impl PartialEq for ConstString {
+    fn eq(&self, other: &ConstString) -> bool {
+        self.as_ref() == other.as_ref()
+    }
+}
+
+impl Deref for ConstString {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        match &self.0 {
+            ConstStringValue::Owned(s) => s,
+            ConstStringValue::Static(s) => *s,
+        }
+    }
+}
+
+impl AsRef<str> for ConstString {
+    fn as_ref(&self) -> &str {
+        match &self.0 {
+            ConstStringValue::Owned(s) => s,
+            ConstStringValue::Static(s) => *s,
+        }
+    }
+}
+
+impl Default for ConstString {
+    fn default() -> ConstString {
+        ConstString::from_static("")
+    }
+}
+
+impl Display for ConstString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match &self.0 {
+            ConstStringValue::Owned(s) => Display::fmt(s, f),
+            ConstStringValue::Static(s) => Display::fmt(*s, f),
+        }
+    }
+}
+
+impl Debug for ConstString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match &self.0 {
+            ConstStringValue::Owned(s) => Debug::fmt(s, f),
+            ConstStringValue::Static(s) => Debug::fmt(*s, f),
+        }
+    }
+}
 
 static MAIN_THREAD_ID: AtomicU64 = AtomicU64::new(0);
 

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -17,6 +17,7 @@
 use std::any::Any;
 use std::time::Duration;
 
+use crate::alert::{AlertOptions, AlertResponse, AlertToken};
 use crate::application::Application;
 use crate::common_util::Counter;
 use crate::dialog::{FileDialogOptions, FileInfo};
@@ -151,6 +152,20 @@ impl WindowHandle {
     /// Get access to a type that can perform text layout.
     pub fn text(&self) -> Text {
         self.0.text()
+    }
+
+    /// Show an alert dialog.
+    ///
+    /// Read [`AlertOptions`] for more information about alert dialogs.
+    ///
+    /// The return value is an [`AlertToken`], which can be used to associate
+    /// the [`AlertResponse`] with this specific alert.
+    ///
+    /// [`AlertOptions`]: struct.AlertOptions.html
+    /// [`AlertToken`]: struct.AlertToken.html
+    /// [`AlertResponse`]: struct.AlertResponse.html
+    pub fn alert(&self, options: AlertOptions) -> AlertToken {
+        self.0.alert(options)
     }
 
     /// Schedule a timer.
@@ -381,6 +396,10 @@ pub trait WinHandler {
 
     /// Called when the mouse cursor has left the application window
     fn mouse_leave(&mut self) {}
+
+    /// Called when an alert dialog is closed.
+    #[allow(unused_variables)]
+    fn alert_response(&mut self, response: AlertResponse) {}
 
     /// Called on timer event.
     ///

--- a/druid/examples/alert.rs
+++ b/druid/examples/alert.rs
@@ -23,8 +23,8 @@ use druid::{AlertButton, AlertOptions, AlertToken, AppLauncher, WidgetExt, Windo
 use druid::{Application, Data, Lens, TimerToken};
 
 // If you know the alert button label at compile time, you can make const AlertButtons.
-const ALERT_BUTTON_TO_LEFT: AlertButton = AlertButton::new("Increase left");
-const ALERT_BUTTON_TO_RIGHT: AlertButton = AlertButton::new("Increase right");
+const ALERT_BUTTON_TO_LEFT: AlertButton = AlertButton::constant("Increase left");
+const ALERT_BUTTON_TO_RIGHT: AlertButton = AlertButton::constant("Increase right");
 
 #[derive(Debug, Clone, Data, Lens)]
 struct State {
@@ -86,10 +86,10 @@ fn ui_builder() -> impl Widget<State> {
                 "This is an example of how the alert system works, \
                 but not an example of a good user experience.",
             )
-            .primary(AlertButton::new("Get me out of here"))
-            .alternative(AlertButton::new("Refrigerate lemons"))
-            .alternative(AlertButton::new("Dip fat-free cheese in fat"))
-            .cancel(AlertButton::new("Translated cancel"));
+            .primary(AlertButton::constant("Get me out of here"))
+            .alternative(AlertButton::constant("Refrigerate lemons"))
+            .alternative(AlertButton::constant("Dip fat-free cheese in fat"))
+            .cancel(AlertButton::constant("Translated cancel"));
         let opts = opts_modal(opts, data);
         ctx.alert(opts);
     });
@@ -166,8 +166,8 @@ impl<W: Widget<State>> Controller<State, W> for ManageButtonController {
 impl BitsButtonController {
     pub fn new(what: &str) -> BitsButtonController {
         BitsButtonController {
-            button_set: AlertButton::dynamic(format!("Set {}", what)),
-            button_clear: AlertButton::dynamic(format!("Clear {}", what)),
+            button_set: AlertButton::new(format!("Set {}", what)),
+            button_clear: AlertButton::new(format!("Clear {}", what)),
             counter: 0,
             timer_token: TimerToken::INVALID,
             tokens: HashMap::new(),

--- a/druid/examples/alert.rs
+++ b/druid/examples/alert.rs
@@ -51,7 +51,7 @@ struct QuitButtonController {
 
 const WINDOW_TITLE: &str = "Alerts everywhere";
 
-fn main() {
+pub fn main() {
     let main_window = WindowDesc::new(ui_builder).title(WINDOW_TITLE);
     let state = State {
         app_modal: false,

--- a/druid/examples/alert.rs
+++ b/druid/examples/alert.rs
@@ -1,0 +1,200 @@
+// Copyright 2020 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Alert dialogs in action.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use druid::widget::prelude::*;
+use druid::widget::{Button, Controller, Flex, Label, MainAxisAlignment, Padding};
+use druid::{AlertButton, AlertOptions, AlertToken, AppLauncher, WidgetExt, WindowDesc};
+use druid::{Data, TimerToken};
+
+const ALERT_BUTTON_TO_LEFT: AlertButton = AlertButton::new("Increase left");
+
+#[derive(Debug, Clone, Data)]
+struct State {
+    left: usize,
+    right: usize,
+    bits: usize,
+}
+
+fn main() {
+    let main_window = WindowDesc::new(ui_builder).title("Alerts everywhere");
+    let state = State {
+        left: 5,
+        right: 5,
+        bits: 0,
+    };
+    AppLauncher::with_window(main_window)
+        .use_simple_logger()
+        .launch(state)
+        .expect("launch failed");
+}
+
+fn ui_builder() -> impl Widget<State> {
+    let button_new_window = Button::new("New window").on_click(|ctx, _data, _env| {
+        let new_window = WindowDesc::new(ui_builder);
+        ctx.new_window(new_window);
+    });
+    let button_kitchen = Button::new("Kitchen sink").on_click(|ctx, _data, _env| {
+        let opts = AlertOptions::error()
+            .context("Heavyweight example")
+            .message("Don't do this at home!")
+            .description(
+                "This is an example of how the alert system works, \
+                but not an example of a good user experience.",
+            )
+            .primary(AlertButton::new("Get me out of here"))
+            .alternative(AlertButton::new("Refrigerate lemons"))
+            .alternative(AlertButton::new("Dip fat-free cheese in fat"))
+            .cancel(AlertButton::new("Custom cancel"));
+        ctx.alert(opts);
+    });
+    let button_flood = Button::new("Three in a row").on_click(|ctx, _data, _env| {
+        for i in 0..3 {
+            let opts = AlertOptions::warning().message(format!("Alert #{}", i + 1));
+            ctx.alert(opts);
+        }
+    });
+    let button_manage = Button::<State>::new("Manage score")
+        .on_click(|ctx, _data, _env| {
+            let opts = AlertOptions::information()
+                .context("Manage score")
+                .message("How would you like to manage the score?")
+                .primary(ALERT_BUTTON_TO_LEFT)
+                .alternative(AlertButton::dynamic("Increase right"))
+                .cancelable();
+            ctx.alert(opts);
+        })
+        .controller(ManageButtonController);
+    let button_bits = Button::<State>::dynamic(|data, _| format!("Bits: {:05b}", data.bits))
+        .controller(BitsButtonController::new());
+
+    let label_left = Label::new(|data: &State, _: &_| format!("{}", data.left));
+    let label_right = Label::new(|data: &State, _: &_| format!("{}", data.right));
+
+    let label_row = Flex::row()
+        .must_fill_main_axis(true)
+        .main_axis_alignment(MainAxisAlignment::SpaceBetween)
+        .with_child(label_left)
+        .with_child(label_right);
+
+    Flex::column()
+        .main_axis_alignment(MainAxisAlignment::End)
+        .with_flex_child(Padding::new(5.0, button_new_window), 1.0)
+        .with_flex_child(Padding::new(5.0, button_kitchen), 1.0)
+        .with_flex_child(Padding::new(5.0, button_manage), 1.0)
+        .with_flex_child(Padding::new(5.0, button_flood), 1.0)
+        .with_flex_child(Padding::new(5.0, button_bits), 1.0)
+        .with_flex_child(Padding::new(20.0, label_row), 1.0)
+}
+
+struct ManageButtonController;
+
+impl<W: Widget<State>> Controller<State, W> for ManageButtonController {
+    fn event(
+        &mut self,
+        child: &mut W,
+        ctx: &mut EventCtx,
+        event: &Event,
+        data: &mut State,
+        env: &Env,
+    ) {
+        match event {
+            Event::AlertResponse(response) => {
+                if response.button() == Some(&ALERT_BUTTON_TO_LEFT) {
+                    if data.right > 0 {
+                        data.left += 1;
+                        data.right -= 1;
+                    }
+                } else if response.button() == Some(&AlertButton::dynamic("Increase right")) {
+                    if data.left > 0 {
+                        data.left -= 1;
+                        data.right += 1;
+                    }
+                }
+            }
+            _ => child.event(ctx, event, data, env),
+        }
+    }
+}
+
+const BITS_BUTTON_SET: AlertButton = AlertButton::new("Set");
+const BITS_BUTTON_CLEAR: AlertButton = AlertButton::new("Clear");
+
+struct BitsButtonController {
+    counter: usize,
+    timer_token: TimerToken,
+    tokens: HashMap<AlertToken, usize>,
+}
+
+impl BitsButtonController {
+    pub fn new() -> BitsButtonController {
+        BitsButtonController {
+            counter: 0,
+            timer_token: TimerToken::INVALID,
+            tokens: HashMap::new(),
+        }
+    }
+}
+
+impl<W: Widget<State>> Controller<State, W> for BitsButtonController {
+    fn event(
+        &mut self,
+        child: &mut W,
+        ctx: &mut EventCtx,
+        event: &Event,
+        data: &mut State,
+        env: &Env,
+    ) {
+        match event {
+            Event::MouseUp(_) => {
+                if ctx.is_active() && ctx.is_hot() {
+                    self.timer_token = ctx.request_timer(Duration::from_millis(1));
+                }
+            }
+            Event::Timer(timer_token) => {
+                if self.timer_token == *timer_token {
+                    if self.counter == 0 {
+                        self.tokens.clear();
+                    }
+                    self.counter += 1;
+                    let opts = AlertOptions::new()
+                        .message(format!("What about bit #{}?", self.counter))
+                        .primary(BITS_BUTTON_SET)
+                        .alternative(BITS_BUTTON_CLEAR);
+                    let token = ctx.alert(opts);
+                    self.tokens.insert(token, self.counter);
+                    if self.counter < 5 {
+                        self.timer_token = ctx.request_timer(Duration::from_millis(200));
+                    } else {
+                        self.counter = 0;
+                        self.timer_token = TimerToken::INVALID;
+                    }
+                }
+            }
+            Event::AlertResponse(response) => {
+                let bit = self.tokens.get(&response.token()).unwrap();
+                if response.button() == Some(&BITS_BUTTON_SET) {
+                    data.bits |= 1 << (bit - 1);
+                } else if response.button() == Some(&BITS_BUTTON_CLEAR) {
+                    data.bits &= !(1 << (bit - 1));
+                }
+            }
+            _ => child.event(ctx, event, data, env),
+        }
+    }
+}

--- a/druid/examples/alert.rs
+++ b/druid/examples/alert.rs
@@ -150,16 +150,12 @@ impl<W: Widget<State>> Controller<State, W> for ManageButtonController {
     ) {
         match event {
             Event::AlertResponse(response) => {
-                if response.button() == Some(&ALERT_BUTTON_TO_LEFT) {
-                    if data.right > 0 {
-                        data.left += 1;
-                        data.right -= 1;
-                    }
-                } else if response.button() == Some(&ALERT_BUTTON_TO_RIGHT) {
-                    if data.left > 0 {
-                        data.left -= 1;
-                        data.right += 1;
-                    }
+                if response.button() == Some(&ALERT_BUTTON_TO_LEFT) && data.right > 0 {
+                    data.left += 1;
+                    data.right -= 1;
+                } else if response.button() == Some(&ALERT_BUTTON_TO_RIGHT) && data.left > 0 {
+                    data.left -= 1;
+                    data.right += 1;
                 }
             }
             _ => child.event(ctx, event, data, env),

--- a/druid/examples/alert.rs
+++ b/druid/examples/alert.rs
@@ -49,8 +49,10 @@ struct QuitButtonController {
     timer_token: TimerToken,
 }
 
+const WINDOW_TITLE: &str = "Alerts everywhere";
+
 fn main() {
-    let main_window = WindowDesc::new(ui_builder).title("Alerts everywhere");
+    let main_window = WindowDesc::new(ui_builder).title(WINDOW_TITLE);
     let state = State {
         app_modal: false,
         left: 5,
@@ -73,7 +75,7 @@ fn opts_modal(options: AlertOptions, data: &State) -> AlertOptions {
 
 fn ui_builder() -> impl Widget<State> {
     let button_new_window = Button::new("New window").on_click(|ctx, _data, _env| {
-        let new_window = WindowDesc::new(ui_builder);
+        let new_window = WindowDesc::new(ui_builder).title(WINDOW_TITLE);
         ctx.new_window(new_window);
     });
     let button_kitchen = Button::new("Kitchen sink").on_click(|ctx, data, _env| {

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -14,27 +14,33 @@
 
 //! Opening and closing windows and using window and context menus.
 
+use std::collections::HashMap;
+use std::time::Duration;
+
 use druid::widget::prelude::*;
 use druid::widget::{
     Align, BackgroundBrush, Button, Controller, ControllerHost, Flex, Label, Padding,
 };
 use druid::Target::Global;
 use druid::{
-    commands as sys_cmds, AppDelegate, AppLauncher, Application, Color, Command, ContextMenu, Data,
-    DelegateCtx, LocalizedString, MenuDesc, MenuItem, Selector, Target, WindowDesc, WindowId,
+    commands as sys_cmds, AlertButton, AlertOptions, AlertToken, AppDelegate, AppLauncher,
+    Application, Color, Command, ContextMenu, Data, DelegateCtx, LocalizedString, MenuDesc,
+    MenuItem, Selector, Target, TimerToken, WidgetExt, WindowDesc, WindowId,
 };
-use log::info;
 
 const MENU_COUNT_ACTION: Selector<usize> = Selector::new("menu-count-action");
 const MENU_INCREMENT_ACTION: Selector = Selector::new("menu-increment-action");
 const MENU_DECREMENT_ACTION: Selector = Selector::new("menu-decrement-action");
 const MENU_SWITCH_GLOW_ACTION: Selector = Selector::new("menu-switch-glow");
 
+const ALERT_ADD_MENU_ITEM_BUTTON: AlertButton = AlertButton::const_positive("Add menu item");
+
 #[derive(Debug, Clone, Default, Data)]
 struct State {
     menu_count: usize,
     selected: usize,
     glow_hot: bool,
+    button_bits: usize,
 }
 
 pub fn main() {
@@ -61,6 +67,27 @@ fn ui_builder() -> impl Widget<State> {
         .on_click(|ctx, _data, _env| ctx.submit_command(MENU_INCREMENT_ACTION, Global));
     let dec_button = Button::<State>::new("Remove menu item")
         .on_click(|ctx, _data, _env| ctx.submit_command(MENU_DECREMENT_ACTION, Global));
+    let manage_button = Button::<State>::new("Manage menu items")
+        .on_click(|ctx, _data, _env| {
+            let buttons = vec![
+                AlertButton::negative("Remove menu item"), // A button generated at runtime
+                ALERT_ADD_MENU_ITEM_BUTTON,                // A button generated at compile time
+                AlertButton::CANCEL,                       // A predefined button
+            ];
+            let opts = AlertOptions::new()
+                .information()
+                .context("Manage menu items")
+                .message("How would you like to manage the menu items?")
+                .description(
+                    "Clicking the action buttons below has the same result \
+                    as clicking the regular buttons in the window.",
+                )
+                .buttons(buttons);
+            ctx.alert(opts);
+        })
+        .controller(ManageButtonController);
+    let bits_button = Button::<State>::dynamic(|data, _| format!("{:05b}", data.button_bits))
+        .controller(BitsButtonController::new());
     let new_button = Button::<State>::new("New window").on_click(|ctx, _data, _env| {
         ctx.submit_command(sys_cmds::NEW_FILE, Target::Global);
     });
@@ -73,6 +100,10 @@ fn ui_builder() -> impl Widget<State> {
     let mut row = Flex::row();
     row.add_child(Padding::new(5.0, inc_button));
     row.add_child(Padding::new(5.0, dec_button));
+    row.add_child(Padding::new(5.0, manage_button));
+    col.add_flex_child(Align::centered(row), 1.0);
+    let mut row = Flex::row();
+    row.add_child(Padding::new(5.0, bits_button));
     col.add_flex_child(Align::centered(row), 1.0);
     let mut row = Flex::row();
     row.add_child(Padding::new(5.0, new_button));
@@ -80,6 +111,90 @@ fn ui_builder() -> impl Widget<State> {
     col.add_flex_child(Align::centered(row), 1.0);
     let content = ControllerHost::new(col, ContextMenuController);
     Glow::new(content)
+}
+
+struct ManageButtonController;
+
+impl<T, W: Widget<T>> Controller<T, W> for ManageButtonController {
+    fn event(&mut self, child: &mut W, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
+        match event {
+            Event::AlertResponse(response) => {
+                if *response.button() == ALERT_ADD_MENU_ITEM_BUTTON {
+                    ctx.submit_command(MENU_INCREMENT_ACTION, Global);
+                } else if *response.button() == AlertButton::negative("Remove menu item") {
+                    ctx.submit_command(MENU_DECREMENT_ACTION, Global);
+                }
+            }
+            _ => child.event(ctx, event, data, env),
+        }
+    }
+}
+
+const BITS_BUTTON_SET: AlertButton = AlertButton::const_positive("Set");
+const BITS_BUTTON_CLEAR: AlertButton = AlertButton::const_negative("Clear");
+
+struct BitsButtonController {
+    counter: usize,
+    timer_token: TimerToken,
+    tokens: HashMap<AlertToken, usize>,
+}
+
+impl BitsButtonController {
+    pub fn new() -> BitsButtonController {
+        BitsButtonController {
+            counter: 0,
+            timer_token: TimerToken::INVALID,
+            tokens: HashMap::new(),
+        }
+    }
+}
+
+impl<W: Widget<State>> Controller<State, W> for BitsButtonController {
+    fn event(
+        &mut self,
+        child: &mut W,
+        ctx: &mut EventCtx,
+        event: &Event,
+        data: &mut State,
+        env: &Env,
+    ) {
+        match event {
+            Event::MouseUp(_) => {
+                if ctx.is_active() && ctx.is_hot() {
+                    self.timer_token = ctx.request_timer(Duration::from_millis(1));
+                }
+            }
+            Event::Timer(timer_token) => {
+                if self.timer_token == *timer_token {
+                    if self.counter == 0 {
+                        self.tokens.clear();
+                    }
+                    self.counter += 1;
+                    let buttons = vec![BITS_BUTTON_SET, BITS_BUTTON_CLEAR];
+                    let opts = AlertOptions::new()
+                        .message(format!("What about bit #{}?", self.counter))
+                        .buttons(buttons);
+                    let token = ctx.alert(opts);
+                    self.tokens.insert(token, self.counter);
+                    if self.counter < 5 {
+                        self.timer_token = ctx.request_timer(Duration::from_millis(200));
+                    } else {
+                        self.counter = 0;
+                        self.timer_token = TimerToken::INVALID;
+                    }
+                }
+            }
+            Event::AlertResponse(response) => {
+                let bit = self.tokens.get(&response.token()).unwrap();
+                if *response.button() == BITS_BUTTON_SET {
+                    data.button_bits |= 1 << (bit - 1);
+                } else if *response.button() == BITS_BUTTON_CLEAR {
+                    data.button_bits &= !(1 << (bit - 1));
+                }
+            }
+            _ => child.event(ctx, event, data, env),
+        }
+    }
 }
 
 struct Glow<W> {
@@ -204,7 +319,7 @@ impl AppDelegate<State> for Delegate {
         _env: &Env,
         _ctx: &mut DelegateCtx,
     ) {
-        info!("Window added, id: {:?}", id);
+        log::info!("Window added, id: {:?}", id);
         self.windows.push(id);
     }
 
@@ -215,7 +330,7 @@ impl AppDelegate<State> for Delegate {
         _env: &Env,
         _ctx: &mut DelegateCtx,
     ) {
-        info!("Window removed, id: {:?}", id);
+        log::info!("Window removed, id: {:?}", id);
         if let Some(pos) = self.windows.iter().position(|x| *x == id) {
             self.windows.remove(pos);
         }

--- a/druid/examples/web/src/lib.rs
+++ b/druid/examples/web/src/lib.rs
@@ -54,6 +54,7 @@ macro_rules! impl_example {
 
 // Below is a list of examples that can be built for the web.
 // Please add the examples that cannot be built to the EXCEPTIONS list in build.rs.
+impl_example!(alert);
 impl_example!(anim);
 impl_example!(calc);
 impl_example!(custom_widget);

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -24,8 +24,9 @@ use crate::core::{CommandQueue, FocusChange, WidgetState};
 use crate::piet::Piet;
 use crate::piet::RenderContext;
 use crate::{
-    commands, Affine, Command, ContextMenu, Cursor, Insets, MenuDesc, Point, Rect, SingleUse, Size,
-    Target, Text, TimerToken, Vec2, WidgetId, WindowDesc, WindowHandle, WindowId,
+    commands, Affine, AlertOptions, AlertToken, Command, ContextMenu, Cursor, Insets, MenuDesc,
+    Point, Rect, SingleUse, Size, Target, Text, TimerToken, Vec2, WidgetId, WindowDesc,
+    WindowHandle, WindowId,
 };
 
 /// A macro for implementing methods on multiple contexts.
@@ -337,6 +338,21 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
     /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
     pub fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {
         self.state.set_menu(menu);
+    }
+
+    /// Show an alert dialog.
+    ///
+    /// Read [`AlertOptions`] for more information about alert dialogs.
+    ///
+    /// The return value is an [`AlertToken`], which can be used to associate this
+    /// specific alert with an [`AlertResponse`] delivered via [`Event::AlertResponse`].
+    ///
+    /// [`AlertOptions`]: struct.AlertOptions.html
+    /// [`AlertToken`]: struct.AlertToken.html
+    /// [`AlertResponse`]: struct.AlertResponse.html
+    /// [`Event::AlertResponse`]: enum.Event.html#variant.AlertResponse
+    pub fn alert(&mut self, options: AlertOptions) -> AlertToken {
+        self.state.alert(&mut self.widget_state, options)
     }
 });
 
@@ -652,6 +668,12 @@ impl<'a> ContextState<'a> {
                 log::error!("EventCtx::set_menu: {}", MSG)
             }
         }
+    }
+
+    fn alert(&self, widget_state: &mut WidgetState, options: AlertOptions) -> AlertToken {
+        let alert_token = self.window.alert(options);
+        widget_state.add_alert(alert_token);
+        alert_token
     }
 
     fn request_timer(&self, widget_state: &mut WidgetState, deadline: Duration) -> TimerToken {

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -19,7 +19,7 @@ use crate::kurbo::{Rect, Shape, Size, Vec2};
 use druid_shell::{Clipboard, KeyEvent, TimerToken};
 
 use crate::mouse::MouseEvent;
-use crate::{Command, Target, WidgetId};
+use crate::{AlertResponse, Command, Target, WidgetId};
 
 /// An event, propagated downwards during event flow.
 ///
@@ -103,6 +103,13 @@ pub enum Event {
     ///
     /// The value is a delta.
     Zoom(f64),
+    /// Called when an alert dialog is closed.
+    ///
+    /// You can show an alert with the [`EventCtx::alert`] method.
+    /// The response to that alert is delivered via this event.
+    ///
+    /// [`EventCtx::alert`]: struct.EventCtx.html#method.alert
+    AlertResponse(AlertResponse),
     /// Called on a timer event.
     ///
     /// Request a timer event through [`EventCtx::request_timer()`]. That will
@@ -149,6 +156,8 @@ pub enum InternalEvent {
     MouseLeave,
     /// A command still in the process of being dispatched.
     TargetedCommand(Target, Command),
+    /// Used for routing AlertResponse events.
+    RouteAlertResponse(WidgetId, AlertResponse),
     /// Used for routing timer events.
     RouteTimer(TimerToken, WidgetId),
 }

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -168,9 +168,10 @@ pub use kurbo::{Affine, Insets, Point, Rect, Size, Vec2};
 pub use piet::{Color, LinearGradient, RadialGradient, RenderContext, UnitPoint};
 // these are the types from shell that we expose; others we only use internally.
 pub use shell::{
-    Application, Clipboard, ClipboardFormat, Cursor, Error as PlatformError, FileDialogOptions,
-    FileInfo, FileSpec, FormatId, HotKey, KeyCode, KeyEvent, KeyModifiers, MouseButton,
-    MouseButtons, RawMods, Scale, SysMods, Text, TimerToken, WindowHandle,
+    AlertButton, AlertIcon, AlertOptions, AlertResponse, AlertToken, Application, Clipboard,
+    ClipboardFormat, Cursor, Error as PlatformError, FileDialogOptions, FileInfo, FileSpec,
+    FormatId, HotKey, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseButtons, RawMods, Scale,
+    SysMods, Text, TimerToken, WindowHandle,
 };
 
 pub use crate::core::WidgetPod;

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -29,8 +29,8 @@ use crate::ext_event::ExtEventHost;
 use crate::menu::ContextMenu;
 use crate::window::Window;
 use crate::{
-    Command, Data, Env, Event, InternalEvent, KeyEvent, MenuDesc, Target, TimerToken, WindowDesc,
-    WindowId,
+    AlertResponse, Command, Data, Env, Event, InternalEvent, KeyEvent, MenuDesc, Target,
+    TimerToken, WindowDesc, WindowId,
 };
 
 use crate::command::sys as sys_cmd;
@@ -716,6 +716,11 @@ impl<T: Data> WinHandler for DruidHandler<T> {
 
     fn got_focus(&mut self) {
         self.app_state.window_got_focus(self.window_id);
+    }
+
+    fn alert_response(&mut self, response: AlertResponse) {
+        self.app_state
+            .do_window_event(Event::AlertResponse(response), self.window_id);
     }
 
     fn timer(&mut self, token: TimerToken) {


### PR DESCRIPTION
## API

This PR adds a cross-platform alert API that will enable a good user experience on Windows/macOS/Linux.

The API is designed in a way that a single `AlertOptions` configuration will result in a native feeling alert on all these platforms. The buttons are ordered automatically, so none of this *windows-app-on-mac* or vice versa feeling when you encounter an alert with a weird layout.

The API also favors a good user experience with contextualized (and translated) button labels. This is something that all the platform guideline documents agree on. Yes you can find plenty of legacy apps with basic labels like *Confirm* or *Yes* but neither of those are actually recommended.

## macOS implementation

This PR also contains the macOS implementation of this API to get things started and show that the API works.

I am aware of at least two macOS `druid-shell` issues that show up in relation to the alerts work. These issues aren't directly related to the alerts API though so I am tackling them separately. The first one is timers not firing when modal dialogs are up, which is resolved in #1028. When that fix is applied another issue surfaces - `Application::quit` doesn't properly end the runloop when an app modal dialog is up - it just ends the modal runloop. This is an issue I'm still investigating but will also solve separately as it's more of a bug in the `quit` method.

## Alert example

I also added a new `alert` example. It shows a few different ways to use alerts, although some of it can feel needlessly complex for an example. I built it more as a testing tool to see how edge cases are handled when multiple alerts show up in various ways. This made me think that perhaps we should have an `examples` directory but also some sort of `testing` directory of example-like apps that help us confirm whether various implementations are working properly. For now, I think the `alert` example can live as an example, but this distinction is something to think about for the future.

## Future work

I actually started this alerts work with the Windows implementation, which I've had 80% done for months now. This helped me really understand the cross-platform requirements. Moving forward I'll finish up the Windows implementation and post that as a separate PR.

---

Fixes #383.