### PR TITLE
Remove old Text typealias from druid-shell

### DIFF
--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -61,8 +61,6 @@ pub use menu::Menu;
 pub use mouse::{Cursor, MouseButton, MouseButtons, MouseEvent};
 pub use region::Region;
 pub use scale::{Scalable, Scale, ScaledArea};
-pub use window::{
-    IdleHandle, IdleToken, Text, TimerToken, WinHandler, WindowBuilder, WindowHandle,
-};
+pub use window::{IdleHandle, IdleToken, TimerToken, WinHandler, WindowBuilder, WindowHandle};
 
 pub use keyboard_types;

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -33,7 +33,7 @@ use gtk::prelude::*;
 use gtk::{AccelGroup, ApplicationWindow, DrawingArea};
 
 use crate::kurbo::{Point, Rect, Size, Vec2};
-use crate::piet::{Piet, RenderContext};
+use crate::piet::{Piet, PietText, RenderContext};
 
 use crate::common_util::IdleCallback;
 use crate::dialog::{FileDialogOptions, FileDialogType, FileInfo};
@@ -42,7 +42,7 @@ use crate::keyboard::{KbKey, KeyEvent, KeyState, Modifiers};
 use crate::mouse::{Cursor, MouseButton, MouseButtons, MouseEvent};
 use crate::region::Region;
 use crate::scale::{Scalable, Scale, ScaledArea};
-use crate::window::{IdleToken, Text, TimerToken, WinHandler};
+use crate::window::{IdleToken, TimerToken, WinHandler};
 
 use super::application::Application;
 use super::dialog;
@@ -705,8 +705,8 @@ impl WindowHandle {
         }
     }
 
