### PR TITLE
Compare only base modifiers for hotkey match

### DIFF
--- a/druid-shell/src/hotkey.rs
+++ b/druid-shell/src/hotkey.rs
@@ -111,8 +111,10 @@ impl HotKey {
     ///
     /// [`KeyboardEvent`]: keyboard_types::KeyEvent
     pub fn matches(&self, event: impl Borrow<KeyEvent>) -> bool {
+        // Should be a const but const bit_or doesn't work here.
+        let base_mods = Modifiers::SHIFT | Modifiers::CONTROL | Modifiers::ALT | Modifiers::META;
         let event = event.borrow();
-        self.mods == event.mods && self.key == event.key
+        self.mods == event.mods & base_mods && self.key == event.key
     }
 }
 


### PR DESCRIPTION
Fixes the issue raised in #1077