### PR TITLE
Adds an idle loop to the x11 backend, and uses it for repainting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - GTK: Don't crash when receiving an external command while a file dialog is visible. ([#1043] by [@jneem])
 - Fix derive `Data` when type param bounds are defined ([#1058] by [@chris-zen])
 - Ensure that `update` is called after all commands. ([#1062] by [@jneem])
+- X11: Support idle callbacks. ([#1072] by [@jneem])
 - GTK: Don't interrupt `KeyEvent.repeat` when releasing another key. ([#1081] by [@raphlinus])
 
 ### Visual
@@ -352,6 +353,7 @@ Last release without a changelog :(
 [#1054]: https://github.com/linebender/druid/pull/1054
 [#1058]: https://github.com/linebender/druid/pull/1058
 [#1062]: https://github.com/linebender/druid/pull/1062
+[#1072]: https://github.com/linebender/druid/pull/1072
 [#1081]: https://github.com/linebender/druid/pull/1081
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -14,7 +14,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default-target = "x86_64-pc-windows-msvc"
 
 [features]
-x11 = ["x11rb", "cairo-sys-rs"]
+x11 = ["x11rb", "nix", "cairo-sys-rs"]
 
 [dependencies]
 # NOTE: When changing the piet or kurbo versions, ensure that
@@ -40,6 +40,7 @@ gtk = { version = "0.8.1", optional = true }
 glib = { version = "0.9.3", optional = true }
 glib-sys = { version = "0.9.1", optional = true }
 gtk-sys = { version = "0.9.2", optional = true }
+nix = { version = "0.17.0", optional = true }
 x11rb = { version = "0.6.0", features = ["allow-unsafe-code", "present", "randr", "xfixes"], optional = true }
 
 [target.'cfg(target_os="windows")'.dependencies]

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -527,7 +527,7 @@ fn poll_with_timeout(conn: &Rc<XCBConnection>, idle: RawFd, timeout: Instant) ->
     // start setting one.
     let mut poll_timeout = -1;
     loop {
-        fn readable(p: &PollFd) -> bool {
+        fn readable(p: PollFd) -> bool {
             p.revents()
                 .unwrap_or_else(PollFlags::empty)
                 .contains(PollFlags::POLLIN)
@@ -535,11 +535,11 @@ fn poll_with_timeout(conn: &Rc<XCBConnection>, idle: RawFd, timeout: Instant) ->
 
         match poll(poll_fds, poll_timeout) {
             Ok(_) => {
-                if readable(&poll_fds[0]) {
+                if readable(poll_fds[0]) {
                     // There is an X11 event ready to be handled.
                     break;
                 }
-                if poll_fds.len() == 1 || readable(&poll_fds[1]) {
+                if poll_fds.len() == 1 || readable(poll_fds[1]) {
                     // Now that we got signalled, stop polling from the idle pipe and use a timeout
                     // instead.
                     poll_fds = &mut just_connection;

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -522,7 +522,7 @@ fn poll_with_timeout(conn: &Rc<XCBConnection>, idle: RawFd, timeout: Instant) ->
     // start setting one.
     let mut poll_timeout = -1;
     loop {
-        let readable = |p: &PollFd| {
+        fn readable(p: &PollFd) -> bool {
             p.revents()
                 .unwrap_or_else(PollFlags::empty)
                 .contains(PollFlags::POLLIN)

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -45,7 +45,7 @@ pub(crate) struct Application {
     /// A display is a collection of screens.
     connection: Rc<XCBConnection>,
     /// An `XCBConnection` is *technically* safe to use from other threads, but there are
-    /// subtleties; see https://github.com/psychon/x11rb/blob/master/src/event_loop_integration.rs.
+    /// subtleties; see https://github.com/psychon/x11rb/blob/41ab6610f44f5041e112569684fc58cd6d690e57/src/event_loop_integration.rs.
     /// Let's just avoid the issue altogether. As far as public API is concerned, this causes
     /// `druid_shell::WindowHandle` to be `!Send` and `!Sync`.
     marker: std::marker::PhantomData<*mut XCBConnection>,

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -504,7 +504,7 @@ fn drain_idle_pipe(idle_read: RawFd) -> Result<(), Error> {
 /// Returns when there is an event ready to read from `conn`, or we got signalled by another thread
 /// writing into our idle pipe and the `timeout` has passed.
 // This was taken, with minor modifications, from the xclock_utc example in the x11rb crate.
-// https://raw.githubusercontent.com/psychon/x11rb/a6bd1453fd8e931394b9b1f2185fad48b7cca5fe/examples/xclock_utc.rs
+// https://github.com/psychon/x11rb/blob/a6bd1453fd8e931394b9b1f2185fad48b7cca5fe/examples/xclock_utc.rs
 fn poll_with_timeout(conn: &Rc<XCBConnection>, idle: RawFd, timeout: Instant) -> Result<(), Error> {
     use nix::poll::{poll, PollFd, PollFlags};
     use std::os::raw::c_int;

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -660,7 +660,7 @@ impl Window {
     /// Schedule a redraw on the idle loop, or if we are waiting on present then schedule it for
     /// when the current present finishes.
     fn redraw_soon(&self) {
-        if matches!(self.waiting_on_present(), Ok(true)) {
+        if let Ok(true) = self.waiting_on_present() {
             if let Err(e) = self.set_needs_present(true) {
                 log::error!("Window::redraw_soon - failed to schedule present: {}", e);
             }

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -886,7 +886,13 @@ impl Window {
                 }
             }
 
-            present.last_msc = Some(event.msc);
+            // Only store the last MSC if we're animating (if we aren't animating, missed MSCs
+            // aren't interesting).
+            present.last_msc = if present.needs_present {
+                Some(event.msc)
+            } else {
+                None
+            };
             present.last_ust = Some(event.ust);
             present.waiting_on = None;
         }

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -17,7 +17,9 @@
 use std::any::Any;
 use std::cell::RefCell;
 use std::convert::TryInto;
+use std::os::unix::io::RawFd;
 use std::rc::{Rc, Weak};
+use std::sync::{Arc, Mutex};
 
 use anyhow::{anyhow, Context, Error};
 use cairo::{XCBConnection as CairoXCBConnection, XCBDrawable, XCBSurface, XCBVisualType};
@@ -26,15 +28,16 @@ use x11rb::connection::Connection;
 use x11rb::protocol::present::{CompleteNotifyEvent, ConnectionExt as _, IdleNotifyEvent};
 use x11rb::protocol::xfixes::{ConnectionExt as _, Region};
 use x11rb::protocol::xproto::{
-    self, AtomEnum, ConfigureNotifyEvent, ConnectionExt, CreateGCAux, EventMask, ExposeEvent,
-    Gcontext, Pixmap, PropMode, Rectangle, Visualtype, WindowClass,
+    self, AtomEnum, ConfigureNotifyEvent, ConnectionExt, CreateGCAux, EventMask, Gcontext, Pixmap,
+    PropMode, Rectangle, Visualtype, WindowClass,
 };
 use x11rb::wrapper::ConnectionExt as _;
 use x11rb::xcb_ffi::XCBConnection;
 
+use crate::common_util::IdleCallback;
 use crate::dialog::{FileDialogOptions, FileInfo};
 use crate::error::Error as ShellError;
-use crate::keyboard::{KeyState, KeyEvent, Modifiers};
+use crate::keyboard::{KeyEvent, KeyState, Modifiers};
 use crate::kurbo::{Point, Rect, Size, Vec2};
 use crate::mouse::{Cursor, MouseButton, MouseButtons, MouseEvent};
 use crate::piet::{Piet, RenderContext};
@@ -246,8 +249,6 @@ impl WindowBuilder {
         // TODO(x11/errors): Should do proper cleanup (window destruction etc) in case of error
         let atoms = self.atoms(id)?;
         let cairo_surface = RefCell::new(self.create_cairo_surface(id, &visual_type)?);
-        // Figure out the refresh rate of the current screen
-        let refresh_rate = util::refresh_rate(conn, id);
         let state = RefCell::new(WindowState {
             size: self.size,
             invalid: Rect::ZERO,
@@ -279,9 +280,10 @@ impl WindowBuilder {
             app: self.app.clone(),
             handler,
             cairo_surface,
-            refresh_rate,
             atoms,
             state,
+            idle_queue: Arc::new(Mutex::new(Vec::new())),
+            idle_pipe: self.app.idle_pipe(),
             present_data: RefCell::new(present_data),
             buffers,
         });
@@ -332,9 +334,11 @@ pub(crate) struct Window {
     app: Application,
     handler: RefCell<Box<dyn WinHandler>>,
     cairo_surface: RefCell<XCBSurface>,
-    refresh_rate: Option<f64>,
     atoms: WindowAtoms,
     state: RefCell<WindowState>,
+    idle_queue: Arc<Mutex<Vec<IdleKind>>>,
+    // Writing to this wakes up the event loop, so that it can run idle handlers.
+    idle_pipe: RawFd,
 
     /// When this is `Some(_)`, we use the X11 Present extension to present windows. This syncs all
     /// presentation to vblank and it appears to prevent tearing (subject to various caveats
@@ -352,10 +356,10 @@ pub(crate) struct Window {
     ///    this case, we will render the next frame immediately unless we're already waiting for a
     ///    completion notification. (If we are waiting for a completion notification, we just make
     ///    a note to schedule a new frame once we get it.)
-    /// 3) Someone calls `invalidate` or `invalidate_rect` on us. We send ourselves an expose event
-    ///    and end up in state 2. This is better than rendering straight away, because for example
-    ///    they might have called `invalidate` from their paint callback, and then we'd end up
-    ///    painting re-entrantively.
+    /// 3) Someone calls `invalidate` or `invalidate_rect` on us. We schedule ourselves to repaint
+    ///    in the idle loop. This is better than rendering straight away, because for example they
+    ///    might have called `invalidate` from their paint callback, and then we'd end up painting
+    ///    re-entrantively.
     ///
     /// This is probably not the best (or at least, not the lowest-latency) scheme we can come up
     /// with, because invalidations that happen shortly after a vblank might need to wait 2 frames
@@ -585,16 +589,11 @@ impl Window {
             self.app
                 .connection()
                 .copy_area(pixmap, self.id, self.gc, x, y, x, y, w, h)?;
-            // We aren't using the present extension, so fall back to sleeping for scheduling
-            // redraws. Sleeping is a terrible way to schedule redraws, but hopefully we don't
-            // have to fall back to this very often.
-            // TODO: once we have an idle handler, we should use that. Sleeping causes lots of
-            // problems when windows are dragged to resize.
-            if anim && self.refresh_rate.is_some() {
-                let sleep_amount_ms = (1000.0 / self.refresh_rate.unwrap()) as u64;
-                std::thread::sleep(std::time::Duration::from_millis(sleep_amount_ms));
-
-                self.invalidate_rect(size.to_rect());
+            // We aren't using the present extension, so use the idle loop to schedule redraws.
+            // Note that the idle loop's wakeup times are roughly tied to the refresh rate, so this
+            // shouldn't draw too often.
+            if anim {
+                self.invalidate();
             }
         }
         self.app.connection().flush()?;
@@ -649,6 +648,28 @@ impl Window {
         Ok(())
     }
 
+    /// Redraw more-or-less now.
+    ///
+    /// "More-or-less" because if we're already waiting on a present, we defer the drawing until it
+    /// completes.
+    fn redraw_now(&self) -> Result<(), Error> {
+        if self.waiting_on_present()? {
+            self.set_needs_present(true)?;
+        } else {
+            self.render()?;
+        }
+        Ok(())
+    }
+
+    /// Schedule a redraw on the idle loop.
+    fn redraw_soon(&self) {
+        let idle = IdleHandle {
+            queue: Arc::clone(&self.idle_queue),
+            pipe: self.idle_pipe,
+        };
+        idle.schedule_redraw();
+    }
+
     fn invalidate(&self) {
         match self.size() {
             Ok(size) => self.invalidate_rect(size.to_rect()),
@@ -657,28 +678,11 @@ impl Window {
     }
 
     fn invalidate_rect(&self, rect: Rect) {
-        if let Err(err) =  self.enlarge_invalid_rect(rect) {
+        if let Err(err) = self.enlarge_invalid_rect(rect) {
             log::error!("Window::invalidate_rect - failed to enlarge rect: {}", err);
         }
 
-        // See: http://rtbo.github.io/rust-xcb/xcb/ffi/xproto/struct.xcb_expose_event_t.html
-        let expose_event = ExposeEvent {
-            window: self.id,
-            x: rect.x0 as u16,
-            y: rect.y0 as u16,
-            width: rect.width() as u16,
-            height: rect.height() as u16,
-            count: 0,
-            response_type: x11rb::protocol::xproto::EXPOSE_EVENT,
-            sequence: 0,
-        };
-        log_x11!(self.app.connection().send_event(
-            false,
-            self.id,
-            EventMask::Exposure,
-            expose_event,
-        ));
-        log_x11!(self.app.connection().flush());
+        self.redraw_soon();
     }
 
     fn set_title(&self, title: &str) {
@@ -869,13 +873,13 @@ impl Window {
             // Check whether we missed presenting on any frames.
             if let Some(last_msc) = present.last_msc {
                 if last_msc.wrapping_add(1) != event.msc {
-                    log::info!(
+                    log::debug!(
                         "missed a present: msc went from {} to {}",
                         last_msc,
                         event.msc
                     );
                     if let Some(last_ust) = present.last_ust {
-                        log::info!("ust went from {} to {}", last_ust, event.ust);
+                        log::debug!("ust went from {} to {}", last_ust, event.ust);
                     }
                 }
             }
@@ -922,6 +926,36 @@ impl Window {
             .as_ref()
             .map(|p| p.needs_present)
             .unwrap_or(false))
+    }
+
+    pub(crate) fn run_idle(&self) {
+        let mut queue = Vec::new();
+        std::mem::swap(&mut *self.idle_queue.lock().unwrap(), &mut queue);
+
+        let mut needs_redraw = false;
+        if let Ok(mut handler) = self.handler.try_borrow_mut() {
+            for callback in queue {
+                match callback {
+                    IdleKind::Callback(f) => {
+                        f.call(handler.as_any());
+                    }
+                    IdleKind::Token(tok) => {
+                        handler.idle(tok);
+                    }
+                    IdleKind::Redraw => {
+                        needs_redraw = true;
+                    }
+                }
+            }
+        } else {
+            log::error!("Not running idle callbacks because the handler is borrowed");
+        }
+
+        if needs_redraw {
+            if let Err(e) = self.redraw_now() {
+                log::error!("Error redrawing: {}", e);
+            }
+        }
     }
 }
 
@@ -1117,21 +1151,56 @@ fn key_mods(mods: u16) -> Modifiers {
     ret
 }
 
+/// A handle that can get used to schedule an idle handler. Note that
+/// this handle is thread safe.
 #[derive(Clone)]
-pub(crate) struct IdleHandle;
+pub struct IdleHandle {
+    queue: Arc<Mutex<Vec<IdleKind>>>,
+    pipe: RawFd,
+}
+
+pub(crate) enum IdleKind {
+    Callback(Box<dyn IdleCallback>),
+    Token(IdleToken),
+    Redraw,
+}
 
 impl IdleHandle {
-    pub fn add_idle_callback<F>(&self, _callback: F)
+    fn wake(&self) {
+        loop {
+            match nix::unistd::write(self.pipe, &[0]) {
+                Err(nix::Error::Sys(nix::errno::Errno::EINTR)) => {}
+                Err(nix::Error::Sys(nix::errno::Errno::EAGAIN)) => {}
+                Err(e) => {
+                    log::error!("Failed to write to idle pipe: {}", e);
+                    break;
+                }
+                Ok(_) => {
+                    break;
+                }
+            }
+        }
+    }
+
+    pub(crate) fn schedule_redraw(&self) {
+        self.queue.lock().unwrap().push(IdleKind::Redraw);
+        self.wake();
+    }
+
+    pub fn add_idle_callback<F>(&self, callback: F)
     where
         F: FnOnce(&dyn Any) + Send + 'static,
     {
-        // TODO(x11/idle_handles): implement IdleHandle::add_idle_callback
-        log::warn!("IdleHandle::add_idle_callback is currently unimplemented for X11 platforms.");
+        self.queue
+            .lock()
+            .unwrap()
+            .push(IdleKind::Callback(Box::new(callback)));
+        self.wake();
     }
 
-    pub fn add_idle_token(&self, _token: IdleToken) {
-        // TODO(x11/idle_handles): implement IdleHandle::add_idle_token
-        log::warn!("IdleHandle::add_idle_token is currently unimplemented for X11 platforms.");
+    pub fn add_idle_token(&self, token: IdleToken) {
+        self.queue.lock().unwrap().push(IdleKind::Token(token));
+        self.wake();
     }
 }
 
@@ -1253,9 +1322,14 @@ impl WindowHandle {
     }
 
     pub fn get_idle_handle(&self) -> Option<IdleHandle> {
-        // TODO(x11/idle_handles): implement WindowHandle::get_idle_handle
-        //log::warn!("WindowHandle::get_idle_handle is currently unimplemented for X11 platforms.");
-        Some(IdleHandle)
+        if let Some(w) = self.window.upgrade() {
+            Some(IdleHandle {
+                queue: Arc::clone(&w.idle_queue),
+                pipe: w.idle_pipe,
+            })
+        } else {
+            None
+        }
     }
 
     pub fn get_scale(&self) -> Result<Scale, ShellError> {

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -474,7 +474,7 @@ impl Window {
     ///
     /// ### Connection
     ///
-    /// Does not flush the connection.
+    /// Does not flush the connection (it gets flushed by the event loop).
     pub fn destroy(&self) {
         log_x11!(self.app.connection().destroy_window(self.id));
     }
@@ -596,18 +596,15 @@ impl Window {
                 self.invalidate();
             }
         }
-        self.app.connection().flush()?;
         Ok(())
     }
 
     fn show(&self) {
         log_x11!(self.app.connection().map_window(self.id));
-        log_x11!(self.app.connection().flush());
     }
 
     fn close(&self) {
         self.destroy();
-        log_x11!(self.app.connection().flush());
     }
 
     /// Set whether the window should be resizable
@@ -633,7 +630,6 @@ impl Window {
             self.id,
             xproto::Time::CurrentTime,
         ));
-        log_x11!(conn.flush());
     }
 
     fn enlarge_invalid_rect(&self, rect: Rect) -> Result<(), Error> {
@@ -693,7 +689,6 @@ impl Window {
             AtomEnum::STRING,
             title.as_bytes(),
         ));
-        log_x11!(self.app.connection().flush());
     }
 
     fn set_menu(&self, _menu: Menu) {

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -471,10 +471,6 @@ impl Window {
     }
 
     /// Start the destruction of the window.
-    ///
-    /// ### Connection
-    ///
-    /// Does not flush the connection (it gets flushed by the event loop).
     pub fn destroy(&self) {
         log_x11!(self.app.connection().destroy_window(self.id));
     }


### PR DESCRIPTION
Fixes #932 and #935.