### PR TITLE
Don't fail fast in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
   test-stable:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macOS-latest, windows-2019, ubuntu-latest]
     name: cargo clippy+test
@@ -131,6 +132,7 @@ jobs:
   test-stable-wasm:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macOS-latest, windows-2019, ubuntu-latest]
 
@@ -233,6 +235,7 @@ jobs:
   test-nightly:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macOS-latest, windows-2019, ubuntu-latest]
     name: cargo test nightly
@@ -297,6 +300,7 @@ jobs:
     name: Docs
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macOS-latest, windows-2019, ubuntu-latest]
     steps:


### PR DESCRIPTION
Currently when a job fails the other jobs in the os matrix gets cancelled
I think it would make sense to try and finish the tests on the other operating systems to see if anything else pops up.