### PR TITLE
Fix misaligned labels with debug_widget_id

### DIFF
--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -462,12 +462,9 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
 
             ctx.paint_with_z_index(ctx.depth(), move |ctx| {
                 let origin = Point::new(origin.x.max(0.0), origin.y.max(0.0));
-
-                let text_pos = origin + Vec2::new(0., 8.0);
                 let text_rect = Rect::from_origin_size(origin, text_size);
-
                 ctx.fill(text_rect, &border_color);
-                ctx.draw_text(&text, text_pos);
+                ctx.draw_text(&text, origin);
             })
         }
     }


### PR DESCRIPTION
Calling debug_widget_id() on a widget tree sets a flag that causes
us to draw the id and frame of widgets when they are hovered; this
had broken slightly as a result of 67c7db6c.

before this patch (with `debug_widget_id()` added to the `hello` example):

<img width="455" alt="Screen Shot 2020-09-08 at 12 00 05 PM" src="https://user-images.githubusercontent.com/3330916/92500842-bffe7180-f1cb-11ea-9333-3c65caa54afe.png">

after this patch:
<img width="512" alt="Screen Shot 2020-09-08 at 12 00 49 PM" src="https://user-images.githubusercontent.com/3330916/92500860-c55bbc00-f1cb-11ea-8fe1-d601c0fc95a2.png">
