### PR TITLE
Implement std::fmt::Debug for ImageData

### DIFF
--- a/druid/src/widget/image.rs
+++ b/druid/src/widget/image.rs
@@ -15,6 +15,7 @@
 //! An Image widget.
 //! Please consider using SVG and the SVG wideget as it scales much better.
 
+use std::fmt;
 #[cfg(feature = "image")]
 use std::{convert::AsRef, error::Error, path::Path};
 
@@ -286,6 +287,17 @@ impl ImageData {
 impl Default for ImageData {
     fn default() -> Self {
         ImageData::empty()
+    }
+}
+
+impl fmt::Debug for ImageData {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("ImageData")
+            .field("size", &self.pixels.len())
+            .field("width", &self.x_pixels)
+            .field("height", &self.y_pixels)
+            .field("format", &format_args!("{:?}", self.format))
+            .finish()
     }
 }
 


### PR DESCRIPTION
Stumbled over this today, bit annoying to not have it.

Not 100 percent sure about the format. 

I chose default struct formatting for convenience, which might be a tiny bit misleading because the fields are private and I used more descriptive names. 