### PR TITLE
Add FontDescriptor type

### DIFF
--- a/druid/src/data.rs
+++ b/druid/src/data.rs
@@ -395,6 +395,24 @@ impl Data for piet::Color {
     }
 }
 
+impl Data for piet::FontFamily {
+    fn same(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
+impl Data for piet::FontWeight {
+    fn same(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
+impl Data for piet::FontStyle {
+    fn same(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
 #[cfg(feature = "im")]
 impl<T: Data> Data for im::Vector<T> {
     fn same(&self, other: &Self) -> bool {

--- a/druid/src/env.rs
+++ b/druid/src/env.rs
@@ -23,6 +23,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use crate::localization::L10nManager;
+use crate::text::FontDescriptor;
 use crate::{ArcStr, Color, Data, Point, Rect, Size};
 
 /// An environment passed down through all widget traversals.
@@ -108,6 +109,7 @@ pub enum Value {
     Bool(bool),
     UnsignedInt(u64),
     String(ArcStr),
+    Font(FontDescriptor),
 }
 // ANCHOR_END: value_type
 
@@ -376,6 +378,7 @@ impl Value {
             (Bool(_), Bool(_)) => true,
             (UnsignedInt(_), UnsignedInt(_)) => true,
             (String(_), String(_)) => true,
+            (Font(_), Font(_)) => true,
             _ => false,
         }
     }
@@ -392,6 +395,7 @@ impl Debug for Value {
             Value::Bool(b) => write!(f, "Bool {}", b),
             Value::UnsignedInt(x) => write!(f, "UnsignedInt {}", x),
             Value::String(s) => write!(f, "String {:?}", s),
+            Value::Font(font) => write!(f, "Font {:?}", font),
         }
     }
 }
@@ -410,6 +414,7 @@ impl Data for Value {
             (Bool(b1), Bool(b2)) => b1 == b2,
             (UnsignedInt(f1), UnsignedInt(f2)) => f1.same(&f2),
             (String(s1), String(s2)) => s1.same(s2),
+            (Font(s1), Font(s2)) => s1.same(s2),
             _ => false,
         }
     }
@@ -536,6 +541,7 @@ impl_value_type!(Rect, Rect);
 impl_value_type!(Point, Point);
 impl_value_type!(Size, Size);
 impl_value_type!(ArcStr, String);
+impl_value_type!(FontDescriptor, Font);
 
 impl<T: ValueType> KeyOrValue<T> {
     /// Resolve the concrete type `T` from this `KeyOrValue`, using the provided

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -169,7 +169,10 @@ mod window;
 
 // Types from kurbo & piet that are required by public API.
 pub use kurbo::{Affine, Insets, Point, Rect, Size, Vec2};
-pub use piet::{Color, LinearGradient, RadialGradient, RenderContext, UnitPoint};
+pub use piet::{
+    Color, FontFamily, FontStyle, FontWeight, LinearGradient, RadialGradient, RenderContext,
+    UnitPoint,
+};
 // these are the types from shell that we expose; others we only use internally.
 pub use shell::keyboard_types;
 pub use shell::{
@@ -193,6 +196,7 @@ pub use lens::{Lens, LensExt, LensWrap};
 pub use localization::LocalizedString;
 pub use menu::{sys as platform_menus, ContextMenu, MenuDesc, MenuItem};
 pub use mouse::MouseEvent;
+pub use text::FontDescriptor;
 pub use widget::{Widget, WidgetExt, WidgetId};
 pub use win_handler::DruidHandler;
 pub use window::{Window, WindowId};

--- a/druid/src/text/font_descriptor.rs
+++ b/druid/src/text/font_descriptor.rs
@@ -1,0 +1,78 @@
+// Copyright 2020 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Font attributes
+
+use crate::{Data, FontFamily, FontStyle, FontWeight};
+
+/// A collection of attributes that describe a font.
+///
+/// This is provided as a convenience; library consumers may wish to have
+/// a single type that represents a specific font face at a specific size.
+#[derive(Debug, Data, Clone, PartialEq)]
+pub struct FontDescriptor {
+    /// The font's [`FontFamily`](struct.FontFamily.html).
+    pub family: FontFamily,
+    /// The font's size.
+    pub size: f64,
+    /// The font's [`FontWeight`](struct.FontWeight.html).
+    pub weight: FontWeight,
+    /// The font's [`FontStyle`](struct.FontStyle.html).
+    pub style: FontStyle,
+}
+
+impl FontDescriptor {
+    /// Create a new descriptor with the provided [`FontFamily`].
+    ///
+    /// [`FontFamily`]: struct.FontFamily.html
+    pub fn new(family: FontFamily) -> Self {
+        FontDescriptor {
+            family,
+            ..Default::default()
+        }
+    }
+
+    /// Buider-style method to set the descriptor's font size.
+    pub fn with_size(mut self, size: f64) -> Self {
+        self.size = size;
+        self
+    }
+
+    /// Buider-style method to set the descriptor's [`FontWeight`].
+    ///
+    /// [`FontWeight`]: struct.FontWeight.html
+    pub fn with_weight(mut self, weight: FontWeight) -> Self {
+        self.weight = weight;
+        self
+    }
+
+    /// Buider-style method to set the descriptor's [`FontStyle`].
+    ///
+    /// [`FontStyle`]: enum.FontStyle.html
+    pub fn with_style(mut self, style: FontStyle) -> Self {
+        self.style = style;
+        self
+    }
+}
+
+impl Default for FontDescriptor {
+    fn default() -> Self {
+        FontDescriptor {
+            family: Default::default(),
+            weight: Default::default(),
+            style: Default::default(),
+            size: crate::piet::util::DEFAULT_FONT_SIZE,
+        }
+    }
+}

--- a/druid/src/text/mod.rs
+++ b/druid/src/text/mod.rs
@@ -14,17 +14,16 @@
 
 //! Text editing utilities.
 
-mod editable_text;
-pub use self::editable_text::{EditableText, EditableTextCursor, StringCursor};
-
-pub mod selection;
-pub use self::selection::Selection;
-
-pub mod movement;
-pub use self::movement::{movement, Movement};
-
 pub mod backspace;
-pub use self::backspace::offset_for_delete_backwards;
-
+mod editable_text;
+mod font_descriptor;
+pub mod movement;
+pub mod selection;
 mod text_input;
+
+pub use self::backspace::offset_for_delete_backwards;
+pub use self::editable_text::{EditableText, EditableTextCursor, StringCursor};
+pub use self::font_descriptor::FontDescriptor;
+pub use self::movement::{movement, Movement};
+pub use self::selection::Selection;
 pub use self::text_input::{BasicTextInput, EditAction, MouseAction, TextInput};


### PR DESCRIPTION
This adds a new type for describing fonts; it aggregates family, weight,  style, and size, and will be the default way of representing fonts in the environment.

This isn't used in this patch, but it will be in some follow-up work shortly.