### PR TITLE
Add set_focus to EventCtx.

### DIFF
--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -449,6 +449,21 @@ impl EventCtx<'_, '_> {
         self.widget_state.request_focus = Some(FocusChange::Focus(id));
     }
 
+    /// Transfer focus to the widget with the given `WidgetId`.
+    ///
+    /// This should only be called by a widget that currently has focus.
+    ///
+    /// See [`is_focused`] for more information about focus.
+    ///
+    /// [`is_focused`]: struct.EventCtx.html#method.is_focused
+    pub fn set_focus(&mut self, target: WidgetId) {
+        if self.is_focused() {
+            self.widget_state.request_focus = Some(FocusChange::Focus(target));
+        } else {
+            log::warn!("set_focus can only be called by the currently focused widget");
+        }
+    }
+
     /// Transfer focus to the next focusable widget.
     ///
     /// This should only be called by a widget that currently has focus.

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -451,17 +451,11 @@ impl EventCtx<'_, '_> {
 
     /// Transfer focus to the widget with the given `WidgetId`.
     ///
-    /// This should only be called by a widget that currently has focus.
-    ///
     /// See [`is_focused`] for more information about focus.
     ///
     /// [`is_focused`]: struct.EventCtx.html#method.is_focused
     pub fn set_focus(&mut self, target: WidgetId) {
-        if self.is_focused() {
-            self.widget_state.request_focus = Some(FocusChange::Focus(target));
-        } else {
-            log::warn!("set_focus can only be called by the currently focused widget");
-        }
+        self.widget_state.request_focus = Some(FocusChange::Focus(target));
     }
 
     /// Transfer focus to the next focusable widget.


### PR DESCRIPTION
A simple method that allows transferring focus to any arbitrary WidgetId, instead of just next and previous. I know focus is being reworked somewhat, but given how small this is I'd love if it could be added.

Open question: What would happen if a WidgetId is passed in whose widget has not registered_for_focus? Should documentation be added about this case? Should a check and warning/panic be added?