### PR TITLE
ViewSwitcher uses Data instead of PartialEq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - The `WindowHandle::get_dpi` method got replaced by `WindowHandle::get_scale`. ([#904] by [@xStrom])
 - The `WinHandler::size` method now gets a `Size` in display points. ([#904] by [@xStrom])
 - Standardized the type returned by the contexts' `text` methods. ([#996] by [@cmyr])
+- `ViewSwitcher` uses `Data` type constraint instead of `PartialEq`. ([#1112] by [@justinmoon])
 
 ### Removed
 
@@ -257,6 +258,7 @@ Last release without a changelog :(
 [@vkahl]: https://github.com/vkahl
 [@psychon]: https://github.com/psychon
 [@sysint64]: https://github.com/sysint64
+[@justinmoon]: https://github.com/justinmoon
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611

--- a/druid/src/widget/view_switcher.rs
+++ b/druid/src/widget/view_switcher.rs
@@ -32,7 +32,7 @@ pub struct ViewSwitcher<T, U> {
     active_child_id: Option<U>,
 }
 
-impl<T: Data, U: PartialEq> ViewSwitcher<T, U> {
+impl<T: Data, U: Data> ViewSwitcher<T, U> {
     /// Create a new view switcher.
     ///
     /// The `child_picker` closure is called every time the application data changes.
@@ -55,7 +55,7 @@ impl<T: Data, U: PartialEq> ViewSwitcher<T, U> {
     }
 }
 
-impl<T: Data, U: PartialEq> Widget<T> for ViewSwitcher<T, U> {
+impl<T: Data, U: Data> Widget<T> for ViewSwitcher<T, U> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if let Some(child) = self.active_child.as_mut() {
             child.event(ctx, event, data, env);
@@ -75,7 +75,8 @@ impl<T: Data, U: PartialEq> Widget<T> for ViewSwitcher<T, U> {
 
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
         let child_id = (self.child_picker)(data, env);
-        if Some(&child_id) != self.active_child_id.as_ref() {
+        // Safe to unwrap because self.active_child_id should not be empty
+        if !child_id.same(self.active_child_id.as_ref().unwrap()) {
             self.active_child = Some(WidgetPod::new((self.child_builder)(&child_id, data, env)));
             self.active_child_id = Some(child_id);
             ctx.children_changed();


### PR DESCRIPTION
As I was playing around with @Finnerale's wonderful [druid-enums](https://github.com/Finnerale/druid-enums) package, I attempted to create a `ViewSwitcher` based on an enum `MyEnum`. I would get an error:

```
no implementation for `MyEnum == MyEnum`
```

It seemed like I could fix this by recursively deriving or implementing `PartialEq` for every type inside `MyEnum`. But perhaps it makes much more sense to use `Data` for such comparisons, right? So that's what I tried to implement here.