### PR TITLE
Windows: pass the expanded region to the paint call

### DIFF
--- a/druid-shell/examples/invalidate.rs
+++ b/druid-shell/examples/invalidate.rs
@@ -14,12 +14,12 @@
 
 use std::any::Any;
 
-use std::time::{Duration, Instant};
+use std::time::{Instant};
 
 use druid_shell::kurbo::{Point, Rect, Size};
 use druid_shell::piet::{Color, Piet, RenderContext};
 
-use druid_shell::{Application, Region, TimerToken, WinHandler, WindowBuilder, WindowHandle};
+use druid_shell::{Application, Region, WinHandler, WindowBuilder, WindowHandle};
 
 struct InvalidateTest {
     handle: WindowHandle,
@@ -27,6 +27,7 @@ struct InvalidateTest {
     start_time: Instant,
     color: Color,
     rect: Rect,
+    cursor: Rect,
 }
 
 impl InvalidateTest {
@@ -43,25 +44,37 @@ impl InvalidateTest {
         self.rect.x1 = (self.rect.x1 + 5.5) % self.size.width;
         self.rect.y0 = (self.rect.y0 + 3.0) % self.size.height;
         self.rect.y1 = (self.rect.y1 + 3.5) % self.size.height;
+
+        // Invalidate the old and new cursor positions.
+        self.handle.invalidate_rect(self.cursor);
+        self.cursor.x0 += 4.0;
+        self.cursor.x1 += 4.0;
+        if self.cursor.x0 > self.size.width {
+            self.cursor.x1 = self.cursor.width();
+            self.cursor.x0 = 0.0;
+        }
+        self.handle.invalidate_rect(self.cursor);
     }
 }
 
 impl WinHandler for InvalidateTest {
     fn connect(&mut self, handle: &WindowHandle) {
         self.handle = handle.clone();
-        self.handle.request_timer(Duration::from_millis(60));
     }
 
-    fn timer(&mut self, _id: TimerToken) {
+    fn prepare_paint(&mut self) {
         self.update_color_and_rect();
         self.handle.invalidate_rect(self.rect);
-        self.handle.request_timer(Duration::from_millis(60));
     }
 
-    fn prepare_paint(&mut self) {}
-
     fn paint(&mut self, piet: &mut Piet, region: &Region) {
+        // We can ask to draw something bigger than our rect, but things outside
+        // the invalidation region won't draw. (So they'll draw if and only if
+        // they intersect the cursor's invalidated region or the rect that we
+        // invalidated.)
         piet.fill(region.bounding_box(), &self.color);
+        piet.fill(self.cursor, &Color::WHITE);
+        self.handle.request_anim_frame();
     }
 
     fn size(&mut self, size: Size) {
@@ -97,6 +110,7 @@ fn main() {
         handle: Default::default(),
         start_time: Instant::now(),
         rect: Rect::from_origin_size(Point::ZERO, (10.0, 20.0)),
+        cursor: Rect::from_origin_size(Point::ZERO, (2.0, 100.0)),
         color: Color::WHITE,
     };
     builder.set_handler(Box::new(inv_test));

--- a/druid-shell/examples/invalidate.rs
+++ b/druid-shell/examples/invalidate.rs
@@ -14,7 +14,7 @@
 
 use std::any::Any;
 
-use std::time::{Instant};
+use std::time::Instant;
 
 use druid_shell::kurbo::{Point, Rect, Size};
 use druid_shell::piet::{Color, Piet, RenderContext};

--- a/druid-shell/src/platform/windows/util.rs
+++ b/druid-shell/src/platform/windows/util.rs
@@ -130,12 +130,12 @@ pub(crate) fn recti_to_rect(rect: RECT) -> Rect {
 }
 
 /// Converts a `Region` into a vec of winapi `RECT`, with a scaling applied.
-/// If necessary, the rectangles are expanded to the nearest pixel border.
+/// If necessary, the rectangles are rounded to the nearest pixel border.
 pub(crate) fn region_to_rectis(region: &Region, scale: Scale) -> Vec<RECT> {
     region
         .rects()
         .iter()
-        .map(|r| rect_to_recti(r.to_px(scale).expand()))
+        .map(|r| rect_to_recti(r.to_px(scale).round()))
         .collect()
 }
 

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -1290,7 +1290,12 @@ impl WindowHandle {
 
     pub fn invalidate_rect(&self, rect: Rect) {
         if let Some(w) = self.state.upgrade() {
-            w.invalid.borrow_mut().add_rect(rect);
+            let scale = w.scale.get();
+            // We need to invalidate an integer number of pixels, but we also want to keep
+            // the invalid region in display points, since that's what we need to pass
+            // to WinHandler::paint.
+            w.invalid.borrow_mut().add_rect(rect.to_px(scale).expand().to_dp(scale));
+
         }
         self.request_anim_frame();
     }


### PR DESCRIPTION
Previously, we were expanding the invalid region to the nearest
pixel when invalidated, but passing the non-expanded region to
WinHandler::paint. This could cause graphical glitches.