### PR TITLE
Temp fix for stepper triggering multiple times with double/triple click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - Allow submit_command from the layout method in Widgets ([#1119] by [@rjwittams])
 - Allow derivation of lenses for generic types ([#1120]) by [@rjwittams])
 - Switch widget: Toggle animation being window refresh rate dependent ([#1145] by [@ForLoveOfCats])
+- Stepper widget: Double/triple clicks triggering increment/decrement multiple times. ([#1154] by [@ForLoveOfCats])
 
 ### Visual
 
@@ -399,6 +400,7 @@ Last release without a changelog :(
 [#1143]: https://github.com/linebender/druid/pull/1143
 [#1145]: https://github.com/linebender/druid/pull/1145
 [#1152]: https://github.com/linebender/druid/pull/1152
+[#1154]: https://github.com/linebender/druid/pull/1154
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master
 [0.6.0]: https://github.com/linebender/druid/compare/v0.5.0...v0.6.0

--- a/druid/src/widget/stepper.rs
+++ b/druid/src/widget/stepper.rs
@@ -202,17 +202,19 @@ impl Widget<f64> for Stepper {
             Event::MouseDown(mouse) => {
                 ctx.set_active(true);
 
-                if mouse.pos.y > height / 2. {
-                    self.decrease_active = true;
-                    self.decrement(data);
-                } else {
-                    self.increase_active = true;
-                    self.increment(data);
+                if mouse.count == 1 {
+                    if mouse.pos.y > height / 2. {
+                        self.decrease_active = true;
+                        self.decrement(data);
+                    } else {
+                        self.increase_active = true;
+                        self.increment(data);
+                    }
+
+                    self.timer_id = ctx.request_timer(STEPPER_REPEAT_DELAY);
+
+                    ctx.request_paint();
                 }
-
-                self.timer_id = ctx.request_timer(STEPPER_REPEAT_DELAY);
-
-                ctx.request_paint();
             }
             Event::MouseUp(_) => {
                 ctx.set_active(false);


### PR DESCRIPTION
Closes https://github.com/linebender/druid/issues/1029

A better solution would be to implement https://github.com/linebender/druid/issues/859 as then multi-click events would only fire one mouse down event but until someone does that (which will take some work with the different platforms which will be the tricky part) it made sense to handle the current situation a bit more gracefully. I'm on Linux so this is only tested on the GTK and x11 shells so it would be great if someone could test this on Windows and macOS. Something to note is that the x11 behavior appeared to already behave correctly but that seems to be because it doesn't implement multi-click at all [see here](https://github.com/linebender/druid/blob/master/druid-shell/src/platform/x11/window.rs#L825).