### PR TITLE
Re-export `druid_shell::Scalable` & remove to_px/to_dp helpers on Scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,14 @@ You can find its changes [documented below](#060---2020-06-01).
 - `Scale::from_scale` to `Scale::new`, and `Scale` methods `scale_x` / `scale_y` to `x` / `y`. ([#1042] by [@xStrom])
 - Major rework of keyboard event handling ([#1049] by [@raphlinus])
 - `Container::rounded` takes `KeyOrValue<f64>` instead of `f64`. ([#1054] by [@binomial0])
+- Re-export `druid_shell::Scalable` under `druid` namespace. ([#1075] by [@ForLoveOfCats])
 
 ### Deprecated
 
 ### Removed
 
 - `Scale::from_dpi`, `Scale::dpi_x`, and `Scale::dpi_y`. ([#1042] by [@xStrom])
+- `Scale::to_px` and `Scale::to_dp`. ([#1075] by [@ForLoveOfCats])
 
 ### Fixed
 
@@ -239,6 +241,7 @@ Last release without a changelog :(
 [@covercash2]: https://github.com/covercash2
 [@raphlinus]: https://github.com/raphlinus
 [@binomial0]: https://github.com/binomial0
+[@ForLoveOfCats]: https://github.com/ForLoveOfCats
 [@chris-zen]: https://github.com/chris-zen
 
 [#599]: https://github.com/linebender/druid/pull/599
@@ -347,6 +350,7 @@ Last release without a changelog :(
 [#1050]: https://github.com/linebender/druid/pull/1050
 [#1054]: https://github.com/linebender/druid/pull/1054
 [#1058]: https://github.com/linebender/druid/pull/1058
+[#1075]: https://github.com/linebender/druid/pull/1075
 [#1062]: https://github.com/linebender/druid/pull/1062
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -39,7 +39,7 @@ use crate::dialog::{FileDialogOptions, FileDialogType, FileInfo};
 use crate::error::Error as ShellError;
 use crate::keyboard::{KbKey, KeyState, KeyEvent, Modifiers};
 use crate::mouse::{Cursor, MouseButton, MouseButtons, MouseEvent};
-use crate::scale::{Scale, ScaledArea};
+use crate::scale::{Scale, Scalable, ScaledArea};
 use crate::window::{IdleToken, Text, TimerToken, WinHandler};
 
 use super::application::Application;
@@ -323,7 +323,7 @@ impl WindowBuilder {
                         let button_state = event.get_state();
                         handler.mouse_down(
                             &MouseEvent {
-                                pos: scale.to_dp(&Point::from(event.get_position())),
+                                pos: Point::from(event.get_position()).to_dp(scale),
                                 buttons: get_mouse_buttons_from_modifiers(button_state).with(button),
                                 mods: get_modifiers(button_state),
                                 count: get_mouse_click_count(event.get_event_type()),
@@ -349,7 +349,7 @@ impl WindowBuilder {
                         let button_state = event.get_state();
                         handler.mouse_up(
                             &MouseEvent {
-                                pos: scale.to_dp(&Point::from(event.get_position())),
+                                pos: Point::from(event.get_position()).to_dp(scale),
                                 buttons: get_mouse_buttons_from_modifiers(button_state).without(button),
                                 mods: get_modifiers(button_state),
                                 count: 0,
@@ -372,7 +372,7 @@ impl WindowBuilder {
                 let scale = state.scale.get();
                 let motion_state = motion.get_state();
                 let mouse_event = MouseEvent {
-                    pos: scale.to_dp(&Point::from(motion.get_position())),
+                    pos: Point::from(motion.get_position()).to_dp(scale),
                     buttons: get_mouse_buttons_from_modifiers(motion_state),
                     mods: get_modifiers(motion_state),
                     count: 0,
@@ -396,7 +396,7 @@ impl WindowBuilder {
                 let scale = state.scale.get();
                 let crossing_state = crossing.get_state();
                 let mouse_event = MouseEvent {
-                    pos: scale.to_dp(&Point::from(crossing.get_position())),
+                    pos: Point::from(crossing.get_position()).to_dp(scale),
                     buttons: get_mouse_buttons_from_modifiers(crossing_state),
                     mods: get_modifiers(crossing_state),
                     count: 0,
@@ -452,7 +452,7 @@ impl WindowBuilder {
 
                 if let Some(wheel_delta) = wheel_delta {
                     let mouse_event = MouseEvent {
-                        pos: scale.to_dp(&Point::from(scroll.get_position())),
+                        pos: Point::from(scroll.get_position()).to_dp(scale),
                         buttons: get_mouse_buttons_from_modifiers(scroll.get_state()),
                         mods,
                         count: 0,
@@ -573,7 +573,7 @@ impl WindowHandle {
     pub fn invalidate_rect(&self, rect: Rect) {
         if let Some(state) = self.state.upgrade() {
             // GTK takes rects with non-negative integer width/height.
-            let r = state.scale.get().to_px(&rect.abs()).expand();
+            let r = rect.abs().to_px(state.scale.get()).expand();
             let origin = state.drawing_area.get_allocation();
             state.window.queue_draw_area(
                 r.x0 as i32 + origin.x,

--- a/druid-shell/src/scale.rs
+++ b/druid-shell/src/scale.rs
@@ -116,14 +116,6 @@ impl Scale {
         self.y
     }
 
-    /// Converts the `item` from display points into pixels,
-    /// using the x axis scale factor for coordinates on the x axis
-    /// and the y axis scale factor for coordinates on the y axis.
-    #[inline]
-    pub fn to_px<T: Scalable>(self, item: &T) -> T {
-        item.to_px(self)
-    }
-
     /// Converts from pixels into display points, using the x axis scale factor.
     #[inline]
     pub fn px_to_dp_x<T: Into<f64>>(self, x: T) -> f64 {
@@ -141,14 +133,6 @@ impl Scale {
     #[inline]
     pub fn px_to_dp_xy<T: Into<f64>>(self, x: T, y: T) -> (f64, f64) {
         (x.into() / self.x, y.into() / self.y)
-    }
-
-    /// Converts the `item` from pixels into display points,
-    /// using the x axis scale factor for coordinates on the x axis
-    /// and the y axis scale factor for coordinates on the y axis.
-    #[inline]
-    pub fn to_dp<T: Scalable>(self, item: &T) -> T {
-        item.to_dp(self)
     }
 }
 

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -171,7 +171,7 @@ pub use shell::keyboard_types;
 pub use shell::{
     Application, Clipboard, ClipboardFormat, Code, Cursor, Error as PlatformError,
     FileDialogOptions, FileInfo, FileSpec, FormatId, HotKey, KbKey, KeyEvent, Location, Modifiers,
-    MouseButton, MouseButtons, RawMods, Scale, SysMods, Text, TimerToken, WindowHandle,
+    MouseButton, MouseButtons, RawMods, Scalable, Scale, SysMods, Text, TimerToken, WindowHandle,
 };
 
 pub use crate::core::WidgetPod;


### PR DESCRIPTION
This allows `use`-ing `Scalable` and thus various type's implementation of `to_px` ect