### PR TITLE
Add OPEN_PANEL_CANCELLED and SAVE_PANEL_CANCELLED commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ You can find its changes [documented below](#060---2020-06-01).
 ### Highlights
 
 ### Added
+- `OPEN_PANEL_CANCELLED` and `SAVE_PANEL_CANCELLED` commands. ([#1061] by @cmyr)
 
 - Added ctrl/shift key support to textbox. ([#1063] by [@vkahl])
 
@@ -351,6 +352,7 @@ Last release without a changelog :(
 [#1050]: https://github.com/linebender/druid/pull/1050
 [#1054]: https://github.com/linebender/druid/pull/1054
 [#1058]: https://github.com/linebender/druid/pull/1058
+[#1061]: https://github.com/linebender/druid/pull/1061
 [#1062]: https://github.com/linebender/druid/pull/1062
 [#1081]: https://github.com/linebender/druid/pull/1081
 
@@ -360,4 +362,3 @@ Last release without a changelog :(
 [0.4.0]: https://github.com/linebender/druid/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/linebender/druid/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/linebender/druid/compare/v0.3.0...v0.3.1
-

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -193,6 +193,9 @@ pub mod sys {
     pub const SHOW_OPEN_PANEL: Selector<FileDialogOptions> =
         Selector::new("druid-builtin.menu-file-open");
 
+    /// Sent when the user cancels an open file panel.
+    pub const OPEN_PANEL_CANCELLED: Selector = Selector::new("druid-builtin.open-panel-cancelled");
+
     /// Open a file, must be handled by the application.
     ///
     /// [`FileInfo`]: ../struct.FileInfo.html
@@ -205,6 +208,9 @@ pub mod sys {
     /// [`SAVE_FILE`]: constant.SAVE_FILE.html
     pub const SHOW_SAVE_PANEL: Selector<FileDialogOptions> =
         Selector::new("druid-builtin.menu-file-save-as");
+
+    /// Sent when the user cancels a save file panel.
+    pub const SAVE_PANEL_CANCELLED: Selector = Selector::new("druid-builtin.save-panel-cancelled");
 
     /// Save the current file, must be handled by the application.
     ///

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -581,6 +581,9 @@ impl<T: Data> AppState<T> {
         if let Some(info) = result {
             let cmd = Command::new(sys_cmd::OPEN_FILE, info);
             self.inner.borrow_mut().dispatch_cmd(window_id.into(), cmd);
+        } else {
+            let cmd = sys_cmd::OPEN_PANEL_CANCELLED.into();
+            self.inner.borrow_mut().dispatch_cmd(window_id.into(), cmd);
         }
     }
 
@@ -595,6 +598,9 @@ impl<T: Data> AppState<T> {
         let result = handle.and_then(|mut handle| handle.save_as_sync(options));
         if let Some(info) = result {
             let cmd = Command::new(sys_cmd::SAVE_FILE, Some(info));
+            self.inner.borrow_mut().dispatch_cmd(window_id.into(), cmd);
+        } else {
+            let cmd = sys_cmd::SAVE_PANEL_CANCELLED.into();
             self.inner.borrow_mut().dispatch_cmd(window_id.into(), cmd);
         }
     }


### PR DESCRIPTION
This lets the user take special action if needed in either of
these cases.


I needed this in order to implement a "you have unsaved changes" prompt in Runebender, while testing out #1039. I think that we may want to further modify the general alerts API, and I think that we should try and make the open and save panels use a similar API to whatever we come up with for alerts, more generally, in which case this might be a stop-gap solution.