### PR TITLE
Wrap EnvScope child in WidgetPod and pass down the new Env during layout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ You can find its changes [documented below](#060---2020-06-01).
 - GTK: Don't interrupt `KeyEvent.repeat` when releasing another key. ([#1081] by [@raphlinus])
 - X11: Set some more common window properties. ([#1097] by [@psychon])
 - X11: Support timers. ([#1096] by [@psychon])
+- `EnvScope` now also updates the `Env` during `Widget::lifecycle`. ([#1100] by [@finnerale])
+- `WidgetExt::debug_widget_id` and `debug_paint_layout` now also apply to the widget they are called on. ([#1100] by [@finnerale])
 
 ### Visual
 
@@ -365,6 +367,7 @@ Last release without a changelog :(
 [#1081]: https://github.com/linebender/druid/pull/1081
 [#1096]: https://github.com/linebender/druid/pull/1096
 [#1097]: https://github.com/linebender/druid/pull/1097
+[#1100]: https://github.com/linebender/druid/pull/1100
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master
 [0.6.0]: https://github.com/linebender/druid/compare/v0.5.0...v0.6.0

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -69,7 +69,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for EnvScope<T, W> {
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         let mut new_env = env.clone();
         (self.f)(&mut new_env, &data);
-        self.child.lifecycle(ctx, event, data, env)
+        self.child.lifecycle(ctx, event, data, &new_env)
     }
 
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -17,16 +17,16 @@
 use crate::kurbo::Size;
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
-    UpdateCtx, Widget, WidgetId,
+    UpdateCtx, Widget, WidgetPod,
 };
 
 /// A widget that accepts a closure to update the environment for its child.
 pub struct EnvScope<T, W> {
     pub(crate) f: Box<dyn Fn(&mut Env, &T)>,
-    pub(crate) child: W,
+    pub(crate) child: WidgetPod<T, W>,
 }
 
-impl<T, W> EnvScope<T, W> {
+impl<T, W: Widget<T>> EnvScope<T, W> {
     /// Create a widget that updates the environment for its descendants.
     ///
     /// Accepts a closure that sets Env values.
@@ -53,7 +53,7 @@ impl<T, W> EnvScope<T, W> {
     pub fn new(f: impl Fn(&mut Env, &T) + 'static, child: W) -> EnvScope<T, W> {
         EnvScope {
             f: Box::new(f),
-            child,
+            child: WidgetPod::new(child),
         }
     }
 }
@@ -72,26 +72,22 @@ impl<T: Data, W: Widget<T>> Widget<T> for EnvScope<T, W> {
         self.child.lifecycle(ctx, event, data, &new_env)
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
         let mut new_env = env.clone();
         (self.f)(&mut new_env, &data);
 
-        self.child.update(ctx, old_data, data, &new_env);
+        self.child.update(ctx, data, &new_env);
     }
 
-    fn layout(
-        &mut self,
-        layout_ctx: &mut LayoutCtx,
-        bc: &BoxConstraints,
-        data: &T,
-        env: &Env,
-    ) -> Size {
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         bc.debug_check("EnvScope");
 
         let mut new_env = env.clone();
         (self.f)(&mut new_env, &data);
 
-        self.child.layout(layout_ctx, &bc, data, &new_env)
+        let size = self.child.layout(ctx, &bc, data, &new_env);
+        self.child.set_layout_rect(ctx, data, env, size.to_rect());
+        size
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
@@ -99,9 +95,5 @@ impl<T: Data, W: Widget<T>> Widget<T> for EnvScope<T, W> {
         (self.f)(&mut new_env, &data);
 
         self.child.paint(ctx, data, &new_env);
-    }
-
-    fn id(&self) -> Option<WidgetId> {
-        self.child.id()
     }
 }


### PR DESCRIPTION
With this, `EnvScope` will wrap its child in a `WidgetPod`.

This means that `debug_paint_layout` and `debug_widget_id` will now apply to the widget they are called on (until now it would only apply to "the child's children"). For example calling one of those methods on a `Button` will now work. `debug_widget_id` will now show the root widget's id as well, which was not possible before.

Also, we've been passing down `env` instead of `new_env` during `Widget::layout`, now we are passing `new_env`.