### PR TITLE
Scrolling changes and small other fixes to support druid_table

### DIFF
--- a/druid/examples/sync_scroll.rs
+++ b/druid/examples/sync_scroll.rs
@@ -17,8 +17,8 @@ fn build_widget() -> impl Widget<String> {
 
     let mut leader = Scroll::new(make_col(0));
 
-    leader.add_scroll_handler(move |ctx, scroll_offsets| {
-        ctx.submit_command(SCROLL_TO.with(ScrollTo::y(scroll_offsets.y)), follower_id);
+    leader.add_scroll_handler(move |submit_command, scroll_offsets| {
+        submit_command(SCROLL_TO.with(ScrollTo::y(scroll_offsets.y)), follower_id.into());
     });
 
     let follower = Scroll::new(make_col(1))

--- a/druid/examples/sync_scroll.rs
+++ b/druid/examples/sync_scroll.rs
@@ -1,0 +1,45 @@
+use druid::widget::prelude::*;
+use druid::widget::{Flex, Label, Padding, Scroll, ScrollTo, TextBox, SCROLL_TO};
+use druid::{AppLauncher, LocalizedString, Target, WidgetExt, WindowDesc};
+
+pub fn main() {
+    let window = WindowDesc::new(build_widget)
+        .title(LocalizedString::new("scroll-demo-window-title").with_placeholder("Scroll demo"));
+    AppLauncher::with_window(window)
+        .use_simple_logger()
+        .launch("Synchronised scrolling".into())
+        .expect("launch failed");
+}
+
+fn build_widget() -> impl Widget<String> {
+    let mut row = Flex::row();
+    let follower_id = WidgetId::next();
+
+    let mut leader = Scroll::new(make_col(0));
+
+    leader.add_scroll_handler(move |ctx, scroll_offsets| {
+        ctx.submit_command(SCROLL_TO.with(ScrollTo::y(scroll_offsets.y)), follower_id);
+    });
+
+    row.add_child(leader);
+
+    row.add_child(Scroll::new(make_col(1)).with_id(follower_id));
+
+    row
+}
+
+fn make_col(i: i32) -> Flex<String> {
+    let mut col = Flex::column();
+
+    for j in 0..100 {
+        if i == j {
+            col.add_child(Padding::new(3.0, TextBox::new()));
+        } else {
+            col.add_child(Padding::new(
+                3.0,
+                Label::new(move |d: &String, _env: &_| format!("Label {}, {}, {}", i, j, d)),
+            ));
+        };
+    }
+    col
+}

--- a/druid/examples/sync_scroll.rs
+++ b/druid/examples/sync_scroll.rs
@@ -18,7 +18,10 @@ fn build_widget() -> impl Widget<String> {
     let mut leader = Scroll::new(make_col(0));
 
     leader.add_scroll_handler(move |submit_command, scroll_offsets| {
-        submit_command(SCROLL_TO.with(ScrollTo::y(scroll_offsets.y)), follower_id.into());
+        submit_command(
+            SCROLL_TO.with(ScrollTo::y(scroll_offsets.y)),
+            follower_id.into(),
+        );
     });
 
     let follower = Scroll::new(make_col(1))

--- a/druid/examples/sync_scroll.rs
+++ b/druid/examples/sync_scroll.rs
@@ -21,9 +21,12 @@ fn build_widget() -> impl Widget<String> {
         ctx.submit_command(SCROLL_TO.with(ScrollTo::y(scroll_offsets.y)), follower_id);
     });
 
-    row.add_child(leader);
+    let follower = Scroll::new(make_col(1))
+        .disable_scrollbars()
+        .with_id(follower_id);
+    row.add_child(follower);
 
-    row.add_child(Scroll::new(make_col(1)).with_id(follower_id));
+    row.add_child(leader);
 
     row
 }

--- a/druid/examples/sync_scroll.rs
+++ b/druid/examples/sync_scroll.rs
@@ -1,6 +1,6 @@
 use druid::widget::prelude::*;
 use druid::widget::{Flex, Label, Padding, Scroll, ScrollTo, TextBox, SCROLL_TO};
-use druid::{AppLauncher, LocalizedString, Target, WidgetExt, WindowDesc};
+use druid::{AppLauncher, LocalizedString, WidgetExt, WindowDesc};
 
 pub fn main() {
     let window = WindowDesc::new(build_widget)

--- a/druid/examples/web/src/lib.rs
+++ b/druid/examples/web/src/lib.rs
@@ -73,6 +73,7 @@ impl_example!(panels.unwrap());
 impl_example!(parse);
 impl_example!(scroll_colors);
 impl_example!(scroll);
+impl_example!(sync_scroll);
 impl_example!(split_demo);
 impl_example!(styled_text.unwrap());
 impl_example!(switches);

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -328,20 +328,30 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
 });
 
 // methods on event, update, and lifecycle
-impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, LayoutCtx<'_,'_>, {
-    /// Submit a [`Command`] to be run after this event is handled.
-    ///
-    /// Commands are run in the order they are submitted; all commands
-    /// submitted during the handling of an event are executed before
-    /// the [`update`] method is called; events submitted during [`update`]
-    /// are handled after painting.
-    ///
-    /// [`Command`]: struct.Command.html
-    /// [`update`]: trait.Widget.html#tymethod.update
-    pub fn submit_command(&mut self, cmd: impl Into<Command>, target: impl Into<Option<Target>>) {
-        self.state.submit_command(cmd.into(), target.into())
+impl_context_method!(
+    EventCtx<'_, '_>,
+    UpdateCtx<'_, '_>,
+    LifeCycleCtx<'_, '_>,
+    LayoutCtx<'_, '_>,
+    {
+        /// Submit a [`Command`] to be run after this event is handled.
+        ///
+        /// Commands are run in the order they are submitted; all commands
+        /// submitted during the handling of an event are executed before
+        /// the [`update`] method is called; events submitted during [`update`]
+        /// are handled after painting.
+        ///
+        /// [`Command`]: struct.Command.html
+        /// [`update`]: trait.Widget.html#tymethod.update
+        pub fn submit_command(
+            &mut self,
+            cmd: impl Into<Command>,
+            target: impl Into<Option<Target>>,
+        ) {
+            self.state.submit_command(cmd.into(), target.into())
+        }
     }
-});
+);
 
 impl EventCtx<'_, '_> {
     /// Set the cursor icon.
@@ -618,7 +628,6 @@ impl PaintCtx<'_, '_, '_> {
             transform: current_transform,
         })
     }
