### PR TITLE
Move AnimFrame from lifecycle to event.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - Replaced uses of `Option<Target>` with the new `Target::Auto`. ([#1185] by [@finnerale])
 - Moved `Target` parameter from `submit_command` to `Command::new` and `Command::to`. ([#1185] by [@finnerale])
 - `Movement::RightOfLine` to `Movement::NextLineBreak`, and `Movement::LeftOfLine` to `Movement::PrecedingLineBreak`. ([#1092] by [@sysint64])
+- `AnimFrame` was moved from `lifecycle` to `event` ([#1155] by [@jneem])
 
 ### Deprecated
 
@@ -414,6 +415,7 @@ Last release without a changelog :(
 [#1145]: https://github.com/linebender/druid/pull/1145
 [#1151]: https://github.com/linebender/druid/pull/1151
 [#1152]: https://github.com/linebender/druid/pull/1152
+[#1155]: https://github.com/linebender/druid/pull/1155
 [#1157]: https://github.com/linebender/druid/pull/1157
 [#1171]: https://github.com/linebender/druid/pull/1171
 [#1172]: https://github.com/linebender/druid/pull/1172

--- a/druid/examples/anim.rs
+++ b/druid/examples/anim.rs
@@ -26,21 +26,23 @@ struct AnimWidget {
 
 impl Widget<u32> for AnimWidget {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, _data: &mut u32, _env: &Env) {
-        if let Event::MouseDown(_) = event {
-            self.t = 0.0;
-            ctx.request_anim_frame();
+        match event {
+            Event::MouseDown(_) => {
+                self.t = 0.0;
+                ctx.request_anim_frame();
+            }
+            Event::AnimFrame(interval) => {
+                ctx.request_paint();
+                self.t += (*interval as f64) * 1e-9;
+                if self.t < 1.0 {
+                    ctx.request_anim_frame();
+                }
+            }
+            _ => (),
         }
     }
 
-    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &u32, _env: &Env) {
-        if let LifeCycle::AnimFrame(interval) = event {
-            ctx.request_paint();
-            self.t += (*interval as f64) * 1e-9;
-            if self.t < 1.0 {
-                ctx.request_anim_frame();
-            }
-        }
-    }
+    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &u32, _env: &Env) {}
 
     fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: &u32, _data: &u32, _env: &Env) {}
 

--- a/druid/examples/invalidation.rs
+++ b/druid/examples/invalidation.rs
@@ -93,24 +93,23 @@ impl Widget<Vector<Circle>> for CircleView {
                 });
             }
             ctx.request_anim_frame();
-        }
-    }
-
-    fn lifecycle(
-        &mut self,
-        ctx: &mut LifeCycleCtx,
-        ev: &LifeCycle,
-        data: &Vector<Circle>,
-        _env: &Env,
-    ) {
-        if let LifeCycle::AnimFrame(_) = ev {
-            for c in data {
+        } else if let Event::AnimFrame(_) = ev {
+            for c in &*data {
                 ctx.request_paint_rect(kurbo::Circle::new(c.pos, RADIUS).bounding_box());
             }
             if !data.is_empty() {
                 ctx.request_anim_frame();
             }
         }
+    }
+
+    fn lifecycle(
+        &mut self,
+        _ctx: &mut LifeCycleCtx,
+        _ev: &LifeCycle,
+        _data: &Vector<Circle>,
+        _env: &Env,
+    ) {
     }
 
     fn update(

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -689,6 +689,11 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                     false
                 }
             }
+            Event::AnimFrame(_) => {
+                let r = self.state.request_anim;
+                self.state.request_anim = false;
+                r
+            }
             Event::KeyDown(_) => self.state.has_focus,
             Event::KeyUp(_) => self.state.has_focus,
             Event::Paste(_) => self.state.has_focus,
@@ -786,11 +791,6 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                     true
                 }
             },
-            LifeCycle::AnimFrame(_) => {
-                let r = self.state.request_anim;
-                self.state.request_anim = false;
-                r
-            }
             LifeCycle::WidgetAdded => {
                 assert!(self.old_data.is_none());
 

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -113,6 +113,11 @@ pub enum Event {
     /// On the first frame when transitioning from idle to animating, `interval`
     /// will be 0. (This logic is presently per-window but might change to
     /// per-widget to make it more consistent). Otherwise it is in nanoseconds.
+    ///
+    /// The `paint` method will be called shortly after this event is finished.
+    /// As a result, you should try to avoid doing anything computationally
+    /// intensive in response to an `AnimFrame` event: it might make Druid miss
+    /// the monitor's refresh, causing lag or jerky animation.
     AnimFrame(u64),
     /// Called with an arbitrary [`Command`], submitted from elsewhere in
     /// the application.

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -108,6 +108,12 @@ pub enum Event {
     ///
     /// [`EventCtx::request_timer()`]: struct.EventCtx.html#method.request_timer
     Timer(TimerToken),
+    /// Called at the beginning of a new animation frame.
+    ///
+    /// On the first frame when transitioning from idle to animating, `interval`
+    /// will be 0. (This logic is presently per-window but might change to
+    /// per-widget to make it more consistent). Otherwise it is in nanoseconds.
+    AnimFrame(u64),
     /// Called with an arbitrary [`Command`], submitted from elsewhere in
     /// the application.
     ///
@@ -182,12 +188,6 @@ pub enum LifeCycle {
     /// [`Rect`]: struct.Rect.html
     /// [`WidgetPod::set_layout_rect`]: struct.WidgetPod.html#method.set_layout_rect
     Size(Size),
-    /// Called at the beginning of a new animation frame.
-    ///
-    /// On the first frame when transitioning from idle to animating, `interval`
-    /// will be 0. (This logic is presently per-window but might change to
-    /// per-widget to make it more consistent). Otherwise it is in nanoseconds.
-    AnimFrame(u64),
     /// Called when the "hot" status changes.
     ///
     /// This will always be called _before_ the event that triggered it; that is,

--- a/druid/src/widget/spinner.rs
+++ b/druid/src/widget/spinner.rs
@@ -67,19 +67,19 @@ impl Default for Spinner {
 }
 
 impl<T: Data> Widget<T> for Spinner {
-    fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut T, _env: &Env) {}
-
-    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &T, _env: &Env) {
-        if let LifeCycle::WidgetAdded = event {
-            ctx.request_anim_frame();
-            ctx.request_paint();
-        }
-
-        if let LifeCycle::AnimFrame(interval) = event {
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, _data: &mut T, _env: &Env) {
+        if let Event::AnimFrame(interval) = event {
             self.t += (*interval as f64) * 1e-9;
             if self.t >= 1.0 {
                 self.t = 0.0;
             }
+            ctx.request_anim_frame();
+            ctx.request_paint();
+        }
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &T, _env: &Env) {
+        if let LifeCycle::WidgetAdded = event {
             ctx.request_anim_frame();
             ctx.request_paint();
         }

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -297,7 +297,6 @@ impl<T: Data> Inner<T> {
             win.prepare_paint(&mut self.command_queue, &mut self.data, &self.env);
         }
         self.do_update();
-        self.invalidate_and_finalize();
     }
 
     fn paint(&mut self, window_id: WindowId, piet: &mut Piet, invalid: &Region) {

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -294,8 +294,9 @@ impl<T: Data> Inner<T> {
 
     fn prepare_paint(&mut self, window_id: WindowId) {
         if let Some(win) = self.windows.get_mut(window_id) {
-            win.prepare_paint(&mut self.command_queue, &self.data, &self.env);
+            win.prepare_paint(&mut self.command_queue, &mut self.data, &self.env);
         }
+        self.do_update();
         self.invalidate_and_finalize();
     }
 

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -307,14 +307,19 @@ impl<T: Data> Window<T> {
         let last = self.last_anim.take();
         let elapsed_ns = last.map(|t| now.duration_since(t).as_nanos()).unwrap_or(0) as u64;
 
-        if self.wants_animation_frame() {
-            self.event(queue, Event::AnimFrame(elapsed_ns), data, env);
-        }
-
         if self.root.state().needs_layout {
             self.layout(queue, data, env);
         }
 
+        // Here, `self.wants_animation_frame()` refers to the animation frame that is currently
+        // being prepared for. (This is relying on the fact that `self.layout()` can't request
+        // an animation frame.)
+        if self.wants_animation_frame() {
+            self.event(queue, Event::AnimFrame(elapsed_ns), data, env);
+        }
+
+        // Here, `self.wants_animation_frame()` is true if we want *another* animation frame after
+        // the current one. (It got modified in the call to `self.event` above.)
         if self.wants_animation_frame() {
             self.last_anim = Some(now);
         }

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -83,9 +83,9 @@ impl<T> Window<T> {
 }
 
 impl<T: Data> Window<T> {
-    /// `true` iff any child requested an animation frame during the last `AnimFrame` event.
+    /// `true` iff any child requested an animation frame since the last `AnimFrame` event.
     pub(crate) fn wants_animation_frame(&self) -> bool {
-        self.last_anim.is_some()
+        self.root.state().request_anim
     }
 
     pub(crate) fn focus_chain(&self) -> &[WidgetId] {
@@ -150,9 +150,6 @@ impl<T: Data> Window<T> {
         self.timers.extend_drain(&mut widget_state.timers);
 
         // If we need a new paint pass, make sure druid-shell knows it.
-        if widget_state.request_anim && self.last_anim.is_none() {
-            self.last_anim = Some(Instant::now());
-        }
         if self.wants_animation_frame() {
             self.handle.request_anim_frame();
         }
@@ -263,21 +260,6 @@ impl<T: Data> Window<T> {
         env: &Env,
         process_commands: bool,
     ) {
-        // for AnimFrame, the event the window receives doesn't have the correct
-        // elapsed time; we calculate it here.
-        let now = Instant::now();
-        let substitute_event = if let LifeCycle::AnimFrame(_) = event {
-            // TODO: this calculation uses wall-clock time of the paint call, which
-            // potentially has jitter.
-            //
-            // See https://github.com/linebender/druid/issues/85 for discussion.
-            let last = self.last_anim.take();
-            let elapsed_ns = last.map(|t| now.duration_since(t).as_nanos()).unwrap_or(0) as u64;
-            Some(LifeCycle::AnimFrame(elapsed_ns))
-        } else {
-            None
-        };
-
         let mut widget_state = WidgetState::new(self.root.id(), Some(self.size));
         let mut state =
             ContextState::new::<T>(queue, &self.ext_handle, &self.handle, self.id, self.focus);
@@ -285,13 +267,7 @@ impl<T: Data> Window<T> {
             state: &mut state,
             widget_state: &mut widget_state,
         };
-        let event = substitute_event.as_ref().unwrap_or(event);
         self.root.lifecycle(&mut ctx, event, data, env);
-
-        if substitute_event.is_some() && ctx.widget_state.request_anim {
-            self.last_anim = Some(now);
-        }
-
         self.post_event_processing(&mut widget_state, queue, data, env, process_commands);
     }
 
@@ -322,12 +298,24 @@ impl<T: Data> Window<T> {
     }
 
     /// Get ready for painting, by doing layout and sending an `AnimFrame` event.
-    pub(crate) fn prepare_paint(&mut self, queue: &mut CommandQueue, data: &T, env: &Env) {
-        // FIXME: only do AnimFrame if root has requested_anim?
-        self.lifecycle(queue, &LifeCycle::AnimFrame(0), data, env, true);
-
+    pub(crate) fn prepare_paint(&mut self, queue: &mut CommandQueue, data: &mut T, env: &Env) {
         if self.root.state().needs_layout {
             self.layout(queue, data, env);
+        }
+
+        let now = Instant::now();
+        // TODO: this calculation uses wall-clock time of the paint call, which
+        // potentially has jitter.
+        //
+        // See https://github.com/linebender/druid/issues/85 for discussion.
+        let last = self.last_anim.take();
+        let elapsed_ns = last.map(|t| now.duration_since(t).as_nanos()).unwrap_or(0) as u64;
+
+        if self.wants_animation_frame() {
+            self.event(queue, Event::AnimFrame(elapsed_ns), data, env);
+        }
+        if self.wants_animation_frame() {
+            self.last_anim = Some(now);
         }
     }
 

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -299,10 +299,6 @@ impl<T: Data> Window<T> {
 
     /// Get ready for painting, by doing layout and sending an `AnimFrame` event.
     pub(crate) fn prepare_paint(&mut self, queue: &mut CommandQueue, data: &mut T, env: &Env) {
-        if self.root.state().needs_layout {
-            self.layout(queue, data, env);
-        }
-
         let now = Instant::now();
         // TODO: this calculation uses wall-clock time of the paint call, which
         // potentially has jitter.
@@ -314,6 +310,11 @@ impl<T: Data> Window<T> {
         if self.wants_animation_frame() {
             self.event(queue, Event::AnimFrame(elapsed_ns), data, env);
         }
+
+        if self.root.state().needs_layout {
+            self.layout(queue, data, env);
+        }
+
         if self.wants_animation_frame() {
             self.last_anim = Some(now);
         }


### PR DESCRIPTION
Fixes #1060.

I'm sure there's a good reason for the current placement of AnimFrame, so I definitely expect pushback on this; I'm mostly just exploring possible solutions for #1060, and this seemed like the easiest.

I think there is part of this patch that is worth salvaging in any case: it simplifies the handling of `last_anim` in window.rs, and it makes the behavior of `AnimFrame` match the documentation, even in the case that the animation is first requested in the event context (previously, that would lead to `AnimFrame` having a non-zero initial value).