### PR TITLE
Fix unresolved docstring reference in hotkey.rs Fix doc build

### DIFF
--- a/druid-shell/src/hotkey.rs
+++ b/druid-shell/src/hotkey.rs
@@ -109,7 +109,7 @@ impl HotKey {
 
     /// Returns `true` if this [`KeyboardEvent`] matches this `HotKey`.
     ///
-    /// [`KeyboardEvent`]: keyboard_types::KeyEvent
+    /// [`KeyboardEvent`]: KeyEvent
     pub fn matches(&self, event: impl Borrow<KeyEvent>) -> bool {
         // Should be a const but const bit_or doesn't work here.
         let base_mods = Modifiers::SHIFT | Modifiers::CONTROL | Modifiers::ALT | Modifiers::META;

--- a/druid-shell/src/hotkey.rs
+++ b/druid-shell/src/hotkey.rs
@@ -109,7 +109,7 @@ impl HotKey {
 
     /// Returns `true` if this [`KeyboardEvent`] matches this `HotKey`.
     ///
-    /// [`KeyboardEvent`]: KeyEvent
+    /// [`KeyEvent`]: KeyEvent
     pub fn matches(&self, event: impl Borrow<KeyEvent>) -> bool {
         // Should be a const but const bit_or doesn't work here.
         let base_mods = Modifiers::SHIFT | Modifiers::CONTROL | Modifiers::ALT | Modifiers::META;


### PR DESCRIPTION
The wrapper type for keyboard events was changed, but a docstring still referred to `keyboard_types` which is not able to be resolved from hotkeys.rs.