### PR TITLE
Don't install rustfmt twice on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,6 @@ jobs:
           components: rustfmt
           override: true
 
-      - name: install rustfmt
-        run: rustup component add rustfmt
-
       - name: cargo fmt
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
It seems that rustfmt is already installed by [this line](https://github.com/linebender/druid/blob/master/.github/workflows/ci.yml#L19).