### PR TITLE
WIP: Attempt to speed up CI by caching cargo dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        if: contains(matrix.os, 'ubuntu')
+        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'MacOS')
 
       - name: install libgtk-3-dev libx11-dev
         run: |
@@ -154,7 +154,7 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        if: contains(matrix.os, 'ubuntu')
+        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'MacOS')
 
       # libgtk-dev seems to be needed by e.g. druid-derive
       - name: install libgtk-dev
@@ -264,7 +264,7 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        if: contains(matrix.os, 'ubuntu')
+        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'MacOS')
 
       - name: install libgtk-dev libx11-dev
         run: |
@@ -336,7 +336,7 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        if: contains(matrix.os, 'ubuntu')
+        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'MacOS')
 
       - name: install libgtk-dev
         run: |
@@ -397,7 +397,7 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        if: contains(matrix.os, 'ubuntu')
+        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'MacOS')
 
       - name: install stable toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+
       - uses: actions/cache@v2
         with:
           path: |
@@ -147,6 +150,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+
       - uses: actions/cache@v2
         with:
           path: |
@@ -257,6 +263,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+
       - uses: actions/cache@v2
         with:
           path: |
@@ -329,6 +338,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+
       - uses: actions/cache@v2
         with:
           path: |
@@ -389,6 +401,9 @@ jobs:
     name: mdbook build
     steps:
       - uses: actions/checkout@v2
+
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'MacOS')
+        #if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'MacOS')
 
       - name: install libgtk-3-dev libx11-dev
         run: |
@@ -154,7 +154,7 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'MacOS')
+        #if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'MacOS')
 
       # libgtk-dev seems to be needed by e.g. druid-derive
       - name: install libgtk-dev
@@ -264,7 +264,7 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'MacOS')
+        #if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'MacOS')
 
       - name: install libgtk-dev libx11-dev
         run: |
@@ -336,7 +336,7 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'MacOS')
+        #if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'MacOS')
 
       - name: install libgtk-dev
         run: |
@@ -397,7 +397,7 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'MacOS')
+        #if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'MacOS')
 
       - name: install stable toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        if: contains(matrix.os, 'ubuntu')
+
       - name: install libgtk-3-dev libx11-dev
         run: |
           sudo apt update
@@ -138,6 +147,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        if: contains(matrix.os, 'ubuntu')
+
       # libgtk-dev seems to be needed by e.g. druid-derive
       - name: install libgtk-dev
         run: |
@@ -239,6 +257,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        if: contains(matrix.os, 'ubuntu')
+
       - name: install libgtk-dev libx11-dev
         run: |
           sudo apt update
@@ -302,6 +329,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        if: contains(matrix.os, 'ubuntu')
+
       - name: install libgtk-dev
         run: |
           sudo apt update
@@ -353,6 +389,15 @@ jobs:
     name: mdbook build
     steps:
       - uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        if: contains(matrix.os, 'ubuntu')
 
       - name: install stable toolchain
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
I'm attempting to adapt an ["official example"](https://github.com/actions/cache/blob/master/examples.md#rust---cargo). This same technique worked for my project which uses Druid (7 minute build -> 2 minute build), but it doesn't speed things up here.

I suspect the problem might be that [Cargo.lock isn't checked in](https://github.com/linebender/druid/blob/master/.gitignore#L3) -- [as discussed in this thread](https://github.com/actions-rs/meta/issues/21#issuecomment-629712798).

Perhaps druid being a "workspace" also interferes somehow?

[Note about CI in cargo book](https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci).