### PR TITLE
Skip update in ViewSwitcher after switching.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@ You can find its changes [documented below](#060---2020-06-01).
 - X11: Support timers. ([#1096] by [@psychon])
 - `EnvScope` now also updates the `Env` during `Widget::lifecycle`. ([#1100] by [@finnerale])
 - `WidgetExt::debug_widget_id` and `debug_paint_layout` now also apply to the widget they are called on. ([#1100] by [@finnerale])
-- X11: Fix X11 errors caused by destroyed windows ([#1103] by [@jneem])
+- X11: Fix X11 errors caused by destroyed windows. ([#1103] by [@jneem])
+- `ViewSwitcher` now skips the update after switching widgets. ([#1113] by [@finnerale])
 
 ### Visual
 

--- a/druid/src/widget/view_switcher.rs
+++ b/druid/src/widget/view_switcher.rs
@@ -80,9 +80,8 @@ impl<T: Data, U: Data> Widget<T> for ViewSwitcher<T, U> {
             self.active_child = Some(WidgetPod::new((self.child_builder)(&child_id, data, env)));
             self.active_child_id = Some(child_id);
             ctx.children_changed();
-        }
-
-        if let Some(child) = self.active_child.as_mut() {
+        // Because the new child has not yet been initialized, we have to skip the update after switching.
+        } else if let Some(child) = self.active_child.as_mut() {
             child.update(ctx, data, env);
         }
     }


### PR DESCRIPTION
As @justinmoon reported in an issue on `druid-enums` [here](https://github.com/Finnerale/druid-enums/issues/2), there was a problem when wrapping a `Matcher` into `ViewSwitcher`. This was caused, because `Matcher` relies on receiving `LifeCycle::WidgetAdded` as first event, and `ViewSwitcher` was violating that rule by calling update directly on a newly created widget.

I'm not perfectly sure yet, how those things are interacting with each other and what other problems we might have here, but this change makes sense to me regardless of other problems we might have.

`ViewSwitcher` caused the following warning before (can be seen in the `view_switcher` example):
```
old_data missing in WidgetId(27), skipping update.
```