-
 }
 
 impl<'a> ContextState<'a> {

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -318,6 +318,17 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
         self.request_layout();
     }
 
+    /// Set the menu of the window containing the current widget.
+    /// `T` must be the application's root `Data` type (the type provided to [`AppLauncher::launch`]).
+    ///
+    /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
+    pub fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {
+        self.state.set_menu(menu);
+    }
+});
+
+// methods on event, update, and lifecycle
+impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, LayoutCtx<'_,'_>, {
     /// Submit a [`Command`] to be run after this event is handled.
     ///
     /// Commands are run in the order they are submitted; all commands
@@ -329,14 +340,6 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
     /// [`update`]: trait.Widget.html#tymethod.update
     pub fn submit_command(&mut self, cmd: impl Into<Command>, target: impl Into<Option<Target>>) {
         self.state.submit_command(cmd.into(), target.into())
-    }
-
-    /// Set the menu of the window containing the current widget.
-    /// `T` must be the application's root `Data` type (the type provided to [`AppLauncher::launch`]).
-    ///
-    /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
-    pub fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {
-        self.state.set_menu(menu);
     }
 });
 
@@ -523,10 +526,6 @@ impl LayoutCtx<'_, '_> {
     pub fn set_paint_insets(&mut self, insets: impl Into<Insets>) {
         self.widget_state.paint_insets = insets.into().nonnegative();
     }
-
-    pub fn submit_command(&mut self, cmd: impl Into<Command>, target: impl Into<Option<Target>>) {
-        self.state.submit_command(cmd.into(), target.into())
-    }
 }
 
 impl PaintCtx<'_, '_, '_> {
@@ -620,9 +619,6 @@ impl PaintCtx<'_, '_, '_> {
         })
     }
 
-    pub fn viewport_offset(&self) -> Vec2 {
-        self.widget_state.viewport_offset
-    }
 }
 
 impl<'a> ContextState<'a> {
@@ -641,7 +637,7 @@ impl<'a> ContextState<'a> {
         }
     }
 
