### PR TITLE
Move Target inside Command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ You can find its changes [documented below](#060---2020-06-01).
 - `ExtEventSink`s can now be obtained from widget methods. ([#1152] by [@jneem])
 - 'Scope' widget to allow encapsulation of reactive state. ([#1151] by [@rjwittams])
 - `Ref` lens that applies `AsRef` and thus allow indexing arrays. ([#1171] by [@finnerale])
+- `Command::to` and `Command::target` to set and get a commands target. ([#1185] by [@finnerale])
+- `Menu` commands can now choose a custom target. ([#1185] by [@finnerale])
 - `Movement::StartOfDocument`, `Movement::EndOfDocument`. ([#1092] by [@sysint64])
 
 ### Changed
@@ -33,6 +35,8 @@ You can find its changes [documented below](#060---2020-06-01).
 - `Env::try_get` (and related methods) return a `Result` instead of an `Option`. ([#1172] by [@cmyr])
 - `lens!` macro to use move semantics for the index. ([#1171] by [@finnerale])
 - `Env` stores `Arc<str>` instead of `String` ([#1173] by [@cmyr])
+- Replaced uses of `Option<Target>` with the new `Target::Auto`. ([#1185] by [@finnerale])
+- Moved `Target` parameter from `submit_command` to `Command::new` and `Command::to`. ([#1185] by [@finnerale])
 - `Movement::RightOfLine` to `Movement::NextLineBreak`, and `Movement::LeftOfLine` to `Movement::PrecedingLineBreak`. ([#1092] by [@sysint64])
 
 ### Deprecated
@@ -414,6 +418,7 @@ Last release without a changelog :(
 [#1171]: https://github.com/linebender/druid/pull/1171
 [#1172]: https://github.com/linebender/druid/pull/1172
 [#1173]: https://github.com/linebender/druid/pull/1173
+[#1185]: https://github.com/linebender/druid/pull/1185
 [#1092]: https://github.com/linebender/druid/pull/1092
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master

--- a/docs/book_examples/src/custom_widgets_md.rs
+++ b/docs/book_examples/src/custom_widgets_md.rs
@@ -60,14 +60,14 @@ impl Controller<String, TextBox> for TextBoxActionController {
     ) {
         match event {
             Event::KeyDown(k) if k.key == Key::Enter => {
-                ctx.submit_command(ACTION, None);
+                ctx.submit_command(ACTION);
             }
             Event::KeyUp(k) if k.key == Key::Enter => {
                 self.timer = Some(ctx.request_timer(DELAY));
                 child.event(ctx, event, data, env);
             }
             Event::Timer(token) if Some(*token) == self.timer => {
-                ctx.submit_command(ACTION, None);
+                ctx.submit_command(ACTION);
             }
             _ => child.event(ctx, event, data, env),
         }

--- a/druid/examples/blocking_function.rs
+++ b/druid/examples/blocking_function.rs
@@ -18,10 +18,13 @@ use std::{thread, time};
 
 use druid::{
     AppDelegate, AppLauncher, Command, Data, DelegateCtx, Env, ExtEventSink, Lens, LocalizedString,
-    Selector, Target, Widget, WidgetExt, WindowDesc,
+    Selector, Widget, WidgetExt, WindowDesc,
 };
 
-use druid::widget::{Button, Either, Flex, Label, Spinner};
+use druid::{
+    widget::{Button, Either, Flex, Label, Spinner},
+    Target,
+};
 
 const FINISH_SLOW_FUNCTION: Selector<u32> = Selector::new("finish_slow_function");
 
@@ -43,7 +46,7 @@ fn slow_function(number: u32) -> u32 {
 fn wrapped_slow_function(sink: ExtEventSink, number: u32) {
     thread::spawn(move || {
         let number = slow_function(number);
-        sink.submit_command(FINISH_SLOW_FUNCTION, number, None)
+        sink.submit_command(FINISH_SLOW_FUNCTION, number, Target::Auto)
             .expect("command failed to submit");
     });
 }

--- a/druid/examples/ext_event.rs
+++ b/druid/examples/ext_event.rs
@@ -20,7 +20,9 @@ use std::time::Duration;
 
 use druid::kurbo::RoundedRect;
 use druid::widget::prelude::*;
-use druid::{AppLauncher, Color, Data, LocalizedString, Rect, Selector, WidgetExt, WindowDesc};
+use druid::{
+    AppLauncher, Color, Data, LocalizedString, Rect, Selector, Target, WidgetExt, WindowDesc,
+};
 
 const SET_COLOR: Selector<Color> = Selector::new("event-example.set-color");
 
@@ -109,7 +111,7 @@ pub fn main() {
 
             // if this fails we're shutting down
             if event_sink
-                .submit_command(SET_COLOR, new_color, None)
+                .submit_command(SET_COLOR, new_color, Target::Auto)
                 .is_err()
             {
                 break;

--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -33,9 +33,9 @@ use std::time::Duration;
 use druid::kurbo::RoundedRect;
 use druid::widget::{Button, CrossAxisAlignment, Flex, WidgetId};
 use druid::{
-    AppLauncher, BoxConstraints, Color, Command, Data, Env, Event, EventCtx, LayoutCtx, Lens,
-    LifeCycle, LifeCycleCtx, LocalizedString, PaintCtx, Rect, RenderContext, Selector, Size,
-    TimerToken, UpdateCtx, Widget, WidgetExt, WindowDesc,
+    AppLauncher, BoxConstraints, Color, Data, Env, Event, EventCtx, LayoutCtx, Lens, LifeCycle,
+    LifeCycleCtx, LocalizedString, PaintCtx, Rect, RenderContext, Selector, Size, TimerToken,
+    UpdateCtx, Widget, WidgetExt, WindowDesc,
 };
 
 const CYCLE_DURATION: Duration = Duration::from_millis(100);
@@ -173,13 +173,14 @@ fn make_ui() -> impl Widget<OurData> {
                 .with_spacer(10.0)
                 .with_child(
                     Button::<OurData>::new("freeze").on_click(move |ctx, data, _env| {
-                        ctx.submit_command(Command::new(FREEZE_COLOR, data.color.clone()), ID_ONE)
+                        ctx.submit_command(FREEZE_COLOR.with(data.color.clone()).to(ID_ONE))
                     }),
                 )
                 .with_spacer(10.0)
                 .with_child(
-                    Button::<OurData>::new("unfreeze")
-                        .on_click(move |ctx, _, _env| ctx.submit_command(UNFREEZE_COLOR, ID_ONE)),
+                    Button::<OurData>::new("unfreeze").on_click(move |ctx, _, _env| {
+                        ctx.submit_command(UNFREEZE_COLOR.to(ID_ONE))
+                    }),
                 ),
             0.5,
         )
@@ -191,13 +192,14 @@ fn make_ui() -> impl Widget<OurData> {
                 .with_spacer(10.0)
                 .with_child(
                     Button::<OurData>::new("freeze").on_click(move |ctx, data, _env| {
-                        ctx.submit_command(Command::new(FREEZE_COLOR, data.color.clone()), id_two)
+                        ctx.submit_command(FREEZE_COLOR.with(data.color.clone()).to(id_two))
                     }),
                 )
                 .with_spacer(10.0)
                 .with_child(
-                    Button::<OurData>::new("unfreeze")
-                        .on_click(move |ctx, _, _env| ctx.submit_command(UNFREEZE_COLOR, id_two)),
+                    Button::<OurData>::new("unfreeze").on_click(move |ctx, _, _env| {
+                        ctx.submit_command(UNFREEZE_COLOR.to(id_two))
+                    }),
                 ),
             0.5,
         )
@@ -209,13 +211,14 @@ fn make_ui() -> impl Widget<OurData> {
                 .with_spacer(10.0)
                 .with_child(
                     Button::<OurData>::new("freeze").on_click(move |ctx, data, _env| {
-                        ctx.submit_command(Command::new(FREEZE_COLOR, data.color.clone()), id_three)
+                        ctx.submit_command(FREEZE_COLOR.with(data.color.clone()).to(id_three))
                     }),
                 )
                 .with_spacer(10.0)
                 .with_child(
-                    Button::<OurData>::new("unfreeze")
-                        .on_click(move |ctx, _, _env| ctx.submit_command(UNFREEZE_COLOR, id_three)),
+                    Button::<OurData>::new("unfreeze").on_click(move |ctx, _, _env| {
+                        ctx.submit_command(UNFREEZE_COLOR.to(id_three))
+                    }),
                 ),
             0.5,
         )

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -57,11 +57,11 @@ fn ui_builder() -> impl Widget<State> {
         .with_arg("count", |data: &State, _env| data.menu_count.into());
     let label = Label::new(text);
     let inc_button = Button::<State>::new("Add menu item")
-        .on_click(|ctx, _data, _env| ctx.submit_command(MENU_INCREMENT_ACTION, Global));
+        .on_click(|ctx, _data, _env| ctx.submit_command(MENU_INCREMENT_ACTION.to(Global)));
     let dec_button = Button::<State>::new("Remove menu item")
-        .on_click(|ctx, _data, _env| ctx.submit_command(MENU_DECREMENT_ACTION, Global));
+        .on_click(|ctx, _data, _env| ctx.submit_command(MENU_DECREMENT_ACTION.to(Global)));
     let new_button = Button::<State>::new("New window").on_click(|ctx, _data, _env| {
-        ctx.submit_command(sys_cmds::NEW_FILE, Target::Global);
+        ctx.submit_command(sys_cmds::NEW_FILE.to(Global));
     });
     let quit_button = Button::<State>::new("Quit app").on_click(|_ctx, _data, _env| {
         Application::global().quit();
@@ -239,7 +239,7 @@ fn make_menu<T: Data>(state: &State) -> MenuDesc<T> {
                     MenuItem::new(
                         LocalizedString::new("hello-counter")
                             .with_arg("count", move |_, _| i.into()),
-                        Command::new(MENU_COUNT_ACTION, i),
+                        MENU_COUNT_ACTION.with(i),
                     )
                     .disabled_if(|| i % 3 == 0)
                     .selected_if(|| i == state.selected)

--- a/druid/examples/open_save.rs
+++ b/druid/examples/open_save.rs
@@ -42,22 +42,18 @@ fn ui_builder() -> impl Widget<String> {
 
     let input = TextBox::new();
     let save = Button::new("Save").on_click(move |ctx, _, _| {
-        ctx.submit_command(
-            Command::new(
-                druid::commands::SHOW_SAVE_PANEL,
-                save_dialog_options.clone(),
-            ),
-            None,
-        )
+        ctx.submit_command(Command::new(
+            druid::commands::SHOW_SAVE_PANEL,
+            save_dialog_options.clone(),
+            Target::Auto,
+        ))
     });
     let open = Button::new("Open").on_click(move |ctx, _, _| {
-        ctx.submit_command(
-            Command::new(
-                druid::commands::SHOW_OPEN_PANEL,
-                open_dialog_options.clone(),
-            ),
-            None,
-        )
+        ctx.submit_command(Command::new(
+            druid::commands::SHOW_OPEN_PANEL,
+            open_dialog_options.clone(),
+            Target::Auto,
+        ))
     });
 
     let mut col = Flex::column();

--- a/druid/src/app_delegate.rs
+++ b/druid/src/app_delegate.rs
@@ -14,20 +14,18 @@
 
 //! Customizing application-level behaviour.
 
-use std::{
-    any::{Any, TypeId},
-    collections::VecDeque,
-};
+use std::any::{Any, TypeId};
 
 use crate::{
-    commands, Command, Data, Env, Event, MenuDesc, SingleUse, Target, WindowDesc, WindowId,
+    commands, core::CommandQueue, Command, Data, Env, Event, MenuDesc, SingleUse, Target,
+    WindowDesc, WindowId,
 };
 
 /// A context passed in to [`AppDelegate`] functions.
 ///
 /// [`AppDelegate`]: trait.AppDelegate.html
 pub struct DelegateCtx<'a> {
-    pub(crate) command_queue: &'a mut VecDeque<(Target, Command)>,
+    pub(crate) command_queue: &'a mut CommandQueue,
     pub(crate) app_data_type: TypeId,
 }
 
@@ -40,14 +38,9 @@ impl<'a> DelegateCtx<'a> {
     ///
     /// [`Command`]: struct.Command.html
     /// [`update()`]: trait.Widget.html#tymethod.update
-    pub fn submit_command(
-        &mut self,
-        command: impl Into<Command>,
-        target: impl Into<Option<Target>>,
-    ) {
-        let command = command.into();
-        let target = target.into().unwrap_or(Target::Global);
-        self.command_queue.push_back((target, command))
+    pub fn submit_command(&mut self, command: impl Into<Command>) {
+        self.command_queue
+            .push_back(command.into().default_to(Target::Global))
     }
 
     /// Create a new window.
@@ -57,8 +50,9 @@ impl<'a> DelegateCtx<'a> {
     pub fn new_window<T: Any>(&mut self, desc: WindowDesc<T>) {
         if self.app_data_type == TypeId::of::<T>() {
             self.submit_command(
-                Command::new(commands::NEW_WINDOW, SingleUse::new(Box::new(desc))),
-                Target::Global,
+                commands::NEW_WINDOW
+                    .with(SingleUse::new(Box::new(desc)))
+                    .to(Target::Global),
             );
         } else {
             const MSG: &str = "WindowDesc<T> - T must match the application data type.";
@@ -77,8 +71,9 @@ impl<'a> DelegateCtx<'a> {
     pub fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>, window: WindowId) {
         if self.app_data_type == TypeId::of::<T>() {
             self.submit_command(
-                Command::new(commands::SET_MENU, Box::new(menu)),
-                Target::Window(window),
+                commands::SET_MENU
+                    .with(Box::new(menu))
+                    .to(Target::Window(window)),
             );
         } else {
             const MSG: &str = "MenuDesc<T> - T must match the application data type.";

--- a/druid/src/app_delegate.rs
+++ b/druid/src/app_delegate.rs
@@ -36,6 +36,8 @@ impl<'a> DelegateCtx<'a> {
     /// submitted during the handling of an event are executed before
     /// the [`update()`] method is called.
     ///
+    /// [`Target::Auto`] commands will be sent to every window (`Target::Global`).
+    ///
     /// [`Command`]: struct.Command.html
     /// [`update()`]: trait.Widget.html#tymethod.update
     pub fn submit_command(&mut self, command: impl Into<Command>) {

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -120,6 +120,9 @@ pub enum Target {
     /// The target is a specific widget.
     Widget(WidgetId),
     /// The target will be determined automatically.
+    ///
+    /// How this behaves depends on the context used to submit the command.
+    /// Each `submit_command` function should have documentation about the specific behavior.
     Auto,
 }
 
@@ -251,7 +254,7 @@ impl Selector<()> {
     /// A selector that does nothing.
     pub const NOOP: Selector = Selector::new("");
 
-    /// Set the commands target.
+    /// Turns this into a command with the specified target.
     pub fn to(self, target: impl Into<Target>) -> Command {
         Command::from(self).to(target.into())
     }
@@ -275,7 +278,12 @@ impl<T: Any> Selector<T> {
     /// If the payload is `()` there is no need to call this,
     /// as `Selector<()>` implements `Into<Command>`.
     ///
+    /// By default, the command will have [`Target::Auto`].
+    /// The [`Command::to`] method can be used to override this.
+    ///
     /// [`Command::new`]: struct.Command.html#method.new
+    /// [`Command::to`]: struct.Command.html#method.to
+    /// [`Target::Auto`]: enum.Target.html#variant.Auto
     pub fn with(self, payload: T) -> Command {
         Command::new(self, payload, Target::Auto)
     }

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -62,11 +62,11 @@ pub struct Selector<T = ()>(SelectorSymbol, PhantomData<*const T>);
 ///
 /// # Examples
 /// ```
-/// use druid::{Command, Selector};
+/// use druid::{Command, Selector, Target};
 ///
 /// let selector = Selector::new("process_rows");
 /// let rows = vec![1, 3, 10, 12];
-/// let command = Command::new(selector, rows);
+/// let command = Command::new(selector, rows, Target::Auto);
 ///
 /// assert_eq!(command.get(selector), Some(&vec![1, 3, 10, 12]));
 /// ```
@@ -78,6 +78,7 @@ pub struct Selector<T = ()>(SelectorSymbol, PhantomData<*const T>);
 pub struct Command {
     symbol: SelectorSymbol,
     payload: Arc<dyn Any>,
+    target: Target,
 }
 
 /// A wrapper type for [`Command`] payloads that should only be used once.
@@ -87,13 +88,13 @@ pub struct Command {
 ///
 /// # Examples
 /// ```
-/// use druid::{Command, Selector, SingleUse};
+/// use druid::{Command, Selector, SingleUse, Target};
 ///
 /// struct CantClone(u8);
 ///
 /// let selector = Selector::new("use-once");
 /// let num = CantClone(42);
-/// let command = Command::new(selector, SingleUse::new(num));
+/// let command = Command::new(selector, SingleUse::new(num), Target::Auto);
 ///
 /// let payload: &SingleUse<CantClone> = command.get_unchecked(selector);
 /// if let Some(num) = payload.take() {
@@ -118,6 +119,8 @@ pub enum Target {
     Window(WindowId),
     /// The target is a specific widget.
     Widget(WidgetId),
+    /// The target will be determined automatically.
+    Auto,
 }
 
 /// Commands with special meaning, defined by druid.
@@ -247,6 +250,11 @@ pub mod sys {
 impl Selector<()> {
     /// A selector that does nothing.
     pub const NOOP: Selector = Selector::new("");
+
+    /// Set the commands target.
+    pub fn to(self, target: impl Into<Target>) -> Command {
+        Command::from(self).to(target.into())
+    }
 }
 
 impl<T> Selector<T> {
@@ -269,7 +277,7 @@ impl<T: Any> Selector<T> {
     ///
     /// [`Command::new`]: struct.Command.html#method.new
     pub fn with(self, payload: T) -> Command {
-        Command::new(self, payload)
+        Command::new(self, payload, Target::Auto)
     }
 }
 
@@ -282,19 +290,49 @@ impl Command {
     ///
     /// [`Selector`]: struct.Selector.html
     /// [`Selector::with`]: struct.Selector.html#method.with
-    pub fn new<T: Any>(selector: Selector<T>, payload: T) -> Self {
+    pub fn new<T: Any>(selector: Selector<T>, payload: T, target: impl Into<Target>) -> Self {
         Command {
             symbol: selector.symbol(),
             payload: Arc::new(payload),
+            target: target.into(),
         }
     }
 
     /// Used to create a command from the types sent via an `ExtEventSink`.
-    pub(crate) fn from_ext(symbol: SelectorSymbol, payload: Box<dyn Any>) -> Self {
+    pub(crate) fn from_ext(
+        symbol: SelectorSymbol,
+        payload: Box<dyn Any>,
+        target: impl Into<Target>,
+    ) -> Self {
         Command {
             symbol,
             payload: payload.into(),
+            target: target.into(),
         }
+    }
+
+    /// Set the commands target.
+    ///
+    /// [`Command::target`] can be used to get the current target.
+    ///
+    /// [`Command::target`]: #method.target
+    pub fn to(mut self, target: impl Into<Target>) -> Self {
+        self.target = target.into();
+        self
+    }
+
+    pub(crate) fn default_to(mut self, target: impl Into<Target>) -> Self {
+        self.target.default(target.into());
+        self
+    }
+
+    /// Returns the commands target.
+    ///
+    /// [`Command::to`] can be used to change the target.
+    ///
+    /// [`Command::to`]: #method.to
+    pub fn target(&self) -> Target {
+        self.target
     }
 
     /// Returns `true` if `self` matches this `selector`.
@@ -370,6 +408,7 @@ impl From<Selector> for Command {
         Command {
             symbol: selector.symbol(),
             payload: Arc::new(()),
+            target: Target::Auto,
         }
     }
 }
@@ -386,6 +425,15 @@ impl<T> Copy for Selector<T> {}
 impl<T> Clone for Selector<T> {
     fn clone(&self) -> Self {
         *self
+    }
+}
+
+impl Target {
+    /// If `self` is `Auto` it will be replaced with `target`.
+    pub(crate) fn default(&mut self, target: Target) {
+        if self == &Target::Auto {
+            *self = target;
+        }
     }
 }
 
@@ -421,7 +469,7 @@ mod tests {
     fn get_payload() {
         let sel = Selector::new("my-selector");
         let payload = vec![0, 1, 2];
-        let command = Command::new(sel, payload);
+        let command = Command::new(sel, payload, Target::Auto);
         assert_eq!(command.get(sel), Some(&vec![0, 1, 2]));
     }
 }

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -336,12 +336,8 @@ impl_context_method!(
         ///
         /// [`Command`]: struct.Command.html
         /// [`update`]: trait.Widget.html#tymethod.update
-        pub fn submit_command(
-            &mut self,
-            cmd: impl Into<Command>,
-            target: impl Into<Option<Target>>,
-        ) {
-            self.state.submit_command(cmd.into(), target.into())
+        pub fn submit_command(&mut self, cmd: impl Into<Command>) {
+            self.state.submit_command(cmd.into())
         }
 
         /// Returns an [`ExtEventSink`] that can be moved between threads,
@@ -387,8 +383,9 @@ impl EventCtx<'_, '_> {
     pub fn new_window<T: Any>(&mut self, desc: WindowDesc<T>) {
         if self.state.root_app_data_type == TypeId::of::<T>() {
             self.submit_command(
-                Command::new(commands::NEW_WINDOW, SingleUse::new(Box::new(desc))),
-                Target::Global,
+                commands::NEW_WINDOW
+                    .with(SingleUse::new(Box::new(desc)))
+                    .to(Target::Global),
             );
         } else {
             const MSG: &str = "WindowDesc<T> - T must match the application data type.";
@@ -407,8 +404,9 @@ impl EventCtx<'_, '_> {
     pub fn show_context_menu<T: Any>(&mut self, menu: ContextMenu<T>) {
         if self.state.root_app_data_type == TypeId::of::<T>() {
             self.submit_command(
-                Command::new(commands::SHOW_CONTEXT_MENU, Box::new(menu)),
-                Target::Window(self.state.window_id),
+                commands::SHOW_CONTEXT_MENU
+                    .with(Box::new(menu))
+                    .to(Target::Window(self.state.window_id)),
             );
         } else {
             const MSG: &str = "ContextMenu<T> - T must match the application data type.";
@@ -680,16 +678,16 @@ impl<'a> ContextState<'a> {
         }
     }
 
-    fn submit_command(&mut self, command: Command, target: Option<Target>) {
-        let target = target.unwrap_or_else(|| self.window_id.into());
-        self.command_queue.push_back((target, command))
+    fn submit_command(&mut self, command: Command) {
+        self.command_queue.push_back(command)
     }
 
     fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {
         if self.root_app_data_type == TypeId::of::<T>() {
             self.submit_command(
-                Command::new(commands::SET_MENU, Box::new(menu)),
-                Some(Target::Window(self.window_id)),
+                commands::SET_MENU
+                    .with(Box::new(menu))
+                    .to(Target::Window(self.window_id)),
             );
         } else {
             const MSG: &str = "MenuDesc<T> - T must match the application data type.";

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -334,6 +334,8 @@ impl_context_method!(
         /// the [`update`] method is called; events submitted during [`update`]
         /// are handled after painting.
         ///
+        /// [`Target::Auto`] commands will be sent to the window containing the widget.
+        ///
         /// [`Command`]: struct.Command.html
         /// [`update`]: trait.Widget.html#tymethod.update
         pub fn submit_command(&mut self, cmd: impl Into<Command>) {

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 
 /// Our queue type
-pub(crate) type CommandQueue = VecDeque<(Target, Command)>;
+pub(crate) type CommandQueue = VecDeque<Command>;
 
 /// A container for one widget in the hierarchy.
 ///
@@ -578,21 +578,22 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                     );
                     had_active || hot_changed
                 }
-                InternalEvent::TargetedCommand(target, cmd) => {
-                    match target {
-                        Target::Widget(id) if *id == self.id() => {
+                InternalEvent::TargetedCommand(cmd) => {
+                    match cmd.target() {
+                        Target::Widget(id) if id == self.id() => {
                             modified_event = Some(Event::Command(cmd.clone()));
                             true
                         }
                         Target::Widget(id) => {
                             // Recurse when the target widget could be our descendant.
                             // The bloom filter we're checking can return false positives.
-                            self.state.children.may_contain(id)
+                            self.state.children.may_contain(&id)
                         }
                         Target::Global | Target::Window(_) => {
                             modified_event = Some(Event::Command(cmd.clone()));
                             true
                         }
+                        _ => false,
                     }
                 }
                 InternalEvent::RouteTimer(token, widget_id) => {

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -19,7 +19,7 @@ use crate::kurbo::{Rect, Shape, Size, Vec2};
 use druid_shell::{Clipboard, KeyEvent, TimerToken};
 
 use crate::mouse::MouseEvent;
-use crate::{Command, Target, WidgetId};
+use crate::{Command, WidgetId};
 
 /// An event, propagated downwards during event flow.
 ///
@@ -142,7 +142,7 @@ pub enum InternalEvent {
     /// but we know that we've stopped receiving the mouse events.
     MouseLeave,
     /// A command still in the process of being dispatched.
-    TargetedCommand(Target, Command),
+    TargetedCommand(Command),
     /// Used for routing timer events.
     RouteTimer(TimerToken, WidgetId),
 }

--- a/druid/src/ext_event.rs
+++ b/druid/src/ext_event.rs
@@ -93,15 +93,16 @@ impl ExtEventSink {
     ///
     /// The `payload` must implement `Any + Send + Sync`.
     ///
-    /// If no explicit `Target` is submitted, the `Command` will be sent to
+    /// If submitted with `Target::Auto`, the [`Command`] will be sent to
     /// the application's first window; if that window is subsequently closed,
     /// then the command will be sent to *an arbitrary other window*.
     ///
     /// This behavior may be changed in the future; in any case, you should
-    /// probably provide an explicit `Target`.
+    /// probably provide an explicit [`Target`].
     ///
     /// [`Command`]: struct.Command.html
     /// [`Selector`]: struct.Selector.html
+    /// [`Target`]: struct.Target.html
     pub fn submit_command<T: Any + Send>(
         &self,
         selector: Selector<T>,

--- a/druid/src/menu.rs
+++ b/druid/src/menu.rs
@@ -266,7 +266,7 @@ impl<T: Data> MenuDesc<T> {
     /// # Examples
     ///
     /// ```
-    /// use druid::{Command, LocalizedString, MenuDesc, MenuItem, Selector};
+    /// use druid::{Command, LocalizedString, MenuDesc, MenuItem, Selector, Target};
     ///
     /// let num_items: usize = 4;
     /// const MENU_COUNT_ACTION: Selector<usize> = Selector::new("menu-count-action");
@@ -275,7 +275,7 @@ impl<T: Data> MenuDesc<T> {
     ///     .append_iter(|| (0..num_items).map(|i| {
     ///         MenuItem::new(
     ///             LocalizedString::new("hello-counter").with_arg("count", move |_, _| i.into()),
-    ///             Command::new(MENU_COUNT_ACTION, i),
+    ///             Command::new(MENU_COUNT_ACTION, i, Target::Auto),
     ///        )
     ///     })
     /// );

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -214,9 +214,9 @@ impl<T: Data> Harness<'_, T> {
     }
 
     /// Send a command to a target.
-    pub fn submit_command(&mut self, cmd: impl Into<Command>, target: impl Into<Option<Target>>) {
-        let target = target.into().unwrap_or_else(|| self.inner.window.id.into());
-        let event = Event::Internal(InternalEvent::TargetedCommand(target, cmd.into()));
+    pub fn submit_command(&mut self, cmd: impl Into<Command>) {
+        let command = cmd.into().default_to(self.inner.window.id);
+        let event = Event::Internal(InternalEvent::TargetedCommand(command));
         self.event(event);
     }
 
@@ -243,9 +243,7 @@ impl<T: Data> Harness<'_, T> {
         loop {
             let cmd = self.inner.cmds.pop_front();
             match cmd {
-                Some((target, cmd)) => {
-                    self.event(Event::Internal(InternalEvent::TargetedCommand(target, cmd)))
-                }
+                Some(cmd) => self.event(Event::Internal(InternalEvent::TargetedCommand(cmd))),
                 None => break,
             }
         }

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -204,26 +204,26 @@ fn take_focus() {
         assert!(right_focus.get().is_none());
 
         // this is sent to all widgets; the last widget to request focus should get it
-        harness.submit_command(TAKE_FOCUS, None);
+        harness.submit_command(TAKE_FOCUS);
         assert_eq!(harness.window().focus, Some(id_2));
         assert_eq!(left_focus.get(), None);
         assert_eq!(right_focus.get(), Some(true));
 
         // this is sent to all widgets; the last widget to request focus should still get it
         // NOTE: This tests siblings in particular, so careful when moving away from Split.
-        harness.submit_command(TAKE_FOCUS, None);
+        harness.submit_command(TAKE_FOCUS);
         assert_eq!(harness.window().focus, Some(id_2));
         assert_eq!(left_focus.get(), None);
         assert_eq!(right_focus.get(), Some(true));
 
         // this is sent to a specific widget; it should get focus
-        harness.submit_command(TAKE_FOCUS, id_1);
+        harness.submit_command(TAKE_FOCUS.to(id_1));
         assert_eq!(harness.window().focus, Some(id_1));
         assert_eq!(left_focus.get(), Some(true));
         assert_eq!(right_focus.get(), Some(false));
 
         // this is sent to a specific widget; it should get focus
-        harness.submit_command(TAKE_FOCUS, id_2);
+        harness.submit_command(TAKE_FOCUS.to(id_2));
         assert_eq!(harness.window().focus, Some(id_2));
         assert_eq!(left_focus.get(), Some(false));
         assert_eq!(right_focus.get(), Some(true));
@@ -291,42 +291,42 @@ fn focus_changed() {
         harness.send_initial_events();
 
         // focus none -> a
-        harness.submit_command(TAKE_FOCUS, id_a);
+        harness.submit_command(TAKE_FOCUS.to(id_a));
         assert_eq!(harness.window().focus, Some(id_a));
         assert!(changed(&a_rec, true));
         assert!(no_change(&b_rec));
         assert!(no_change(&c_rec));
 
         // focus a -> b
-        harness.submit_command(TAKE_FOCUS, id_b);
+        harness.submit_command(TAKE_FOCUS.to(id_b));
         assert_eq!(harness.window().focus, Some(id_b));
         assert!(changed(&a_rec, false));
         assert!(changed(&b_rec, true));
         assert!(no_change(&c_rec));
 
         // focus b -> c
-        harness.submit_command(TAKE_FOCUS, id_c);
+        harness.submit_command(TAKE_FOCUS.to(id_c));
         assert_eq!(harness.window().focus, Some(id_c));
         assert!(no_change(&a_rec));
         assert!(changed(&b_rec, false));
         assert!(changed(&c_rec, true));
 
         // focus c -> a
-        harness.submit_command(TAKE_FOCUS, id_a);
+        harness.submit_command(TAKE_FOCUS.to(id_a));
         assert_eq!(harness.window().focus, Some(id_a));
         assert!(changed(&a_rec, true));
         assert!(no_change(&b_rec));
         assert!(changed(&c_rec, false));
 
         // all focus before passing down the event
-        harness.submit_command(ALL_TAKE_FOCUS_BEFORE, None);
+        harness.submit_command(ALL_TAKE_FOCUS_BEFORE);
         assert_eq!(harness.window().focus, Some(id_c));
         assert!(changed(&a_rec, false));
         assert!(no_change(&b_rec));
         assert!(changed(&c_rec, true));
 
         // all focus after passing down the event
-        harness.submit_command(ALL_TAKE_FOCUS_AFTER, None);
+        harness.submit_command(ALL_TAKE_FOCUS_AFTER);
         assert_eq!(harness.window().focus, Some(id_a));
         assert!(changed(&a_rec, true));
         assert!(no_change(&b_rec));
@@ -370,7 +370,7 @@ fn adding_child_lifecycle() {
 
         assert!(record_new_child.is_empty());
 
-        harness.submit_command(REPLACE_CHILD, None);
+        harness.submit_command(REPLACE_CHILD);
 
         assert!(matches!(record.next(), Record::E(Event::Command(_))));
 
@@ -410,7 +410,7 @@ fn participate_in_autofocus() {
         assert_eq!(harness.window().focus_chain(), &[id_1, id_2, id_3, id_4]);
 
         // tell the replacer widget to swap its children
-        harness.submit_command(REPLACE_CHILD, None);
+        harness.submit_command(REPLACE_CHILD);
 
         // verify that the two new children are registered for focus.
         assert_eq!(
@@ -471,7 +471,7 @@ fn register_after_adding_child() {
         assert!(harness.get_state(id_5).children.may_contain(&id_4));
         assert_eq!(harness.get_state(id_5).children.entry_count(), 3);
 
-        harness.submit_command(REPLACE_CHILD, None);
+        harness.submit_command(REPLACE_CHILD);
 
         assert!(harness.get_state(id_5).children.may_contain(&id_6));
         assert!(harness.get_state(id_5).children.may_contain(&id_4));
@@ -501,7 +501,7 @@ fn request_update() {
     Harness::create_simple((), widget, |harness| {
         harness.send_initial_events();
         assert!(!updated.get());
-        harness.submit_command(REQUEST_UPDATE, None);
+        harness.submit_command(REQUEST_UPDATE);
         assert!(updated.get());
     })
 }

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -371,7 +371,7 @@ impl Widget<String> for TextBox {
         match event {
             LifeCycle::WidgetAdded => ctx.register_for_focus(),
             // an open question: should we be able to schedule timers here?
-            LifeCycle::FocusChanged(true) => ctx.submit_command(RESET_BLINK, ctx.widget_id()),
+            LifeCycle::FocusChanged(true) => ctx.submit_command(RESET_BLINK.to(ctx.widget_id())),
             _ => (),
         }
     }

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -167,8 +167,8 @@ impl<T: Data> Inner<T> {
         }
     }
 
-    fn append_command(&mut self, target: Target, cmd: Command) {
-        self.command_queue.push_back((target, cmd));
+    fn append_command(&mut self, cmd: Command) {
+        self.command_queue.push_back(cmd);
     }
 
     /// A helper fn for setting up the `DelegateCtx`. Takes a closure with
@@ -205,8 +205,8 @@ impl<T: Data> Inner<T> {
         }
     }
 
-    fn delegate_cmd(&mut self, target: Target, cmd: &Command) -> bool {
-        self.with_delegate(|del, data, env, ctx| del.command(ctx, target, cmd, data, env))
+    fn delegate_cmd(&mut self, cmd: &Command) -> bool {
+        self.with_delegate(|del, data, env, ctx| del.command(ctx, cmd.target(), cmd, data, env))
             .unwrap_or(true)
     }
 
@@ -312,12 +312,12 @@ impl<T: Data> Inner<T> {
     }
 
     /// Returns `true` if the command was handled.
-    fn dispatch_cmd(&mut self, target: Target, cmd: Command) -> bool {
-        if !self.delegate_cmd(target, &cmd) {
+    fn dispatch_cmd(&mut self, cmd: Command) -> bool {
+        if !self.delegate_cmd(&cmd) {
             return true;
         }
 
-        match target {
+        match cmd.target() {
             Target::Window(id) => {
                 // first handle special window-level events
                 if cmd.is(sys_cmd::SET_MENU) {
@@ -337,8 +337,7 @@ impl<T: Data> Inner<T> {
             // this widget, breaking if the event is handled.
             Target::Widget(id) => {
                 for w in self.windows.iter_mut().filter(|w| w.may_contain_widget(id)) {
-                    let event =
-                        Event::Internal(InternalEvent::TargetedCommand(id.into(), cmd.clone()));
+                    let event = Event::Internal(InternalEvent::TargetedCommand(cmd.clone()));
                     if w.event(&mut self.command_queue, event, &mut self.data, &self.env) {
                         return true;
                     }
@@ -351,6 +350,9 @@ impl<T: Data> Inner<T> {
                         return true;
                     }
                 }
+            }
+            Target::Auto => {
+                log::error!("{:?} reached window handler with `Target::Auto`", cmd);
             }
         }
         false
@@ -513,7 +515,7 @@ impl<T: Data> AppState<T> {
         loop {
             let next_cmd = self.inner.borrow_mut().command_queue.pop_front();
             match next_cmd {
-                Some((target, cmd)) => self.handle_cmd(target, cmd),
+                Some(cmd) => self.handle_cmd(cmd),
                 None => break,
             }
         }
@@ -523,7 +525,7 @@ impl<T: Data> AppState<T> {
         loop {
             let ext_cmd = self.inner.borrow_mut().ext_event_host.recv();
             match ext_cmd {
-                Some((targ, cmd)) => self.handle_cmd(targ.unwrap_or(Target::Global), cmd),
+                Some(cmd) => self.handle_cmd(cmd),
                 None => break,
             }
         }
@@ -539,7 +541,7 @@ impl<T: Data> AppState<T> {
         let cmd = self.inner.borrow().get_menu_cmd(window_id, cmd_id);
         let target = window_id.map(Into::into).unwrap_or(Target::Global);
         match cmd {
-            Some(cmd) => self.inner.borrow_mut().append_command(target, cmd),
+            Some(cmd) => self.inner.borrow_mut().append_command(cmd.to(target)),
             None => log::warn!("No command for menu id {}", cmd_id),
         }
         self.process_commands();
@@ -548,9 +550,9 @@ impl<T: Data> AppState<T> {
 
     /// Handle a command. Top level commands (e.g. for creating and destroying
     /// windows) have their logic here; other commands are passed to the window.
-    fn handle_cmd(&mut self, target: Target, cmd: Command) {
+    fn handle_cmd(&mut self, cmd: Command) {
         use Target as T;
-        match target {
+        match cmd.target() {
             // these are handled the same no matter where they come from
             _ if cmd.is(sys_cmd::QUIT_APP) => self.quit(),
             _ if cmd.is(sys_cmd::HIDE_APPLICATION) => self.hide_app(),
@@ -566,7 +568,7 @@ impl<T: Data> AppState<T> {
             T::Window(id) if cmd.is(sys_cmd::SHOW_OPEN_PANEL) => self.show_open_panel(cmd, id),
             T::Window(id) if cmd.is(sys_cmd::SHOW_SAVE_PANEL) => self.show_save_panel(cmd, id),
             T::Window(id) if cmd.is(sys_cmd::CLOSE_WINDOW) => {
-                if !self.inner.borrow_mut().dispatch_cmd(target, cmd) {
+                if !self.inner.borrow_mut().dispatch_cmd(cmd) {
                     self.request_close_window(id);
                 }
             }
@@ -579,7 +581,7 @@ impl<T: Data> AppState<T> {
                 log::warn!("SHOW_WINDOW command must target a window.")
             }
             _ => {
-                self.inner.borrow_mut().dispatch_cmd(target, cmd);
+                self.inner.borrow_mut().dispatch_cmd(cmd);
             }
         }
     }
@@ -597,13 +599,13 @@ impl<T: Data> AppState<T> {
             .map(|w| w.handle.clone());
 
         let result = handle.and_then(|mut handle| handle.open_file_sync(options));
-        if let Some(info) = result {
-            let cmd = Command::new(sys_cmd::OPEN_FILE, info);
-            self.inner.borrow_mut().dispatch_cmd(window_id.into(), cmd);
-        } else {
-            let cmd = sys_cmd::OPEN_PANEL_CANCELLED.into();
-            self.inner.borrow_mut().dispatch_cmd(window_id.into(), cmd);
-        }
+        self.inner.borrow_mut().dispatch_cmd({
+            if let Some(info) = result {
+                sys_cmd::OPEN_FILE.with(info).to(window_id)
+            } else {
+                sys_cmd::OPEN_PANEL_CANCELLED.to(window_id)
+            }
+        });
     }
 
     fn show_save_panel(&mut self, cmd: Command, window_id: WindowId) {
@@ -614,14 +616,15 @@ impl<T: Data> AppState<T> {
             .windows
             .get_mut(window_id)
             .map(|w| w.handle.clone());
+
         let result = handle.and_then(|mut handle| handle.save_as_sync(options));
-        if let Some(info) = result {
-            let cmd = Command::new(sys_cmd::SAVE_FILE, Some(info));
-            self.inner.borrow_mut().dispatch_cmd(window_id.into(), cmd);
-        } else {
-            let cmd = sys_cmd::SAVE_PANEL_CANCELLED.into();
-            self.inner.borrow_mut().dispatch_cmd(window_id.into(), cmd);
-        }
+        self.inner.borrow_mut().dispatch_cmd({
+            if let Some(info) = result {
+                sys_cmd::SAVE_FILE.with(Some(info)).to(window_id)
+            } else {
+                sys_cmd::SAVE_PANEL_CANCELLED.to(window_id)
+            }
+        });
     }
 
     fn new_window(&mut self, cmd: Command) -> Result<(), Box<dyn std::error::Error>> {
@@ -762,7 +765,7 @@ impl<T: Data> WinHandler for DruidHandler<T> {
 
     fn request_close(&mut self) {
         self.app_state
-            .handle_cmd(self.window_id.into(), sys_cmd::CLOSE_WINDOW.into());
+            .handle_cmd(sys_cmd::CLOSE_WINDOW.to(self.window_id));
         self.app_state.inner.borrow_mut().do_update();
     }
 

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -539,9 +539,13 @@ impl<T: Data> AppState<T> {
     /// is open but a menu exists, as on macOS) it will be `None`.
     fn handle_system_cmd(&mut self, cmd_id: u32, window_id: Option<WindowId>) {
         let cmd = self.inner.borrow().get_menu_cmd(window_id, cmd_id);
-        let target = window_id.map(Into::into).unwrap_or(Target::Global);
         match cmd {
-            Some(cmd) => self.inner.borrow_mut().append_command(cmd.to(target)),
+            Some(cmd) => {
+                let default_target = window_id.map(Into::into).unwrap_or(Target::Global);
+                self.inner
+                    .borrow_mut()
+                    .append_command(cmd.default_to(default_target))
+            }
             None => log::warn!("No command for menu id {}", cmd_id),
         }
         self.process_commands();


### PR DESCRIPTION
This moves the `Target` into `Command`.

Currently, widgets receiving commands can't tell what the commands target actually was, and internally we have a similar problem, because we have to manually work with `(Target, Command)` tuples when ever we need access to the target.

Now `Command::target` can be used to access it at any time.

@cmyr If I remember correctly, you proposed this? I think it will work well.