### PR TITLE
Replace all references of druid with Druid.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-# This is the list of druid authors for copyright purposes.
+# This is the list of Druid authors for copyright purposes.
 #
 # This does not necessarily list everyone who has contributed code, since in
 # some cases, their employer may be the copyright holder.  To see the full list
@@ -9,3 +9,4 @@ Hilmar Gústafsson
 Dmitry Borodin
 Kaiyin Zhong
 Kaur Kuut
+Leopold Luley

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ all fundamental features are there.
 
 #### Using Core Graphics on macOS.
 
-[@cmyr] continued the work of [@jrmuizel] and implemented Core Graphics support for piet in
+[@cmyr] continued the work of [@jrmuizel] and implemented Core Graphics support for Piet in
 [piet#176](https://github.com/linebender/piet/pull/176).
 
 Those changes made it into druid via [#905].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest published druid release is [0.6.0](#060---2020-06-01) which was released on 2020-06-01.
+The latest published Druid release is [0.6.0](#060---2020-06-01) which was released on 2020-06-01.
 You can find its changes [documented below](#060---2020-06-01).
 
 ## [Unreleased]
@@ -301,7 +301,7 @@ Last release without a changelog :(
 [#920]: https://github.com/linebender/druid/pull/920
 [#924]: https://github.com/linebender/druid/pull/924
 [#925]: https://github.com/linebender/druid/pull/925
-[#926]: https://github.com/linebender/druid/pull/926 
+[#926]: https://github.com/linebender/druid/pull/926
 [#928]: https://github.com/linebender/druid/pull/928
 [#930]: https://github.com/linebender/druid/pull/930
 [#931]: https://github.com/linebender/druid/pull/931

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ add it as part of your patch.
 
 If you're already contributing to this project and want to do more,
 then there might be a chance to help out with the preparation of new releases.
-Whether you're new or have prepared druid releases many times already,
+Whether you're new or have prepared Druid releases many times already,
 it helps to follow a checklist of what needs to be done. This is that list.
 
 ### Increasing the versions
@@ -49,7 +49,7 @@ to specific version documentation that will need updating.
 
 **We only test and specify the newest versions of dependencies.** Read on for more details.
 
-Rust dependencies like druid specify their own sub-dependencies in `Cargo.toml`.
+Rust dependencies like Druid specify their own sub-dependencies in `Cargo.toml`.
 These specifications are usually version ranges according to [semver],
 stating that the dependency requires a sub-dependency of the specified version
 or any newer version that is still compatible. It is up to the final application
@@ -57,12 +57,12 @@ to choose which actual versions get used via the `Cargo.lock` file of that appli
 
 Because the final application chooses the sub-dependency versions and they are most likely
 going to be higher than the minimum that is specified in our `Cargo.toml` file,
-we need to make sure that druid works properly with these newer versions.
+we need to make sure that Druid works properly with these newer versions.
 Yes according to [semver] rules they should work, but library authors make mistakes
-and it won't be a good experience or a sign of druid quality if a new developer
-adds druid as a dependency and it won't even compile.
+and it won't be a good experience or a sign of Druid's quality if a new developer
+adds Druid as a dependency and it won't even compile.
 For that reason our CI testing always uses the highest version that is still compatible.
-This mimics what a new developer would experience when they start using druid.
+This mimics what a new developer would experience when they start using Druid.
 
 What about the the minimum supported version or all the versions between the minimum and maximum?
 It is not practical for us to test all the combinations of possible sub-dependency versions.
@@ -79,7 +79,7 @@ Just because `1.1.1` used to work back in the day doesn't mean that it will alwa
 One partial solution to this problem is to be more precise in what we are actually promising.
 So whenever we release a new version we also update all our dependencies in `Cargo.toml`
 to match the versions that we are actually testing with. This will be much more accurate
-to the spirit of the version specification - druid will work with the specified version
+to the spirit of the version specification - Druid will work with the specified version
 and any newer one if it's [semver] compatible. We're not testing the extremely big matrix of
 old versions of our sub-dependencies and so we shouldn't claim that the old versions will work.
 

--- a/README.md
+++ b/README.md
@@ -100,22 +100,22 @@ doesn't suit your use case, perhaps one of the others will!
 
 ### druid-shell
 
-The Druid toolkit uses druid-shell for a platform-abstracting application shell.
-druid-shell is responsible for starting a native platform runloop, listening to
+The Druid toolkit uses `druid-shell` for a platform-abstracting application shell.
+`druid-shell` is responsible for starting a native platform runloop, listening to
 events, converting them into a platform-agnostic representation, and calling a
 user-provided handler with them.
 
-While druid-shell is being developed with the Druid toolkit in mind, it is
+While `druid-shell` is being developed with the Druid toolkit in mind, it is
 intended to be general enough that it could be reused by other projects
-interested in experimenting with Rust GUI. The druid-shell crate includes a
+interested in experimenting with Rust GUI. The `druid-shell` crate includes a
 couple of [non-druid examples].
 
 ### piet
 
-Druid relies on the [piet library] for drawing and text layout. Piet is a 2D graphics
+Druid relies on the [Piet library] for drawing and text layout. Piet is a 2D graphics
 abstraction with multiple backends: `piet-direct2d`, `piet-coregraphics`, `piet-cairo`,
 `piet-web`, and `piet-svg` are currently available, and a GPU backend is planned.
-In terms of Druid platform support via piet, macOS uses `piet-coregraphics`,
+In terms of Druid platform support via Piet, macOS uses `piet-coregraphics`,
 Linux uses `piet-cairo`, Windows uses `piet-direct2d`, and web uses `piet-web`.
 
 ```rust
@@ -254,7 +254,7 @@ This is particularly useful when working with types defined in another crate.
 
 An explicit goal of Druid is to be easy to build, so please open an issue if you
 run into any difficulties. Druid is available on [crates.io] and should work as
-a lone dependency (it re-exports all the parts of druid-shell, piet, and kurbo
+a lone dependency (it re-exports all the parts of `druid-shell`, piet, and kurbo
 that you'll need):
 
 ```toml
@@ -294,7 +294,7 @@ active and friendly community.
 
 [Runebender]: https://github.com/linebender/runebender
 [the examples folder]: ./druid/examples
-[piet library]: https://github.com/linebender/piet
+[Piet library]: https://github.com/linebender/piet
 [custom_widget]: ./druid/examples/custom_widget.rs
 [basic utility and layout widgets]: ./druid/src/widget
 [Flutter's box layout model]: https://api.flutter.dev/flutter/rendering/BoxConstraints-class.html

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# druid
+# Druid
 
 ## A data-first Rust-native UI toolkit.
 
@@ -15,11 +15,11 @@ See the [goals section](#Goals) for more details.
 Druid's current development is largely driven by its use in [Runebender], a new
 font editor.
 
-We have been doing periodic releases of druid on crates.io, but it is under
+We have been doing periodic releases of Druid on crates.io, but it is under
 active development and its API might change. All changes are documented
 in [the changelog](https://github.com/linebender/druid/blob/master/CHANGELOG.md).
 
-For an overview of some key concepts, see the (work in progress) [druid book].
+For an overview of some key concepts, see the (work in progress) [Druid book].
 
 ## Example
 
@@ -55,7 +55,7 @@ fn ui_builder() -> impl Widget<u32> {
 ```
 
 Check out the [the examples folder] for a more comprehensive demonstration of
-druid's existing functionality and widgets.
+Druid's existing functionality and widgets.
 
 ## Screenshots
 
@@ -85,7 +85,7 @@ platforms. In order to achieve this we strive for a variety of things:
 
 In order to fulfill those goals, we cannot support every use case. Luckily
 the Rust community is working on a variety of different libraries with
-different goals, so here are some of druid's non-goals and possible
+different goals, so here are some of Druid's non-goals and possible
 alternatives that can offer those capabilities:
 
 - Use the the platform-native widgets or mimic them. ([Relm])
@@ -100,12 +100,12 @@ doesn't suit your use case, perhaps one of the others will!
 
 ### druid-shell
 
-The druid toolkit uses druid-shell for a platform-abstracting application shell.
-Druid-shell is responsible for starting a native platform runloop, listening to
+The Druid toolkit uses druid-shell for a platform-abstracting application shell.
+druid-shell is responsible for starting a native platform runloop, listening to
 events, converting them into a platform-agnostic representation, and calling a
 user-provided handler with them.
 
-While druid-shell is being developed with the druid toolkit in mind, it is
+While druid-shell is being developed with the Druid toolkit in mind, it is
 intended to be general enough that it could be reused by other projects
 interested in experimenting with Rust GUI. The druid-shell crate includes a
 couple of [non-druid examples].
@@ -115,7 +115,7 @@ couple of [non-druid examples].
 Druid relies on the [piet library] for drawing and text layout. Piet is a 2D graphics
 abstraction with multiple backends: `piet-direct2d`, `piet-coregraphics`, `piet-cairo`,
 `piet-web`, and `piet-svg` are currently available, and a GPU backend is planned.
-In terms of druid platform support via piet, macOS uses `piet-coregraphics`,
+In terms of Druid platform support via piet, macOS uses `piet-coregraphics`,
 Linux uses `piet-cairo`, Windows uses `piet-direct2d`, and web uses `piet-web`.
 
 ```rust
@@ -144,7 +144,7 @@ ctx.fill(rect, &fill_color);
 
 ### widgets
 
-Widgets in druid (text boxes, buttons, layout components, etc.) are objects
+Widgets in Druid (text boxes, buttons, layout components, etc.) are objects
 which implement the [Widget trait]. The trait is parametrized by a type (`T`)
 for associated data. All trait methods (`event`, `lifecycle`, `update`, `paint`,
 and `layout`) are provided with access to this data, and in the case of
@@ -201,7 +201,7 @@ fn build_widget() -> impl Widget<u32> {
 ### layout
 
 Druid's layout protocol is strongly inspired by [Flutter's box layout model].
-In druid, widgets are passed a `BoxConstraint` that provides them a minimum and
+In Druid, widgets are passed a `BoxConstraint` that provides them a minimum and
 maximum size for layout. Widgets are also responsible for computing appropriate
 constraints for their children if applicable.
 
@@ -250,9 +250,9 @@ LensWrap::new(WidgetThatExpectsf64::new(), lens!(AppState, value));
 
 This is particularly useful when working with types defined in another crate.
 
-## Using druid
+## Using Druid
 
-An explicit goal of druid is to be easy to build, so please open an issue if you
+An explicit goal of Druid is to be easy to build, so please open an issue if you
 run into any difficulties. Druid is available on [crates.io] and should work as
 a lone dependency (it re-exports all the parts of druid-shell, piet, and kurbo
 that you'll need):
@@ -261,7 +261,7 @@ that you'll need):
 druid = "0.6.0"
 ```
 
-Since druid is currently in fast-evolving state, you might prefer to drink from
+Since Druid is currently in fast-evolving state, you might prefer to drink from
 the firehose:
 
 ```toml
@@ -272,7 +272,7 @@ druid = { git = "https://github.com/linebender/druid.git" }
 
 #### Linux
 
-On Linux, druid requires gtk+3; see [gtk-rs dependencies] for installation
+On Linux, Druid requires gtk+3; see [gtk-rs dependencies] for installation
 instructions.
 
 Alternatively, there is an X11 backend available, although it is currently
@@ -313,7 +313,7 @@ active and friendly community.
 [Widget trait]: https://docs.rs/druid/0.6.0/druid/trait.Widget.html
 [Data trait]: https://docs.rs/druid/0.6.0/druid/trait.Data.html
 [Lens datatype]: https://docs.rs/druid/0.6.0/druid/trait.Lens.html
-[druid book]: https://linebender.org/druid/
+[Druid book]: https://linebender.org/druid/
 [Iced]: https://github.com/hecrj/iced
 [Conrod]: https://github.com/PistonDevelopers/conrod
 [Relm]: https://github.com/antoyo/relm

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ user-provided handler with them.
 While `druid-shell` is being developed with the Druid toolkit in mind, it is
 intended to be general enough that it could be reused by other projects
 interested in experimenting with Rust GUI. The `druid-shell` crate includes a
-couple of [non-druid examples].
+couple of [non-`druid` examples].
 
 ### piet
 
@@ -303,7 +303,7 @@ active and friendly community.
 [Rust-native GUI experiments]: https://areweguiyet.com
 [CONTRIBUTING.md]: ./CONTRIBUTING.md
 [Zulip chat instance]: https://xi.zulipchat.com
-[non-druid examples]: ./druid-shell/examples/shello.rs
+[non-`druid` examples]: ./druid-shell/examples/shello.rs
 [crates.io]: https://crates.io/crates/druid
 [EventCtx]: https://docs.rs/druid/0.6.0/druid/struct.EventCtx.html
 [LifeCycleCtx]: https://docs.rs/druid/0.6.0/druid/struct.EventCtx.html

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Druid mdbook documentation
+# Druid mdBook documentation
 This folder contains Druid documentation in mdBook format. mdBook allows documentation written in
 markdown to be published as html. This README.md gives some pointers for contributers on how to
 edit, preview and publish the documentation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,23 +1,23 @@
 # Druid mdbook documentation
-This folder contains druid documentation in mdbook format. Mdbook allows documentation written in 
-markdown to be published as html. This README.md gives some pointers for contributers on how to 
+This folder contains Druid documentation in mdBook format. mdBook allows documentation written in
+markdown to be published as html. This README.md gives some pointers for contributers on how to
 edit, preview and publish the documentation.
 
 ## Editing
-Mdbook handles writing documentation in a similar way to writing software. Documentation 'source 
-code' lives in the `docs/src` folder in the form of markdown files. It can be built and published 
-as html using the mdbook tool.
+mdBook handles writing documentation in a similar way to writing software. Documentation 'source
+code' lives in the `docs/src` folder in the form of markdown files. It can be built and published
+as html using the mdBook tool.
 To edit documentation you edit the corresponding markdown file in `docs/src`. The
 `docs/src/SUMMARY.md` file contains the index for the documentation with links to files for all the
 chapters.
 
 ## Preview documentation
-To preview the documentation or to host it on your own system for offline viewing the mdbook tool
+To preview the documentation or to host it on your own system for offline viewing the mdBook tool
 needs to be installed. The easiest way to install it is from the crates.io repository using cargo.
 `cargo install mdbook`
 
-After this you can start mdbook to serve the documentation locally using
-`mdbook serve` from the `docs\` directory. This will serve documetion on `http://localhost:3000`
+After this you can start mdBook to serve the documentation locally using
+`mdbook serve` from the `docs\` directory. This will serve documentation on `http://localhost:3000`
 
 ## Publish documentation
 To publish documentation to github pages the documentation needs to be built as html and then moved
@@ -25,5 +25,5 @@ to the `gh-pages` branch. This can be done manually or by the build server.
 To build the documentation from the project root run;
 `mdbook build docs`
 This will build the documentation to the `docs\book` folder. This folder can then be copied onto the
-`gh-pages` branch. This will tell github to publish the documentation. For the druid repository it
+`gh-pages` branch. This will tell github to publish the documentation. For the Druid repository it
 will be hosted on [https://linebender.org/druid/]

--- a/docs/book_examples/src/data_md.rs
+++ b/docs/book_examples/src/data_md.rs
@@ -17,8 +17,8 @@ struct TodoItem {
     category: Category,
     // `Data` is implemented for any `Arc`.
     due_date: Option<Arc<DateTime>>,
-    // you can specify a custom comparison fn
-    // (anything with the signature (&T, &T) -> bool)
+    // You can specify a custom comparison fn
+    // (anything with the signature (&T, &T) -> bool).
     #[data(same_fn = "PartialEq::eq")]
     added_date: DateTime,
     title: String,

--- a/docs/book_examples/src/lens_md.rs
+++ b/docs/book_examples/src/lens_md.rs
@@ -76,7 +76,7 @@ struct Item {
     count: usize,
 }
 
-// this now works
+// This works now:
 impl Item {
     fn count(&self) -> usize {
         self.count
@@ -88,7 +88,7 @@ impl Item {
 use druid::widget::{Checkbox, Flex, Label, Widget, WidgetExt};
 
 fn make_todo_item() -> impl Widget<TodoItem> {
-    // A label that generates its text based on the data
+    // A label that generates its text based on the data:
     let title = Label::dynamic(|text: &String, _| text.to_string()).lens(TodoItem::title);
     let completed = Checkbox::new("Completed:").lens(TodoItem::completed);
     let urgent = Checkbox::new("Urgent:").lens(TodoItem::urgent);
@@ -137,7 +137,7 @@ impl Lens<Contacts, Option<Contact>> for ContactIdLens {
             _ => true,
         };
         if changed {
-            //if !data.inner.get(&self.0).same(&contact.as_ref()) {
+            // if !data.inner.get(&self.0).same(&contact.as_ref()) {
             let contacts = Arc::make_mut(&mut data.inner);
             // if we're none, we were deleted, and remove from the map; else replace
             match contact {

--- a/docs/src/custom_widgets.md
+++ b/docs/src/custom_widgets.md
@@ -1,11 +1,11 @@
 # Create custom widgets
 
-The `Widget` trait is the heart of druid, and in any serious application you
+The `Widget` trait is the heart of Druid, and in any serious application you
 will eventually need to create and use custom `Widget`s.
 
 ## `Painter` and `Controller`
 
-There are two helper widgets in druid that let you customize widget behaviour
+There are two helper widgets in Druid that let you customize widget behaviour
 without needing to implement the full widget trait: [`Painter`] and
 [`Controller`].
 

--- a/docs/src/data.md
+++ b/docs/src/data.md
@@ -1,7 +1,7 @@
 # Model data and the `Data` trait
 
-The heart of a `druid` application is your application model. Your model drives
-your UI. When you mutate your model, druid compares the old and new version,
+The heart of a Druid application is your application model. Your model drives
+your UI. When you mutate your model, Druid compares the old and new version,
 and propagates the change to the components ('widgets') of your application that
 are affected by the change.
 
@@ -38,7 +38,7 @@ Here is an example of using `Data` to implement a simple data model.
 issues with collection types. For this reason, `Data` is not implemented for
 `std` types like `Vec` or `HashMap`. This is not a huge issue, however; you can
 always put these types inside an `Rc` or an `Arc`, or if you're dealing with
-larger collections you can build druid with the `im` feature, which brings in
+larger collections you can build Druid with the `im` feature, which brings in
 the [`im crate`], and adds a `Data` impl for the collections there. The [`im`
 crate] is a collection of immutable data structures that act a lot like the `std`
 collections, but can be cloned efficiently.

--- a/docs/src/env.md
+++ b/docs/src/env.md
@@ -81,7 +81,7 @@ The `Env` contains the localization resources for the current locale. A
 calling its [`resolve`] method.
 
 In general, you should not need to worry about localization directly. See the
-[localization] chapter for an overview of localization in druid.
+[localization] chapter for an overview of localization in Druid.
 
 
 [`Env`]: https://docs.rs/druid/0.6.0/druid/struct.Env.html

--- a/docs/src/get_started.md
+++ b/docs/src/get_started.md
@@ -2,7 +2,7 @@
 *this is outdated, and should be replaced with a walkthrough of getting a simple
 app built and running*.
 
-This chapter will walk you through setting up a simple druid application from start to finish.
+This chapter will walk you through setting up a simple Druid application from start to finish.
 
 ## Set up a Druid project
 Setting up a project is a simple as creating a new Rust project;
@@ -10,7 +10,7 @@ Setting up a project is a simple as creating a new Rust project;
 > cargo new druid-example
 ```
 
-And then adding druid as a dependency to Cargo.toml
+And then adding Druid as a dependency to Cargo.toml
 ```toml
 [dependencies]
 druid = "0.6.0"

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -2,7 +2,7 @@
 
 Druid is a framework for building simple graphical applications.
 
-'Druid' is composed of a number of related projects. [`druid-shell`] is a
+Druid is composed of a number of related projects. [`druid-shell`] is a
 low-level library that provides a common abstraction for interacting with the
 current OS & window manager. [`piet`] is an abstraction for doing 2D graphics;
 [`kurbo`] is a library for 2D geometry; and [`druid`] itself is an opinionated set of
@@ -12,11 +12,11 @@ Druid is *data oriented*. It shares many ideas (and is directly inspired by)
 contemporary declarative UI frameworks such as [Flutter], [Jetpack Compose],
 and [SwiftUI], while also attempting to be conceptually simple and largely
 *non-magical*. A programmer familiar with Rust should be able to understand how
-druid works without special difficulty.
+Druid works without special difficulty.
 
 ## Goals and Status
 
-The current goal of druid is to make it easy to write a program in Rust that
+The current goal of Druid is to make it easy to write a program in Rust that
 can present a GUI and accept user input. Running your program should be as
 simple as `cargo run`.
 

--- a/docs/src/lens.md
+++ b/docs/src/lens.md
@@ -9,7 +9,7 @@ that will represent a single todo item. Our data model looks like this:
 
 We would like our widget to display the title of the item, and then below
 that to display two checkmarks that toggle the 'completed' and 'urgent' bools.
-`Checkbox` (a widget included in druid) implements `Widget<bool>`.
+`Checkbox` (a widget included in Druid) implements `Widget<bool>`.
 How do we use it with `TodoItem`? By using a `Lens`.
 
 ## Conceptual
@@ -33,7 +33,7 @@ our `TodoItem`. With our simple trait, we might do:
 {{#include ../book_examples/src/lens_md.rs:completed_lens}}
 ```
 
-> **Note**: `Lens` isn't that helpful on its own; in druid it is generally used alongside
+> **Note**: `Lens` isn't that helpful on its own; in Druid it is generally used alongside
 `LensWrap`, which is a special widget that uses a `Lens` to change the `Data`
 type of its child. Lets say we have a `Checkbox`, but our data is a `TodoItem`:
 we can do, `LensWrap::new(my_checkbox, CompletedLens)` in order to bridge the

--- a/docs/src/setup.md
+++ b/docs/src/setup.md
@@ -7,10 +7,10 @@ This tutorial will first walk you through setting up the dependencies for develo
 application, then it will show you how to set up a basic application, build it and run it.
 
 ## Setting up Druid dependencies
-In addition to including the druid library in your project
+In addition to including the `druid` library in your project
 
 ### Linux
-On Linux, druid requires gtk+3.
+On Linux, Druid requires gtk+3.
 
 On Ubuntu this can be installed with
 ```no_compile

--- a/docs/src/widget.md
+++ b/docs/src/widget.md
@@ -12,7 +12,7 @@ widgets (such as a slider) may expect a single type (such as `f64`).
 > **Note**: For more information on how different parts of your [`Data`] are exposed
 to different widgets, see [`Lens`].
 
-At a high level, druid works like this:
+At a high level, Druid works like this:
 
 - **event**: an `Event` arrives from the operating system, such as a key press,
 a mouse movement, or a timer firing. This event is delivered to your root

--- a/druid-derive/src/attr.rs
+++ b/druid-derive/src/attr.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-derive/src/data.rs
+++ b/druid-derive/src/data.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-derive/src/lens.rs
+++ b/druid-derive/src/lens.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-derive/src/lib.rs
+++ b/druid-derive/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/examples/invalidate.rs
+++ b/druid-shell/examples/invalidate.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/examples/perftest.rs
+++ b/druid-shell/examples/perftest.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The druid Authors.
+// Copyright 2018 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/examples/shello.rs
+++ b/druid-shell/examples/shello.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The druid Authors.
+// Copyright 2018 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/application.rs
+++ b/druid-shell/src/application.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/clipboard.rs
+++ b/druid-shell/src/clipboard.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/common_util.rs
+++ b/druid-shell/src/common_util.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/dialog.rs
+++ b/druid-shell/src/dialog.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/error.rs
+++ b/druid-shell/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/hotkey.rs
+++ b/druid-shell/src/hotkey.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/keyboard.rs
+++ b/druid-shell/src/keyboard.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The druid Authors.
+// Copyright 2018 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/menu.rs
+++ b/druid-shell/src/menu.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/mouse.rs
+++ b/druid-shell/src/mouse.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/gtk/application.rs
+++ b/druid-shell/src/platform/gtk/application.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/gtk/clipboard.rs
+++ b/druid-shell/src/platform/gtk/clipboard.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/gtk/dialog.rs
+++ b/druid-shell/src/platform/gtk/dialog.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/gtk/error.rs
+++ b/druid-shell/src/platform/gtk/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/gtk/keycodes.rs
+++ b/druid-shell/src/platform/gtk/keycodes.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/gtk/menu.rs
+++ b/druid-shell/src/platform/gtk/menu.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/gtk/mod.rs
+++ b/druid-shell/src/platform/gtk/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/gtk/util.rs
+++ b/druid-shell/src/platform/gtk/util.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/mac/appkit.rs
+++ b/druid-shell/src/platform/mac/appkit.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/mac/application.rs
+++ b/druid-shell/src/platform/mac/application.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/mac/clipboard.rs
+++ b/druid-shell/src/platform/mac/clipboard.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/mac/dialog.rs
+++ b/druid-shell/src/platform/mac/dialog.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/mac/error.rs
+++ b/druid-shell/src/platform/mac/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/mac/keyboard.rs
+++ b/druid-shell/src/platform/mac/keyboard.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/mac/menu.rs
+++ b/druid-shell/src/platform/mac/menu.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/mac/mod.rs
+++ b/druid-shell/src/platform/mac/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/mac/util.rs
+++ b/druid-shell/src/platform/mac/util.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/mod.rs
+++ b/druid-shell/src/platform/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/shared/keyboard.rs
+++ b/druid-shell/src/platform/shared/keyboard.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/shared/mod.rs
+++ b/druid-shell/src/platform/shared/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/web/application.rs
+++ b/druid-shell/src/platform/web/application.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/web/clipboard.rs
+++ b/druid-shell/src/platform/web/clipboard.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/web/error.rs
+++ b/druid-shell/src/platform/web/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/web/keycodes.rs
+++ b/druid-shell/src/platform/web/keycodes.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/web/menu.rs
+++ b/druid-shell/src/platform/web/menu.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/web/mod.rs
+++ b/druid-shell/src/platform/web/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/windows/accels.rs
+++ b/druid-shell/src/platform/windows/accels.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/windows/application.rs
+++ b/druid-shell/src/platform/windows/application.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/windows/clipboard.rs
+++ b/druid-shell/src/platform/windows/clipboard.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/windows/dcomp.rs
+++ b/druid-shell/src/platform/windows/dcomp.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The druid Authors.
+// Copyright 2018 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/windows/dialog.rs
+++ b/druid-shell/src/platform/windows/dialog.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The druid Authors.
+// Copyright 2018 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/windows/error.rs
+++ b/druid-shell/src/platform/windows/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/windows/keyboard.rs
+++ b/druid-shell/src/platform/windows/keyboard.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/windows/keycodes.rs
+++ b/druid-shell/src/platform/windows/keycodes.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/windows/menu.rs
+++ b/druid-shell/src/platform/windows/menu.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The druid Authors.
+// Copyright 2018 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/windows/mod.rs
+++ b/druid-shell/src/platform/windows/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The druid Authors.
+// Copyright 2018 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/windows/paint.rs
+++ b/druid-shell/src/platform/windows/paint.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 The druid Authors.
+// Copyright 2017 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/windows/timers.rs
+++ b/druid-shell/src/platform/windows/timers.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/windows/util.rs
+++ b/druid-shell/src/platform/windows/util.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 The druid Authors.
+// Copyright 2017 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The druid Authors.
+// Copyright 2018 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/x11/clipboard.rs
+++ b/druid-shell/src/platform/x11/clipboard.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/x11/error.rs
+++ b/druid-shell/src/platform/x11/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/x11/keycodes.rs
+++ b/druid-shell/src/platform/x11/keycodes.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/x11/menu.rs
+++ b/druid-shell/src/platform/x11/menu.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/x11/mod.rs
+++ b/druid-shell/src/platform/x11/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/x11/util.rs
+++ b/druid-shell/src/platform/x11/util.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/scale.rs
+++ b/druid-shell/src/scale.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/util.rs
+++ b/druid-shell/src/util.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The druid Authors.
+// Copyright 2018 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/anim.rs
+++ b/druid/examples/anim.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/blocking_function.rs
+++ b/druid/examples/blocking_function.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The druid Authors.
+// Copyright 2018 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/custom_widget.rs
+++ b/druid/examples/custom_widget.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/either.rs
+++ b/druid/examples/either.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/ext_event.rs
+++ b/druid/examples/ext_event.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/flex.rs
+++ b/druid/examples/flex.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/game_of_life.rs
+++ b/druid/examples/game_of_life.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/hello.rs
+++ b/druid/examples/hello.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/hello_web/src/lib.rs
+++ b/druid/examples/hello_web/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/image.rs
+++ b/druid/examples/image.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/invalidation.rs
+++ b/druid/examples/invalidation.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/layout.rs
+++ b/druid/examples/layout.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/lens.rs
+++ b/druid/examples/lens.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/open_save.rs
+++ b/druid/examples/open_save.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/panels.rs
+++ b/druid/examples/panels.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/parse.rs
+++ b/druid/examples/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/scroll.rs
+++ b/druid/examples/scroll.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/scroll_colors.rs
+++ b/druid/examples/scroll_colors.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/split_demo.rs
+++ b/druid/examples/split_demo.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/styled_text.rs
+++ b/druid/examples/styled_text.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/svg.rs
+++ b/druid/examples/svg.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/switches.rs
+++ b/druid/examples/switches.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/timer.rs
+++ b/druid/examples/timer.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/view_switcher.rs
+++ b/druid/examples/view_switcher.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/web/build.rs
+++ b/druid/examples/web/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/examples/web/src/lib.rs
+++ b/druid/examples/web/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/app_delegate.rs
+++ b/druid/src/app_delegate.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/bloom.rs
+++ b/druid/src/bloom.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/box_constraints.rs
+++ b/druid/src/box_constraints.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The druid Authors.
+// Copyright 2018 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/data.rs
+++ b/druid/src/data.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/env.rs
+++ b/druid/src/env.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/ext_event.rs
+++ b/druid/src/ext_event.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/lens/lens.rs
+++ b/druid/src/lens/lens.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/lens/mod.rs
+++ b/druid/src/lens/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The druid Authors.
+// Copyright 2018 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/localization.rs
+++ b/druid/src/localization.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/menu.rs
+++ b/druid/src/menu.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/mouse.rs
+++ b/druid/src/mouse.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/tests/helpers.rs
+++ b/druid/src/tests/helpers.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/tests/layout_tests.rs
+++ b/druid/src/tests/layout_tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/text/backspace.rs
+++ b/druid/src/text/backspace.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/text/editable_text.rs
+++ b/druid/src/text/editable_text.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/text/mod.rs
+++ b/druid/src/text/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The druid Authors.
+// Copyright 2018 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/text/movement.rs
+++ b/druid/src/text/movement.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/text/selection.rs
+++ b/druid/src/text/selection.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The druid Authors.
+// Copyright 2018 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/text/text_input.rs
+++ b/druid/src/text/text_input.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/util.rs
+++ b/druid/src/util.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/align.rs
+++ b/druid/src/widget/align.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The druid Authors.
+// Copyright 2018 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The druid Authors.
+// Copyright 2018 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/click.rs
+++ b/druid/src/widget/click.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/common.rs
+++ b/druid/src/widget/common.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/controller.rs
+++ b/druid/src/widget/controller.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/either.rs
+++ b/druid/src/widget/either.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The druid Authors.
+// Copyright 2018 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/identity_wrapper.rs
+++ b/druid/src/widget/identity_wrapper.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/image.rs
+++ b/druid/src/widget/image.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/invalidation.rs
+++ b/druid/src/widget/invalidation.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The druid Authors.
+// Copyright 2018 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/padding.rs
+++ b/druid/src/widget/padding.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The druid Authors.
+// Copyright 2018 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/painter.rs
+++ b/druid/src/widget/painter.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/parse.rs
+++ b/druid/src/widget/parse.rs
@@ -1,3 +1,17 @@
+// Copyright 2020 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::fmt::Display;
 use std::mem;
 use std::str::FromStr;

--- a/druid/src/widget/progress_bar.rs
+++ b/druid/src/widget/progress_bar.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/sized_box.rs
+++ b/druid/src/widget/sized_box.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/spinner.rs
+++ b/druid/src/widget/spinner.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/stepper.rs
+++ b/druid/src/widget/stepper.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The druid Authors.
+// Copyright 2018 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/view_switcher.rs
+++ b/druid/src/widget/view_switcher.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The druid Authors.
+// Copyright 2020 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/widget.rs
+++ b/druid/src/widget/widget.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The druid Authors.
+// Copyright 2018 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The druid Authors.
+// Copyright 2019 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This should replace all references of 'druid' with 'Druid', following the discussion on Zulip.

I think this is the best choice (and [most voted for](https://xi.zulipchat.com/#narrow/stream/147926-druid/topic/name.20style/near/202073103)).

If I remember correctly @xStrom made the argument to use `druid` when referring to the crate, and while I like the idea it turned out to be impossible to define (at least for me) when exactly one is talking about 'the crate', so I preferred 'Druid' in most cases.

I also changed 'Mdbook' and 'mdbook' to the correct spelling 'mdBook' :p