### PR TITLE
Add debug_assert in TextLayout::draw

### DIFF
--- a/druid/src/text/layout.rs
+++ b/druid/src/text/layout.rs
@@ -244,7 +244,14 @@ impl TextLayout {
     ///
     ///  [`rebuild_if_needed`]: #method.rebuild_if_needed
     pub fn draw(&self, ctx: &mut PaintCtx, point: impl Into<Point>) {
-        ctx.draw_text(self.layout.as_ref().unwrap(), point)
+        debug_assert!(
+            self.layout.is_some(),
+            "TextLayout::draw called without rebuilding layout object. Text was '{}'",
+            &self.text
+        );
+        if let Some(layout) = self.layout.as_ref() {
+            ctx.draw_text(layout, point);
+        }
     }
 }
 


### PR DESCRIPTION
This will hopefully help diagnose issues around not rebuilding
layout objects appropriately.

It's arguable we should also panic in release; I don't have strong feelings in either direction. 🤷 