### PR TITLE
Add #[deny(missing_docs)] lint, add missing docs

### DIFF
--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -224,11 +224,13 @@ impl<T: Data> WindowDesc<T> {
         self
     }
 
+    /// Builder-style method to set whether this window can be resized.
     pub fn resizable(mut self, resizable: bool) -> Self {
         self.resizable = resizable;
         self
     }
 
+    /// Builder-style method to set whether this window's titlebar is visible.
     pub fn show_titlebar(mut self, show_titlebar: bool) -> Self {
         self.show_titlebar = show_titlebar;
         self

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -354,6 +354,7 @@ impl Command {
 }
 
 impl<T: Any> SingleUse<T> {
+    /// Create a new single-use payload.
     pub fn new(data: T) -> Self {
         SingleUse(Mutex::new(Some(data)))
     }

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -251,6 +251,7 @@ impl_context_method!(
 // methods on event, update, and lifecycle
 impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, {
     #[deprecated(since = "0.5.0", note = "use request_paint instead")]
+    #[allow(missing_docs)]
     pub fn invalidate(&mut self) {
         self.request_paint();
     }
@@ -511,6 +512,11 @@ impl EventCtx<'_, '_> {
 }
 
 impl UpdateCtx<'_, '_> {
+    /// Returns `true` if this widget or a descendent as explicitly requested
+    /// an update call. This should only be needed in advanced cases;
+    /// See [`EventCtx::request_update`] for more information.
+    ///
+    /// [`EventCtx::request_update`]: struct.EventCtx.html#method.request_update
     pub fn has_requested_update(&mut self) -> bool {
         self.widget_state.request_update
     }

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -721,6 +721,9 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         ctx.widget_state.merge_up(&mut self.state);
     }
 
+    /// Propagate a [`LifeCycle`] event.
+    ///
+    /// [`LifeCycle`]: enum.LifeCycle.html
     pub fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         // in the case of an internal routing event, if we are at our target
         // we may send an extra event after the actual event

--- a/druid/src/env.rs
+++ b/druid/src/env.rs
@@ -97,6 +97,7 @@ pub struct Key<T> {
 // Also consider Box<Any> (though this would also impact debug).
 /// A dynamic type representing all values that can be stored in an environment.
 #[derive(Clone)]
+#[allow(missing_docs)]
 // ANCHOR: value_type
 pub enum Value {
     Point(Point),
@@ -119,7 +120,14 @@ pub enum Value {
 /// [`Env`]: struct.Env.html
 #[derive(Clone)]
 pub enum KeyOrValue<T> {
+    /// A concrete [`Value`] of type `T`.
+    ///
+    /// [`Value`]: enum.Value.html
     Concrete(Value),
+    /// A [`Key<T>`] that can be resolved to a value in the [`Env`].
+    ///
+    /// [`Key<T>`]: struct.Key.html
+    /// [`Env`]: struct.Env.html
     Key(Key<T>),
 }
 
@@ -531,6 +539,10 @@ impl_value_type_owned!(Size, Size);
 impl_value_type_borrowed!(str, String, String);
 
 impl<'a, T: ValueType<'a>> KeyOrValue<T> {
+    /// Resolve the concrete type `T` from this `KeyOrValue`, using the provided
+    /// [`Env`] if required.
+    ///
+    /// [`Env`]: struct.Env.html
     pub fn resolve(&'a self, env: &'a Env) -> T {
         match self {
             KeyOrValue::Concrete(value) => value.to_inner_unchecked(),

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -120,7 +120,7 @@
 //! [`usvg` crate]: https://crates.io/crates/usvg
 //! [`image` crate]: https://crates.io/crates/image
 
-#![deny(intra_doc_link_resolution_failure, unsafe_code)]
+#![deny(intra_doc_link_resolution_failure, missing_docs, unsafe_code)]
 #![allow(clippy::new_ret_no_self, clippy::needless_doctest_main)]
 #![deny(clippy::trivially_copy_pass_by_ref)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -209,4 +209,5 @@ pub(crate) use event::{StateCell, StateCheckFn};
 pub type KeyCode = KbKey;
 
 #[deprecated(since = "0.7.0", note = "Use Modifiers instead")]
+/// See [`Modifiers`](struct.Modifiers.html).
 pub type KeyModifiers = Modifiers;

--- a/druid/src/menu.rs
+++ b/druid/src/menu.rs
@@ -389,6 +389,7 @@ impl<T: Data> MenuDesc<T> {
 }
 
 impl<T> ContextMenu<T> {
+    /// Create a new `ContextMenu`.
     pub fn new(menu: MenuDesc<T>, location: Point) -> Self {
         ContextMenu { menu, location }
     }

--- a/druid/src/text/editable_text.rs
+++ b/druid/src/text/editable_text.rs
@@ -58,8 +58,10 @@ pub trait EditableText: Sized {
     /// Get the next codepoint offset from the given offset, if it exists.
     fn next_codepoint_offset(&self, offset: usize) -> Option<usize>;
 
+    /// Returns `true` if this text has 0 length.
     fn is_empty(&self) -> bool;
 
+    /// Construct an instance of this type from a `&str`.
     fn from_str(s: &str) -> Self;
 }
 

--- a/druid/src/text/text_input.rs
+++ b/druid/src/text/text_input.rs
@@ -24,6 +24,7 @@ use crate::{HotKey, KbKey, KeyEvent, Modifiers, SysMods};
 
 /// An enum that represents actions in a text buffer.
 #[derive(Debug, PartialEq, Clone)]
+#[allow(missing_docs)]
 pub enum EditAction {
     Move(Movement),
     ModifySelection(Movement),
@@ -40,12 +41,14 @@ pub enum EditAction {
 
 /// Extra information related to mouse actions
 #[derive(PartialEq, Debug, Clone)]
+#[allow(missing_docs)]
 pub struct MouseAction {
     pub row: usize,
     pub column: usize,
     pub mods: Modifiers,
 }
 
+/// A trait for types that map keyboard events to possible edit actions.
 pub trait TextInput {
     /// Handle a key event and return an edit action to be executed
     /// for the key event
@@ -58,6 +61,7 @@ pub trait TextInput {
 pub struct BasicTextInput {}
 
 impl BasicTextInput {
+    /// Create a new `BasicTextInput`.
     pub fn new() -> Self {
         Self {}
     }

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -14,6 +14,7 @@
 
 //! Theme keys and initial values.
 
+#![allow(missing_docs)]
 use crate::piet::Color;
 
 use crate::{Env, Key};

--- a/druid/src/widget/common.rs
+++ b/druid/src/widget/common.rs
@@ -15,6 +15,7 @@
 use crate::{Affine, Size};
 
 // These are based on https://api.flutter.dev/flutter/painting/BoxFit-class.html
+/// Strategies for inscribing a rectangle inside another rectangle.
 #[derive(Clone, Copy, PartialEq)]
 pub enum FillStrat {
     /// As large as posible without changing aspect ratio of image and all of image shown

--- a/druid/src/widget/controller.rs
+++ b/druid/src/widget/controller.rs
@@ -63,10 +63,16 @@ use crate::{
 /// [`ControllerHost`]: struct.ControllerHost.html
 /// [`WidgetExt::controller`]: ../trait.WidgetExt.html#tymethod.controller
 pub trait Controller<T, W: Widget<T>> {
+    /// Analogous to [`Widget::event`].
+    ///
+    /// [`Widget::event`]: ../trait.Widget.html#tymethod.event
     fn event(&mut self, child: &mut W, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         child.event(ctx, event, data, env)
     }
 
+    /// Analogous to [`Widget::lifecycle`].
+    ///
+    /// [`Widget::lifecycle`]: ../trait.Widget.html#tymethod.lifecycle
     fn lifecycle(
         &mut self,
         child: &mut W,
@@ -78,6 +84,9 @@ pub trait Controller<T, W: Widget<T>> {
         child.lifecycle(ctx, event, data, env)
     }
 
+    /// Analogous to [`Widget::update`].
+    ///
+    /// [`Widget::update`]: ../trait.Widget.html#tymethod.update
     fn update(&mut self, child: &mut W, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
         child.update(ctx, old_data, data, env)
     }

--- a/druid/src/widget/painter.rs
+++ b/druid/src/widget/painter.rs
@@ -88,6 +88,7 @@ pub struct Painter<T>(Box<dyn FnMut(&mut PaintCtx, &T, &Env)>);
 /// [`Data`]: ../trait.Data.html
 /// [`Env`]: ../struct.Env.html
 #[non_exhaustive]
+#[allow(missing_docs)]
 pub enum BackgroundBrush<T> {
     Color(Color),
     ColorKey(Key<Color>),

--- a/druid/src/widget/parse.rs
+++ b/druid/src/widget/parse.rs
@@ -29,6 +29,7 @@ pub struct Parse<T> {
 }
 
 impl<T> Parse<T> {
+    /// Create a new `Parse` widget.
     pub fn new(widget: T) -> Self {
         Self {
             widget,

--- a/druid/src/widget/stepper.rs
+++ b/druid/src/widget/stepper.rs
@@ -45,6 +45,7 @@ pub struct Stepper {
 }
 
 impl Stepper {
+    /// Create a new `Stepper`.
     pub fn new() -> Self {
         Stepper {
             max: std::f64::MAX,

--- a/druid/src/widget/view_switcher.rs
+++ b/druid/src/widget/view_switcher.rs
@@ -25,6 +25,7 @@ use crate::{
 type ChildPicker<T, U> = dyn Fn(&T, &Env) -> U;
 type ChildBuilder<T, U> = dyn Fn(&U, &T, &Env) -> Box<dyn Widget<T>>;
 
+/// A widget that dynamically switches between two children.
 pub struct ViewSwitcher<T, U> {
     child_picker: Box<ChildPicker<T, U>>,
     child_builder: Box<ChildBuilder<T, U>>,

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -251,6 +251,7 @@ impl<T: Data, W: Widget<T> + 'static> WidgetExt<T> for W {}
 // will choose an impl on a type over an impl in a trait for methods with the same
 // name.
 
+#[doc(hidden)]
 impl<T: Data> SizedBox<T> {
     pub fn fix_width(self, width: f64) -> SizedBox<T> {
         self.width(width)


### PR DESCRIPTION
I've been wanting this for a while, to ensure that PRs document their public API.


This is missing a few docs in `scope.rs`; @rjwittams is going to add those in a separate PR, since I don't know what's going on there. :)