### PR TITLE
Restrict on_click() to left clicks only.

### DIFF
--- a/druid/src/widget/click.rs
+++ b/druid/src/widget/click.rs
@@ -17,7 +17,7 @@
 //! [`Controller`]: struct.Controller.html
 
 use crate::widget::Controller;
-use crate::{Data, Env, Event, EventCtx, LifeCycle, LifeCycleCtx, Widget};
+use crate::{Data, Env, Event, EventCtx, LifeCycle, LifeCycleCtx, MouseButton, Widget};
 
 /// A clickable [`Controller`] widget. Pass this and a child widget to a
 /// [`ControllerHost`] to make the child interactive. More conveniently, this is
@@ -52,12 +52,14 @@ impl<T: Data> Click<T> {
 impl<T: Data, W: Widget<T>> Controller<T, W> for Click<T> {
     fn event(&mut self, child: &mut W, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         match event {
-            Event::MouseDown(_) => {
-                ctx.set_active(true);
-                ctx.request_paint();
+            Event::MouseDown(mouse_event) => {
+                if mouse_event.button == MouseButton::Left {
+                    ctx.set_active(true);
+                    ctx.request_paint();
+                }
             }
-            Event::MouseUp(_) => {
-                if ctx.is_active() {
+            Event::MouseUp(mouse_event) => {
+                if mouse_event.button == MouseButton::Left {
                     ctx.set_active(false);
                     if ctx.is_hot() {
                         (self.action)(ctx, data, env);

--- a/druid/src/widget/click.rs
+++ b/druid/src/widget/click.rs
@@ -59,7 +59,7 @@ impl<T: Data, W: Widget<T>> Controller<T, W> for Click<T> {
                 }
             }
             Event::MouseUp(mouse_event) => {
-                if mouse_event.button == MouseButton::Left {
+                if ctx.is_active() && mouse_event.button == MouseButton::Left {
                     ctx.set_active(false);
                     if ctx.is_hot() {
                         (self.action)(ctx, data, env);

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -160,7 +160,8 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     }
 
     /// Control the events of this widget with a [`Click`] widget. The closure
-    /// provided will be called when the widget is clicked.
+    /// provided will be called when the widget is clicked with the left mouse
+    /// button.
     ///
     /// The child widget will also be updated on [`LifeCycle::HotChanged`] and
     /// mouse down, which can be useful for painting based on `ctx.is_active()`


### PR DESCRIPTION
Previously any click would trigger the on_click() handler.