### PR TITLE
Add &mut self versions of container style methods.

### DIFF
--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -46,7 +46,7 @@ impl<T: Data> Container<T> {
         }
     }
 
-    /// Set the background for this widget.
+    /// Builder-style method for setting the background for this widget.
     ///
     /// This can be passed anything which can be represented by a [`BackgroundBrush`];
     /// noteably, it can be any [`Color`], a [`Key<Color>`] resolvable in the [`Env`],
@@ -58,11 +58,26 @@ impl<T: Data> Container<T> {
     /// [`Env`]: ../struct.Env.html
     /// [`Painter`]: struct.Painter.html
     pub fn background(mut self, brush: impl Into<BackgroundBrush<T>>) -> Self {
-        self.background = Some(brush.into());
+        self.set_background(brush);
         self
     }
 
-    /// Paint a border around the widget with a color and width.
+    /// Set the background for this widget.
+    ///
+    /// This can be passed anything which can be represented by a [`BackgroundBrush`];
+    /// noteably, it can be any [`Color`], a [`Key<Color>`] resolvable in the [`Env`],
+    /// any gradient, or a fully custom [`Painter`] widget.
+    ///
+    /// [`BackgroundBrush`]: ../enum.BackgroundBrush.html
+    /// [`Color`]: ../struct.Color.thml
+    /// [`Key<Color>`]: ../struct.Key.thml
+    /// [`Env`]: ../struct.Env.html
+    /// [`Painter`]: struct.Painter.html
+    pub fn set_background(&mut self, brush: impl Into<BackgroundBrush<T>>) {
+        self.background = Some(brush.into());
+    }
+
+    /// Builder-style method for painting a border around the widget with a color and width.
     ///
     /// Arguments can be either concrete values, or a [`Key`] of the respective
     /// type.
@@ -73,17 +88,36 @@ impl<T: Data> Container<T> {
         color: impl Into<KeyOrValue<Color>>,
         width: impl Into<KeyOrValue<f64>>,
     ) -> Self {
+        self.set_border(color, width);
+        self
+    }
+
+    /// Paint a border around the widget with a color and width.
+    ///
+    /// Arguments can be either concrete values, or a [`Key`] of the respective
+    /// type.
+    ///
+    /// [`Key`]: struct.Key.html
+    pub fn set_border(
+        &mut self,
+        color: impl Into<KeyOrValue<Color>>,
+        width: impl Into<KeyOrValue<f64>>,
+    ) {
         self.border = Some(BorderStyle {
             color: color.into(),
             width: width.into(),
         });
+    }
+
+    /// Builder style method for rounding off corners of this container by setting a corner radius
+    pub fn rounded(mut self, radius: impl Into<KeyOrValue<f64>>) -> Self {
+        self.set_rounded(radius);
         self
     }
 
     /// Round off corners of this container by setting a corner radius
-    pub fn rounded(mut self, radius: impl Into<KeyOrValue<f64>>) -> Self {
+    pub fn set_rounded(&mut self, radius: impl Into<KeyOrValue<f64>>) {
         self.corner_radius = radius.into();
-        self
     }
 
     #[cfg(test)]


### PR DESCRIPTION
I needed these in a case where I wanted to update the style through the &mut reference in `event` and `lifecycle`, so I didn't have the ability to move the container and call its current methods.