### PR TITLE
Implement the close hook for x11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - `ScrollComponent` for ease of adding consistent, customized, scrolling behavior to a widget. ([#1107] by [@ForLoveOfCats])
 - Selection text color to textbox. ([#1093] by [@sysint64])
 - `BoxConstraints::UNBOUNDED` constant. ([#1126] by [@danieldulaney])
-- Close requests from the shell can now be intercepted ([#1118] by [@jneem])
+- Close requests from the shell can now be intercepted ([#1118] by [@jneem], [#1204] by [@psychon])
 - The Lens derive now supports an `ignore` attribute. ([#1133] by [@jneem])
 - `request_update` in `EventCtx`. ([#1128] by [@raphlinus])
 - `ExtEventSink`s can now be obtained from widget methods. ([#1152] by [@jneem])
@@ -424,6 +424,7 @@ Last release without a changelog :(
 [#1182]: https://github.com/linebender/druid/pull/1185
 [#1185]: https://github.com/linebender/druid/pull/1185
 [#1092]: https://github.com/linebender/druid/pull/1092
+[#1204]: https://github.com/linebender/druid/pull/1204
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master
 [0.6.0]: https://github.com/linebender/druid/compare/v0.5.0...v0.6.0

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -906,7 +906,7 @@ impl Window {
         if client_message.type_ == self.atoms.WM_PROTOCOLS && client_message.format == 32 {
             let protocol = client_message.data.as_data32()[0];
             if protocol == self.atoms.WM_DELETE_WINDOW {
-                self.close();
+                self.handler.borrow_mut().request_close();
             }
         }
         Ok(())


### PR DESCRIPTION
Commit 7b6f83e8c48 added a close request hook and implemented it. This
commit implements this request for the x11 platform. Either I did
something wrong, or it is way easier to do this on x11 than on Gtk.

Signed-off-by: Uli Schlachter <psychon@znc.in>

CC @jneem

Edit: Related to #1159