### PR TITLE
Don't make Scroll bigger than its child on the non-scrolling axis.

### DIFF
--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -143,7 +143,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
         self.child
             .set_layout_rect(ctx, data, env, child_size.to_rect());
 
-        let self_size = bc.constrain(max_bc);
+        let self_size = bc.constrain(child_size);
         let _ = self.scroll_component.scroll(Vec2::new(0.0, 0.0), self_size);
         self_size
     }


### PR DESCRIPTION
This undoes another change from #1107 that I think was a regression.

For example, if I have a horizontal scroll whose child has a finite height, I think that the scroll should inherit that same height. After #1107, the scroll would instead make its height as large as possible.