### PR TITLE
Adds a hook for intercepting close requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - Re-export `druid_shell::Scalable` under `druid` namespace. ([#1075] by [@ForLoveOfCats])
 - `TextBox` now supports ctrl and shift hotkeys. ([#1076] by [@vkahl])
 - Added selection text color to textbox. ([#1093] by [@sysint64])
+- Close requests from the shell can now be intercepted ([#1118] by [@jneem])
 
 ### Changed
 
@@ -45,7 +46,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - `ViewSwitcher` now skips the update after switching widgets. ([#1113] by [@finnerale])
 - Key and KeyOrValue derive Clone ([#1119] by [@rjwittams])
 - Allow submit_command from the layout method in Widgets ([#1119] by [@rjwittams])
--  Allow derivation of lenses for generic types ([#1120]) by [@rjwittams])
+- Allow derivation of lenses for generic types ([#1120]) by [@rjwittams])
 
 ### Visual
 
@@ -382,6 +383,7 @@ Last release without a changelog :(
 [#1093]: https://github.com/linebender/druid/pull/1093
 [#1100]: https://github.com/linebender/druid/pull/1100
 [#1103]: https://github.com/linebender/druid/pull/1103
+[#1118]: https://github.com/linebender/druid/pull/1118
 [#1119]: https://github.com/linebender/druid/pull/1119
 [#1120]: https://github.com/linebender/druid/pull/1120
 

--- a/druid-shell/examples/invalidate.rs
+++ b/druid-shell/examples/invalidate.rs
@@ -74,6 +74,10 @@ impl WinHandler for InvalidateTest {
         }
     }
 
+    fn request_close(&mut self) {
+        self.handle.close();
+    }
+
     fn destroy(&mut self) {
         Application::global().quit()
     }

--- a/druid-shell/examples/perftest.rs
+++ b/druid-shell/examples/perftest.rs
@@ -123,6 +123,10 @@ impl WinHandler for PerfTest {
         self.size = size;
     }
 
+    fn request_close(&mut self) {
+        self.handle.close();
+    }
+
     fn destroy(&mut self) {
         Application::global().quit()
     }

--- a/druid-shell/examples/quit.rs
+++ b/druid-shell/examples/quit.rs
@@ -1,0 +1,89 @@
+// Copyright 2020 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+
+use druid_shell::kurbo::{Line, Rect, Size};
+use druid_shell::piet::{Color, RenderContext};
+
+use druid_shell::{Application, HotKey, Menu, SysMods, WinHandler, WindowBuilder, WindowHandle};
+
+const BG_COLOR: Color = Color::rgb8(0x27, 0x28, 0x22);
+const FG_COLOR: Color = Color::rgb8(0xf0, 0xf0, 0xea);
+
+#[derive(Default)]
+struct QuitState {
+    quit_count: u32,
+    size: Size,
+    handle: WindowHandle,
+}
+
+impl WinHandler for QuitState {
+    fn connect(&mut self, handle: &WindowHandle) {
+        self.handle = handle.clone();
+    }
+
+    fn paint(&mut self, piet: &mut piet_common::Piet, _: Rect) -> bool {
+        let rect = self.size.to_rect();
+        piet.fill(rect, &BG_COLOR);
+        piet.stroke(Line::new((10.0, 50.0), (90.0, 90.0)), &FG_COLOR, 1.0);
+        false
+    }
+
+    fn size(&mut self, size: Size) {
+        self.size = size;
+    }
+
+    fn request_close(&mut self) {
+        self.quit_count += 1;
+        if self.quit_count >= 5 {
+            self.handle.close();
+        } else {
+            log::info!("Don't wanna quit");
+        }
+    }
+
+    fn destroy(&mut self) {
+        Application::global().quit()
+    }
+
+    fn as_any(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+fn main() {
+    simple_logger::init().expect("Failed to init simple logger");
+    let app = Application::new().unwrap();
+    let mut file_menu = Menu::new();
+    file_menu.add_item(
+        0x100,
+        "E&xit",
+        Some(&HotKey::new(SysMods::Cmd, "q")),
+        true,
+        false,
+    );
+    let mut menubar = Menu::new();
+    menubar.add_dropdown(Menu::new(), "Application", true);
+
+    let mut builder = WindowBuilder::new(app.clone());
+    builder.set_handler(Box::new(QuitState::default()));
+    builder.set_title("Quit example");
+    builder.set_menu(menubar);
+
+    let window = builder.build().unwrap();
+    window.show();
+
+    app.run(None);
+}

--- a/druid-shell/examples/shello.rs
+++ b/druid-shell/examples/shello.rs
@@ -96,6 +96,10 @@ impl WinHandler for HelloState {
         self.size = size;
     }
 
+    fn request_close(&mut self) {
+        self.handle.close();
+    }
+
     fn destroy(&mut self) {
         Application::global().quit()
     }

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -396,6 +396,16 @@ pub trait WinHandler {
     #[allow(unused_variables)]
     fn got_focus(&mut self) {}
 
+    /// Called when the shell requests to close the window, for example because the user clicked
+    /// the little "X" in the titlebar.
+    ///
+    /// If you want to actually close the window in response to this request, call
+    /// [`WindowHandle::close`]. If you don't implement this method, clicking the titlebar "X" will
+    /// have no effect.
+    ///
+    /// [`WindowHandle::close`]: struct.WindowHandle.html#tymethod.close
+    fn request_close(&mut self) {}
+
     /// Called when the window is being destroyed. Note that this happens
     /// earlier in the sequence than drop (at WM_DESTROY, while the latter is
     /// WM_NCDESTROY).


### PR DESCRIPTION
In druid-shell, a close request from the system will result in a call
to `WinHandler::request_close` instead of just immediately destroying
the window.

In druid, CLOSE_WINDOW commands are passed to the AppDelegate and down
the widget tree. Only if they are unhandled does the window get closed.

Edit: so far the druid-shell part is only implemented for gtk. Other platforms still close the window unconditionally.