### PR TITLE
bring_to_front_and_focus implementation on gtk

### DIFF
--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -562,8 +562,12 @@ impl WindowHandle {
 
     /// Bring this window to the front of the window stack and give it focus.
     pub fn bring_to_front_and_focus(&self) {
-        //FIXME: implementation goes here
-        log::warn!("bring_to_front_and_focus not yet implemented for gtk");
+        if let Some(state) = self.state.upgrade() {
+            // The GTK docs say not to use this and instead use present_with_timestamp.
+            // This works though, and the docs also don't say how the timestamp
+            // is reperesented (seconds maybe?)
+            state.window.present();
+        }
     }
 
     // Request invalidation of the entire window contents.

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -563,9 +563,8 @@ impl WindowHandle {
     /// Bring this window to the front of the window stack and give it focus.
     pub fn bring_to_front_and_focus(&self) {
         if let Some(state) = self.state.upgrade() {
-            // The GTK docs say not to use this and instead use present_with_timestamp.
-            // This works though, and the docs also don't say how the timestamp
-            // is reperesented (seconds maybe?)
+            // TODO(gtk/misc): replace with present_with_timestamp if/when druid-shell
+            // has a system to get the correct input time, as GTK discourages present
             state.window.present();
         }
     }


### PR DESCRIPTION
This should be a working implementation of the bring_to_front_and_focus function for the WindowHandle mentioned in #295.

Also, I noticed that this focus function has a documentation comment above it but the function below just has a regular comment. I didn't bother to change it as it seemed unrelated to what I was doing, and I didn't know if that was intentional. The documentation seems to have gotten it anyway.