-    pub(crate) fn submit_command(&mut self, command: Command, target: Option<Target>) {
+    fn submit_command(&mut self, command: Command, target: Option<Target>) {
         let target = target.unwrap_or_else(|| self.window_id.into());
         self.command_queue.push_back((target, command))
     }

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -523,6 +523,10 @@ impl LayoutCtx<'_, '_> {
     pub fn set_paint_insets(&mut self, insets: impl Into<Insets>) {
         self.widget_state.paint_insets = insets.into().nonnegative();
     }
+
+    pub fn submit_command(&mut self, cmd: impl Into<Command>, target: impl Into<Option<Target>>) {
+        self.state.submit_command(cmd.into(), target.into())
+    }
 }
 
 impl PaintCtx<'_, '_, '_> {
@@ -615,6 +619,10 @@ impl PaintCtx<'_, '_, '_> {
             transform: current_transform,
         })
     }
+
+    pub fn viewport_offset(&self) -> Vec2 {
+        self.widget_state.viewport_offset
+    }
 }
 
 impl<'a> ContextState<'a> {
@@ -633,7 +641,7 @@ impl<'a> ContextState<'a> {
         }
     }
 
-    fn submit_command(&mut self, command: Command, target: Option<Target>) {
+    pub(crate) fn submit_command(&mut self, command: Command, target: Option<Target>) {
         let target = target.unwrap_or_else(|| self.window_id.into());
         self.command_queue.push_back((target, command))
     }

--- a/druid/src/env.rs
+++ b/druid/src/env.rs
@@ -86,6 +86,7 @@ struct EnvImpl {
 ///
 /// [`ValueType`]: trait.ValueType.html
 /// [`Env`]: struct.Env.html
+#[derive(Clone)]
 pub struct Key<T> {
     key: &'static str,
     value_type: PhantomData<*const T>,
@@ -116,6 +117,7 @@ pub enum Value {
 ///
 /// [`Key<T>`]: struct.Key.html
 /// [`Env`]: struct.Env.html
+#[derive(Clone)]
 pub enum KeyOrValue<T> {
     Concrete(Value),
     Key(Key<T>),

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -69,7 +69,7 @@ pub use painter::{BackgroundBrush, Painter};
 pub use parse::Parse;
 pub use progress_bar::ProgressBar;
 pub use radio::{Radio, RadioGroup};
-pub use scroll::Scroll;
+pub use scroll::{Scroll, ScrollTo, SCROLL_TO};
 pub use sized_box::SizedBox;
 pub use slider::Slider;
 pub use spinner::Spinner;

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -100,7 +100,7 @@ impl ScrollbarsState {
     }
 }
 
-type ScrollHandler = dyn Fn(&mut EventCtx, &Vec2) -> ();
+type ScrollHandler = dyn Fn(&mut EventCtx, &Vec2);
 
 /// A container that scrolls its contents.
 ///
@@ -167,10 +167,7 @@ impl<T, W: Widget<T>> Scroll<T, W> {
         }
     }
 
-    pub fn add_scroll_handler(
-        &mut self,
-        scroll_handler: impl Fn(&mut EventCtx, &Vec2) -> () + 'static,
-    ) {
+    pub fn add_scroll_handler(&mut self, scroll_handler: impl Fn(&mut EventCtx, &Vec2) + 'static) {
         self.scroll_handlers.push(Box::new(scroll_handler));
     }
 

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -18,7 +18,7 @@ use std::f64::INFINITY;
 use std::time::Duration;
 
 use crate::kurbo::{Affine, Point, Rect, RoundedRect, Size, Vec2};
-use crate::{theme, Selector, Command, Target};
+use crate::{theme, Command, Selector, Target};
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
     RenderContext, TimerToken, UpdateCtx, Widget, WidgetPod,
@@ -184,7 +184,10 @@ impl<T, W: Widget<T>> Scroll<T, W> {
     // Will get called back when the scroll offsets change.
     // This can be used to send commands to other widgets, eg to synchronise
     // scrolling between siblings
-    pub fn add_scroll_handler(&mut self, scroll_handler: impl Fn(&mut SubmitCommand, &Vec2) + 'static) {
+    pub fn add_scroll_handler(
+        &mut self,
+        scroll_handler: impl Fn(&mut SubmitCommand, &Vec2) + 'static,
+    ) {
         self.scroll_handlers.push(Box::new(scroll_handler));
     }
 
@@ -426,14 +429,22 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                             let bounds = self.calc_vertical_bar_bounds(viewport, env);
                             let mouse_y = event.pos.y + self.scroll_offset.y;
                             let delta = mouse_y - bounds.y0 - offset;
-                            self.scroll_by(&mut |command, target| ctx.submit_command(command, target), Vec2::new(0f64, (delta / scale_y).ceil()), size);
+                            self.scroll_by(
+                                &mut |command, target| ctx.submit_command(command, target),
+                                Vec2::new(0f64, (delta / scale_y).ceil()),
+                                size,
+                            );
                         }
                         BarHeldState::Horizontal(offset) => {
                             let scale_x = viewport.width() / self.child_size.width;
                             let bounds = self.calc_horizontal_bar_bounds(viewport, env);
                             let mouse_x = event.pos.x + self.scroll_offset.x;
                             let delta = mouse_x - bounds.x0 - offset;
-                            self.scroll_by(&mut |command, target| ctx.submit_command(command, target), Vec2::new((delta / scale_x).ceil(), 0f64), size);
+                            self.scroll_by(
+                                &mut |command, target| ctx.submit_command(command, target),
+                                Vec2::new((delta / scale_x).ceil(), 0f64),
+                                size,
+                            );
                         }
                         _ => (),
                     }
@@ -514,7 +525,11 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                     scroll_to.x.unwrap_or(self.scroll_offset.x),
                     scroll_to.y.unwrap_or(self.scroll_offset.y),
                 );
-                self.scroll_to(&mut |command, target| ctx.submit_command(command, target), new_pos, size);
+                self.scroll_to(
+                    &mut |command, target| ctx.submit_command(command, target),
+                    new_pos,
+                    size,
+                );
                 ctx.request_paint();
                 ctx.set_handled();
             }
@@ -522,7 +537,11 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
 
         if !ctx.is_handled() {
             if let Event::Wheel(mouse) = event {
-                if self.scroll_by(&mut |command, target| ctx.submit_command(command, target), mouse.wheel_delta, size) {
+                if self.scroll_by(
+                    &mut |command, target| ctx.submit_command(command, target),
+                    mouse.wheel_delta,
+                    size,
+                ) {
                     ctx.request_paint();
                     ctx.set_handled();
                     self.reset_scrollbar_fade(|d| ctx.request_timer(d), env);
@@ -570,7 +589,11 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
         let x = f64::max(self_size.width - size.width, self.scroll_offset.x);
         let y = f64::max(self_size.height - size.height, self.scroll_offset.y);
 
-        self.scroll_to(&mut |command, target| ctx.submit_command(command, target), Vec2::new(x, y), self_size  );
+        self.scroll_to(
+            &mut |command, target| ctx.submit_command(command, target),
+            Vec2::new(x, y),
+            self_size,
+        );
         self_size
     }
 

--- a/druid/src/widget/view_switcher.rs
+++ b/druid/src/widget/view_switcher.rs
@@ -79,9 +79,7 @@ impl<T: Data, U: PartialEq> Widget<T> for ViewSwitcher<T, U> {
             self.active_child = Some(WidgetPod::new((self.child_builder)(&child_id, data, env)));
             self.active_child_id = Some(child_id);
             ctx.children_changed();
-        }
-
-        if let Some(child) = self.active_child.as_mut() {
+        } else if let Some(child) = self.active_child.as_mut() {
             child.update(ctx, data, env);
         }
     }


### PR DESCRIPTION
Druid_table is at https://github.com/rjwittams/druid_table/  for now and has been discussed on Zulip. 

I had to make some small changes to druid to get things working (synchronising the sibling widgets).

- Disabling scroll bars on a Scroll
- Adding a callback to Scroll to emit scroll offsets
- Using a command to set scroll position (including from within layout so it always happens from within event - the callback passes along the evt context to allow sending commands)
- Making some things in environments (Key, KeyOrValue) Clone as I need to copy them around between sibling widgets.
- Added an example I was using to demonstrate synchronising scroll positions