### PR TITLE
Fix comparison between Modifier with NUM_LOCK and RawMods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -353,6 +353,7 @@ Last release without a changelog :(
 [#1054]: https://github.com/linebender/druid/pull/1054
 [#1058]: https://github.com/linebender/druid/pull/1058
 [#1062]: https://github.com/linebender/druid/pull/1062
+[#1077]: https://github.com/linebender/druid/pull/1077
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master
 [0.6.0]: https://github.com/linebender/druid/compare/v0.5.0...v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - GTK: Don't crash when receiving an external command while a file dialog is visible. ([#1043] by [@jneem])
 - Fix derive `Data` when type param bounds are defined ([#1058] by [@chris-zen])
 - Ensure that `update` is called after all commands. ([#1062] by [@jneem])
+- Fix comparison between Modifier with NUM_LOCK and RawMods. ([#1077] by [@HoNile])
 
 ### Visual
 
@@ -243,6 +244,7 @@ Last release without a changelog :(
 [@binomial0]: https://github.com/binomial0
 [@chris-zen]: https://github.com/chris-zen
 [@vkahl]: https://github.com/vkahl
+[@HoNile]: https://github.com/HoNile
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611

--- a/druid-shell/src/hotkey.rs
+++ b/druid-shell/src/hotkey.rs
@@ -112,7 +112,10 @@ impl HotKey {
     /// [`KeyboardEvent`]: keyboard_types::KeyEvent
     pub fn matches(&self, event: impl Borrow<KeyEvent>) -> bool {
         let event = event.borrow();
-        self.mods == (event.mods & (!Modifiers::NUM_LOCK)) && self.key == event.key
+        self.mods
+            == (event.mods
+                & !(Modifiers::NUM_LOCK | Modifiers::ALT | Modifiers::CAPS_LOCK | Modifiers::META))
+            && self.key == event.key
     }
 }
 

--- a/druid-shell/src/hotkey.rs
+++ b/druid-shell/src/hotkey.rs
@@ -112,7 +112,7 @@ impl HotKey {
     /// [`KeyboardEvent`]: keyboard_types::KeyEvent
     pub fn matches(&self, event: impl Borrow<KeyEvent>) -> bool {
         let event = event.borrow();
-        self.mods == event.mods && self.key == event.key
+        self.mods == (event.mods & (!Modifiers::NUM_LOCK)) && self.key == event.key
     }
 }
 


### PR DESCRIPTION
This is the most basic way I found to solve an issue where arrow key (and some others) doesn't work on texbox, I tracked the issue to the comparison between a Modifier and a RawMods because of NUM_LOCK.