-    pub fn text(&self) -> Text {
-        Text::new()
+    pub fn text(&self) -> PietText {
+        PietText::new()
     }
 
     pub fn request_timer(&self, deadline: Instant) -> TimerToken {

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -56,7 +56,7 @@ use crate::keyboard_types::KeyState;
 use crate::mouse::{Cursor, MouseButton, MouseButtons, MouseEvent};
 use crate::region::Region;
 use crate::scale::Scale;
-use crate::window::{IdleToken, Text, TimerToken, WinHandler};
+use crate::window::{IdleToken, TimerToken, WinHandler};
 use crate::Error;
 
 #[allow(non_upper_case_globals)]
@@ -831,7 +831,7 @@ impl WindowHandle {
         token
     }
 
-    pub fn text(&self) -> Text {
+    pub fn text(&self) -> PietText {
         let view = self.nsview.load();
         unsafe {
             if let Some(view) = (*view).as_ref() {

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -27,7 +27,7 @@ use wasm_bindgen::JsCast;
 
 use crate::kurbo::{Point, Rect, Size, Vec2};
 
-use crate::piet::RenderContext;
+use crate::piet::{RenderContext, PietText};
 
 use super::application::Application;
 use super::error::Error;
@@ -41,7 +41,7 @@ use crate::scale::{Scale, ScaledArea};
 use crate::keyboard::{KbKey, KeyState, Modifiers};
 use crate::mouse::{Cursor, MouseButton, MouseButtons, MouseEvent};
 use crate::region::Region;
-use crate::window::{IdleToken, Text, TimerToken, WinHandler};
+use crate::window::{IdleToken, TimerToken, WinHandler};
 
 // This is a macro instead of a function since KeyboardEvent and MouseEvent has identical functions
 // to query modifier key states.
@@ -461,13 +461,13 @@ impl WindowHandle {
         self.render_soon();
     }
 
-    pub fn text(&self) -> Text {
+    pub fn text(&self) -> PietText {
         let s = self
             .0
             .upgrade()
             .unwrap_or_else(|| panic!("Failed to produce a text context"));
 
-        Text::new(s.context.clone())
+        PietText::new(s.context.clone())
     }
 
     pub fn request_timer(&self, deadline: Instant) -> TimerToken {

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -45,7 +45,7 @@ use piet_common::dwrite::DwriteFactory;
 use crate::platform::windows::HwndRenderTarget;
 
 use crate::kurbo::{Point, Rect, Size, Vec2};
-use crate::piet::{Piet, RenderContext};
+use crate::piet::{Piet, PietText, RenderContext};
 
 use super::accels::register_accel;
 use super::application::Application;
@@ -65,7 +65,7 @@ use crate::keyboard::{KbKey, KeyState};
 use crate::mouse::{Cursor, MouseButton, MouseButtons, MouseEvent};
 use crate::region::Region;
 use crate::scale::{Scalable, Scale, ScaledArea};
-use crate::window::{IdleToken, Text, TimerToken, WinHandler};
+use crate::window::{IdleToken, TimerToken, WinHandler};
 
 /// The platform target DPI.
 ///
@@ -1383,8 +1383,8 @@ impl WindowHandle {
         }
     }
 
-    pub fn text(&self) -> Text {
-        Text::new(self.dwrite_factory.clone())
+    pub fn text(&self) -> PietText {
+        PietText::new(self.dwrite_factory.clone())
     }
 
     /// Request a timer event.

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -42,10 +42,10 @@ use crate::error::Error as ShellError;
 use crate::keyboard::{KeyEvent, KeyState, Modifiers};
 use crate::kurbo::{Point, Rect, Size, Vec2};
 use crate::mouse::{Cursor, MouseButton, MouseButtons, MouseEvent};
-use crate::piet::{Piet, RenderContext};
+use crate::piet::{Piet, PietText, RenderContext};
 use crate::region::Region;
 use crate::scale::Scale;
-use crate::window::{IdleToken, Text, TimerToken, WinHandler};
+use crate::window::{IdleToken, TimerToken, WinHandler};
 
 use super::application::Application;
 use super::keycodes;
@@ -1398,9 +1398,8 @@ impl WindowHandle {
         }
     }
 
-    pub fn text(&self) -> Text {
-        // I'm not entirely sure what this method is doing here, so here's a Text.
-        Text::new()
+    pub fn text(&self) -> PietText {
+        PietText::new()
     }
 
     pub fn request_timer(&self, deadline: Instant) -> TimerToken {

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -28,11 +28,7 @@ use crate::mouse::{Cursor, MouseEvent};
 use crate::platform::window as platform;
 use crate::region::Region;
 use crate::scale::Scale;
-
-// It's possible we'll want to make this type alias at a lower level,
-// see https://github.com/linebender/piet/pull/37 for more discussion.
-/// The platform text factory, reexported from piet.
-pub type Text<'a> = <piet_common::Piet<'a> as piet_common::RenderContext>::Text;
+use piet_common::PietText;
 
 /// A token that uniquely identifies a running timer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
@@ -162,7 +158,7 @@ impl WindowHandle {
     }
 
     /// Get access to a type that can perform text layout.
-    pub fn text(&self) -> Text {
+    pub fn text(&self) -> PietText {
         self.0.text()
     }
 

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -21,12 +21,11 @@ use std::{
 };
 
 use crate::core::{CommandQueue, FocusChange, WidgetState};
-use crate::piet::Piet;
-use crate::piet::RenderContext;
+use crate::piet::{Piet, PietText, RenderContext};
 use crate::shell::Region;
 use crate::{
     commands, Affine, Command, ContextMenu, Cursor, ExtEventSink, Insets, MenuDesc, Point, Rect,
-    SingleUse, Size, Target, Text, TimerToken, WidgetId, WindowDesc, WindowHandle, WindowId,
+    SingleUse, Size, Target, TimerToken, WidgetId, WindowDesc, WindowHandle, WindowId,
 };
 
 /// A macro for implementing methods on multiple contexts.
@@ -155,7 +154,7 @@ impl_context_method!(
         }
 
         /// Get an object which can create text layouts.
-        pub fn text(&self) -> Text {
+        pub fn text(&self) -> PietText {
             self.state.window.text()
         }
     }

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -179,8 +179,7 @@ pub use shell::keyboard_types;
 pub use shell::{
     Application, Clipboard, ClipboardFormat, Code, Cursor, Error as PlatformError,
     FileDialogOptions, FileInfo, FileSpec, FormatId, HotKey, KbKey, KeyEvent, Location, Modifiers,
-    MouseButton, MouseButtons, RawMods, Region, Scalable, Scale, SysMods, Text, TimerToken,
-    WindowHandle,
+    MouseButton, MouseButtons, RawMods, Region, Scalable, Scale, SysMods, TimerToken, WindowHandle,
 };
 
 pub use crate::core::WidgetPod;


### PR DESCRIPTION
This was a vestige from long ago? In any case it was confusing since
it was exactly the same as the PietText type alias in piet_common.