### PR TITLE
Set the Command's target in context.

### DIFF
--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -681,7 +681,8 @@ impl<'a> ContextState<'a> {
     }
 
     fn submit_command(&mut self, command: Command) {
-        self.command_queue.push_back(command)
+        self.command_queue
+            .push_back(command.default_to(self.window_id));
     }
 
     fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {


### PR DESCRIPTION
After recently updating druids, many of my commands stopped working. This fixed them, and according to the documentation for `submit_command` I think it has a chance of being correct.