### PR TITLE
Adds support for a lens(ignore) attribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - Selection text color to textbox. ([#1093] by [@sysint64])
 - `BoxConstraints::UNBOUNDED` constant. ([#1126] by [@danieldulaney]) 
 - Close requests from the shell can now be intercepted ([#1118] by [@jneem])
+- The Lens derive now supports an `ignore` attribute. ([#1133] by [@jneem])
 
 ### Changed
 
@@ -388,6 +389,7 @@ Last release without a changelog :(
 [#1119]: https://github.com/linebender/druid/pull/1119
 [#1120]: https://github.com/linebender/druid/pull/1120
 [#1126]: https://github.com/linebender/druid/pull/1120
+[#1133]: https://github.com/linebender/druid/pull/1133
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master
 [0.6.0]: https://github.com/linebender/druid/compare/v0.5.0...v0.6.0

--- a/druid-derive/src/attr.rs
+++ b/druid-derive/src/attr.rs
@@ -30,9 +30,9 @@ const LENS_NAME_OVERRIDE_ATTR_PATH: &str = "name";
 
 /// The fields for a struct or an enum variant.
 #[derive(Debug)]
-pub struct Fields {
+pub struct Fields<Attrs> {
     pub kind: FieldKind,
-    fields: Vec<Field>,
+    fields: Vec<Field<Attrs>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -60,18 +60,28 @@ impl FieldIdent {
 }
 
 #[derive(Debug)]
-pub struct Field {
+pub struct Field<Attrs> {
     pub ident: FieldIdent,
     pub ty: syn::Type,
 
+    pub attrs: Attrs,
+}
+
+#[derive(Debug)]
+pub struct DataAttrs {
     /// `true` if this field should be ignored.
     pub ignore: bool,
     pub same_fn: Option<ExprPath>,
-    pub lens_name_override: Option<Ident>,
-    //TODO: more attrs here
 }
 
-impl Fields {
+#[derive(Debug)]
+pub struct LensAttrs {
+    /// `true` if this field should be ignored.
+    pub ignore: bool,
+    pub lens_name_override: Option<Ident>,
+}
+
+impl Fields<DataAttrs> {
     pub fn parse_ast(fields: &syn::Fields) -> Result<Self, Error> {
         let kind = match fields {
             syn::Fields::Named(_) => FieldKind::Named,
@@ -81,22 +91,41 @@ impl Fields {
         let fields = fields
             .iter()
             .enumerate()
-            .map(|(i, field)| Field::parse_ast(field, i))
+            .map(|(i, field)| Field::<DataAttrs>::parse_ast(field, i))
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Fields { kind, fields })
     }
+}
 
+impl Fields<LensAttrs> {
+    pub fn parse_ast(fields: &syn::Fields) -> Result<Self, Error> {
+        let kind = match fields {
+            syn::Fields::Named(_) => FieldKind::Named,
+            syn::Fields::Unnamed(_) | syn::Fields::Unit => FieldKind::Unnamed,
+        };
+
+        let fields = fields
+            .iter()
+            .enumerate()
+            .map(|(i, field)| Field::<LensAttrs>::parse_ast(field, i))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Fields { kind, fields })
+    }
+}
+
+impl<Attrs> Fields<Attrs> {
     pub fn len(&self) -> usize {
         self.fields.len()
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &Field> {
+    pub fn iter(&self) -> impl Iterator<Item = &Field<Attrs>> {
         self.fields.iter()
     }
 }
 
-impl Field {
+impl Field<DataAttrs> {
     pub fn parse_ast(field: &syn::Field, index: usize) -> Result<Self, Error> {
         let ident = match field.ident.as_ref() {
             Some(ident) => FieldIdent::Named(ident.to_string().trim_start_matches("r#").to_owned()),
@@ -107,7 +136,6 @@ impl Field {
 
         let mut ignore = false;
         let mut same_fn = None;
-        let mut lens_name_override = None;
 
         for attr in field.attrs.iter() {
             if attr.path.is_ident(BASE_DRUID_DEPRECATED_ATTR_PATH) {
@@ -152,11 +180,61 @@ impl Field {
                         ));
                     }
                 }
+            }
+        }
+        Ok(Field {
+            ident,
+            ty,
+            attrs: DataAttrs { ignore, same_fn },
+        })
+    }
+
+    /// The tokens to be used as the function for 'same'.
+    pub fn same_fn_path_tokens(&self) -> TokenStream {
+        match self.attrs.same_fn {
+            Some(ref f) => quote!(#f),
+            None => {
+                let span = Span::call_site();
+                quote_spanned!(span=> druid::Data::same)
+            }
+        }
+    }
+}
+
+impl Field<LensAttrs> {
+    pub fn parse_ast(field: &syn::Field, index: usize) -> Result<Self, Error> {
+        let ident = match field.ident.as_ref() {
+            Some(ident) => FieldIdent::Named(ident.to_string().trim_start_matches("r#").to_owned()),
+            None => FieldIdent::Unnamed(index),
+        };
+
+        let ty = field.ty.clone();
+
+        let mut ignore = false;
+        let mut lens_name_override = None;
+
+        for attr in field.attrs.iter() {
+            if attr.path.is_ident(BASE_DRUID_DEPRECATED_ATTR_PATH) {
+                panic!(
+                    "The 'druid' attribute has been replaced with separate \
+                    'lens' and 'data' attributes.",
+                );
             } else if attr.path.is_ident(BASE_LENS_ATTR_PATH) {
                 match attr.parse_meta()? {
                     Meta::List(meta) => {
                         for nested in meta.nested.iter() {
                             match nested {
+                                NestedMeta::Meta(Meta::Path(path))
+                                    if path.is_ident(IGNORE_ATTR_PATH) =>
+                                {
+                                    if ignore {
+                                        return Err(Error::new(
+                                            nested.span(),
+                                            "Duplicate attribute",
+                                        ));
+                                    }
+                                    ignore = true;
+                                }
                                 NestedMeta::Meta(Meta::NameValue(meta))
                                     if meta.path.is_ident(LENS_NAME_OVERRIDE_ATTR_PATH) =>
                                 {
@@ -174,7 +252,7 @@ impl Field {
                     other => {
                         return Err(Error::new(
                             other.span(),
-                            "Expected attribute list (the form #[data(one, two)])",
+                            "Expected attribute list (the form #[lens(one, two)])",
                         ));
                     }
                 }
@@ -183,12 +261,15 @@ impl Field {
         Ok(Field {
             ident,
             ty,
-            ignore,
-            same_fn,
-            lens_name_override,
+            attrs: LensAttrs {
+                ignore,
+                lens_name_override,
+            },
         })
     }
+}
 
+impl<Attrs> Field<Attrs> {
     pub fn ident_tokens(&self) -> TokenTree {
         match self.ident {
             FieldIdent::Named(ref s) => Ident::new(&s, Span::call_site()).into(),
@@ -200,17 +281,6 @@ impl Field {
         match self.ident {
             FieldIdent::Named(ref s) => s.clone(),
             FieldIdent::Unnamed(num) => num.to_string(),
-        }
-    }
-
-    /// The tokens to be used as the function for 'same'.
-    pub fn same_fn_path_tokens(&self) -> TokenStream {
-        match self.same_fn {
-            Some(ref f) => quote!(#f),
-            None => {
-                let span = Span::call_site();
-                quote_spanned!(span=> druid::Data::same)
-            }
         }
     }
 }

--- a/druid-derive/src/lib.rs
+++ b/druid-derive/src/lib.rs
@@ -34,10 +34,34 @@ pub fn derive_data(input: TokenStream) -> TokenStream {
         .into()
 }
 
-/// Generates lenses to access the fields of a struct
+/// Generates lenses to access the fields of a struct.
 ///
 /// An associated constant is defined on the struct for each field,
 /// having the same name as the field.
+///
+/// This macro supports a `lens` field attribute with the following arguments:
+///
+/// - `#[lens(ignore)]` skips creating a lens for one field.
+/// - `#[lens(name="foo")]` gives the lens the specified name (instead of the default, which is to
+///    create a lens with the same name as the field).
+///
+/// # Example
+///
+/// ```rust
+/// #[derive(Lens)]
+/// struct State {
+///     // The Lens derive will create a `State::text` constant implementing
+///     // `druid::Lens<State, String>`
+///     text: String,
+///     // The Lens derive will create a `State::lens_number` constant implementing
+///     // `druid::Lens<State, f64>`
+///     #[lens(name = "lens_number")]
+///     number: f64,
+///     // The Lens derive won't create anything for this field.
+///     #[lens(ignore)]
+///     blah: f64,
+/// }
+/// ```
 #[proc_macro_derive(Lens, attributes(lens))]
 pub fn derive_lens(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as syn::DeriveInput);

--- a/druid-derive/src/lib.rs
+++ b/druid-derive/src/lib.rs
@@ -26,6 +26,30 @@ use proc_macro::TokenStream;
 use syn::parse_macro_input;
 
 /// Generates implementations of the `Data` trait.
+///
+/// This macro supports a `data` field attribute with the following arguments:
+///
+/// - `#[data(ignore)]` makes the generated `Data::same` function skip comparing this field.
+/// - `#[data(same_fn="foo")]` uses the function `foo` for comparing this field. `foo` should
+///    be the name of a function with signature `fn(&T, &T) -> bool`, where `T` is the type of
+///    the field.
+///
+/// # Example
+///
+/// ```rust
+/// use druid_derive::Data;
+///
+/// #[derive(Clone, Data)]
+/// struct State {
+///     number: f64,
+///     // `Vec` doesn't implement `Data`, so we need to either ignore it or supply a `same_fn`.
+///     #[data(same_fn="PartialEq::eq")]
+///     indices: Vec<usize>,
+///     // This is just some sort of cache; it isn't important for sameness comparison.
+///     #[data(ignore)]
+///     cached_indices: Vec<usize>,
+/// }
+/// ```
 #[proc_macro_derive(Data, attributes(data))]
 pub fn derive_data(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as syn::DeriveInput);
@@ -48,6 +72,8 @@ pub fn derive_data(input: TokenStream) -> TokenStream {
 /// # Example
 ///
 /// ```rust
+/// use druid_derive::Lens;
+///
 /// #[derive(Lens)]
 /// struct State {
 ///     // The Lens derive will create a `State::text` constant implementing

--- a/druid-derive/tests/with_lens.rs
+++ b/druid-derive/tests/with_lens.rs
@@ -31,7 +31,7 @@ fn derive_lens() {
 
     assert_eq!(state.text, "2.0");
     approx_eq!(f64, state.number, 2.0);
-    assert_eq!(state.ignored, 2.0);
+    approx_eq!(f64, state.ignored, 2.0);
 }
 
 #[test]

--- a/druid-derive/tests/with_lens.rs
+++ b/druid-derive/tests/with_lens.rs
@@ -10,11 +10,14 @@ fn derive_lens() {
         text: String,
         #[lens(name = "lens_number")]
         number: f64,
+        #[lens(ignore)]
+        ignored: f64,
     }
 
     let mut state = State {
         text: "1.0".into(),
         number: 1.0,
+        ignored: 2.0,
     };
 
     let text_lens = State::text;
@@ -28,6 +31,7 @@ fn derive_lens() {
 
     assert_eq!(state.text, "2.0");
     approx_eq!(f64, state.number, 2.0);
+    assert_eq!(state.ignored, 2.0);
 }
 
 #[test]


### PR DESCRIPTION
This isn't terribly important because `#[len(name="_ignore")]` is a decent work-around, but having an explicit ignore attribute feels cleaner to me. Also, I think factoring out the data attributes and the lens attributes is something we'll want eventually anyway.