### PR TITLE
Added ctrl/shift hotkey support to textbox.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ You can find its changes [documented below](#060---2020-06-01).
 
 ### Added
 
+- Added ctrl/shift key support to textbox. ([#1063] by [@vkahl])
+
 ### Changed
 
 - `Image` and `ImageData` exported by default. ([#1011] by [@covercash2])
@@ -240,6 +242,7 @@ Last release without a changelog :(
 [@raphlinus]: https://github.com/raphlinus
 [@binomial0]: https://github.com/binomial0
 [@chris-zen]: https://github.com/chris-zen
+[@vkahl]: https://github.com/vkahl
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611

--- a/druid/src/text/editable_text.rs
+++ b/druid/src/text/editable_text.rs
@@ -118,10 +118,9 @@ impl EditableText for String {
     }
 
     fn prev_word_offset(&self, from: usize) -> Option<usize> {
-        let mut graphemes = self.get(0..from)?.graphemes(true);
         let mut offset = from;
         let mut passed_alphanumeric = false;
-        while let Some(prev_grapheme) = graphemes.next_back() {
+        for prev_grapheme in self.get(0..from)?.graphemes(true).rev() {
             let is_alphanumeric = prev_grapheme.chars().next()?.is_alphanumeric();
             if is_alphanumeric {
                 passed_alphanumeric = true;
@@ -134,10 +133,9 @@ impl EditableText for String {
     }
 
     fn next_word_offset(&self, from: usize) -> Option<usize> {
-        let mut graphemes = self.get(from..)?.graphemes(true);
         let mut offset = from;
         let mut passed_alphanumeric = false;
-        while let Some(next_grapheme) = graphemes.next() {
+        for next_grapheme in self.get(from..)?.graphemes(true) {
             let is_alphanumeric = next_grapheme.chars().next()?.is_alphanumeric();
             if is_alphanumeric {
                 passed_alphanumeric = true;

--- a/druid/src/text/movement.rs
+++ b/druid/src/text/movement.rs
@@ -23,6 +23,10 @@ pub enum Movement {
     Left,
     /// Move to the right by one grapheme cluster.
     Right,
+    /// Move to the left by one word.
+    LeftWord,
+    /// Move to the right by one word.
+    RightWord,
     /// Move to left end of visible line.
     LeftOfLine,
     /// Move to right end of visible line.
@@ -34,22 +38,14 @@ pub fn movement(m: Movement, s: Selection, text: &impl EditableText, modify: boo
     let offset = match m {
         Movement::Left => {
             if s.is_caret() || modify {
-                if let Some(offset) = text.prev_grapheme_offset(s.end) {
-                    offset
-                } else {
-                    0
-                }
+                text.prev_grapheme_offset(s.end).unwrap_or(0)
             } else {
                 s.min()
             }
         }
         Movement::Right => {
             if s.is_caret() || modify {
-                if let Some(offset) = text.next_grapheme_offset(s.end) {
-                    offset
-                } else {
-                    s.end
-                }
+                text.next_grapheme_offset(s.end).unwrap_or(s.end)
             } else {
                 s.max()
             }
@@ -57,6 +53,21 @@ pub fn movement(m: Movement, s: Selection, text: &impl EditableText, modify: boo
 
         Movement::LeftOfLine => 0,
         Movement::RightOfLine => text.len(),
+
+        Movement::LeftWord => {
+            if s.is_caret() || modify {
+                text.prev_word_offset(s.end).unwrap_or(0)
+            } else {
+                s.min()
+            }
+        }
+        Movement::RightWord => {
+            if s.is_caret() || modify {
+                text.next_word_offset(s.end).unwrap_or(s.end)
+            } else {
+                s.max()
+            }
+        }
     };
     Selection::new(if modify { s.start } else { offset }, offset)
 }

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -130,6 +130,14 @@ impl TextBox {
             EditAction::Insert(chars) | EditAction::Paste(chars) => self.insert(text, &chars),
             EditAction::Backspace => self.delete_backward(text),
             EditAction::Delete => self.delete_forward(text),
+            EditAction::JumpDelete(movement) => {
+                self.move_selection(movement, text, true);
+                self.delete_forward(text)
+            }
+            EditAction::JumpBackspace(movement) => {
+                self.move_selection(movement, text, true);
+                self.delete_backward(text)
+            }
             EditAction::Move(movement) => self.move_selection(movement, text, false),
             EditAction::ModifySelection(movement) => self.move_selection(movement, text, true),
             EditAction::SelectAll => self.selection.all(text),


### PR DESCRIPTION
New key commands:
Ctrl + Arrow keys -> jump words
Ctrl + Shift + Arrow keys -> select words
Ctrl + Backspace/Delete -> delete words
Shift + Home/End -> select to home/end

Consecutive non-alphanumeric characters are skipped when jumping words.
The behaviour matches the firefox url bar.