### PR TITLE
Pass shared PietText by ref instead of cloning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - Moved `Target` parameter from `submit_command` to `Command::new` and `Command::to`. ([#1185] by [@finnerale])
 - `Movement::RightOfLine` to `Movement::NextLineBreak`, and `Movement::LeftOfLine` to `Movement::PrecedingLineBreak`. ([#1092] by [@sysint64])
 - `AnimFrame` was moved from `lifecycle` to `event` ([#1155] by [@jneem])
+- Contexts' `text()` methods return `&mut PietText` instead of cloning ([#1205] by [@cmyr])
 
 ### Deprecated
 
@@ -425,6 +426,7 @@ Last release without a changelog :(
 [#1185]: https://github.com/linebender/druid/pull/1185
 [#1092]: https://github.com/linebender/druid/pull/1092
 [#1204]: https://github.com/linebender/druid/pull/1204
+[#1205]: https://github.com/linebender/druid/pull/1205
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master
 [0.6.0]: https://github.com/linebender/druid/compare/v0.5.0...v0.6.0

--- a/druid/examples/custom_widget.rs
+++ b/druid/examples/custom_widget.rs
@@ -89,7 +89,7 @@ impl Widget<String> for CustomWidget {
         let mut layout = TextLayout::new(data.as_str());
         layout.set_font(FontDescriptor::new(FontFamily::SERIF).with_size(24.0));
         layout.set_text_color(fill_color);
-        layout.rebuild_if_needed(&mut ctx.text(), env);
+        layout.rebuild_if_needed(ctx.text(), env);
 
         // Let's rotate our text slightly. First we save our current (default) context:
         ctx.with_save(|ctx| {

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -48,6 +48,7 @@ pub(crate) struct ContextState<'a> {
     pub(crate) ext_handle: &'a ExtEventSink,
     pub(crate) window_id: WindowId,
     pub(crate) window: &'a WindowHandle,
+    pub(crate) text: PietText,
     /// The id of the widget that currently has focus.
     pub(crate) focus_widget: Option<WidgetId>,
     pub(crate) root_app_data_type: TypeId,
@@ -154,8 +155,8 @@ impl_context_method!(
         }
 
         /// Get an object which can create text layouts.
-        pub fn text(&self) -> PietText {
-            self.state.window.text()
+        pub fn text(&mut self) -> &mut PietText {
+            &mut self.state.text
         }
     }
 );
@@ -675,6 +676,7 @@ impl<'a> ContextState<'a> {
             window,
             window_id,
             focus_widget,
+            text: window.text(),
             root_app_data_type: TypeId::of::<T>(),
         }
     }

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -442,8 +442,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             self.debug_widget_text.set_text(id_string);
             self.debug_widget_text.set_text_size(10.0);
             self.debug_widget_text.set_text_color(text_color);
-            self.debug_widget_text
-                .rebuild_if_needed(&mut ctx.text(), env);
+            self.debug_widget_text.rebuild_if_needed(ctx.text(), env);
         }
     }
 
@@ -986,16 +985,16 @@ mod tests {
 
         let mut command_queue: CommandQueue = VecDeque::new();
         let mut widget_state = WidgetState::new(WidgetId::next(), None);
+        let window = WindowHandle::default();
         let ext_host = ExtEventHost::default();
         let ext_handle = ext_host.make_sink();
-        let mut state = ContextState {
-            command_queue: &mut command_queue,
-            ext_handle: &ext_handle,
-            window_id: WindowId::next(),
-            window: &WindowHandle::default(),
-            root_app_data_type: std::any::TypeId::of::<Option<u32>>(),
-            focus_widget: None,
-        };
+        let mut state = ContextState::new::<Option<u32>>(
+            &mut command_queue,
+            &ext_handle,
+            &window,
+            WindowId::next(),
+            None,
+        );
 
         let mut ctx = LifeCycleCtx {
             widget_state: &mut widget_state,

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -160,8 +160,8 @@ impl Widget<bool> for Switch {
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &bool, env: &Env) {
         if matches!(event, LifeCycle::WidgetAdded) {
-            self.on_text.rebuild_if_needed(&mut ctx.text(), env);
-            self.off_text.rebuild_if_needed(&mut ctx.text(), env);
+            self.on_text.rebuild_if_needed(ctx.text(), env);
+            self.off_text.rebuild_if_needed(ctx.text(), env);
         }
     }
 

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -361,7 +361,7 @@ impl Widget<String> for TextBox {
             self.do_edit_action(edit_action, data);
             self.reset_cursor_blink(ctx);
             self.text.set_text(data.as_str());
-            self.text.rebuild_if_needed(&mut ctx.text(), env);
+            self.text.rebuild_if_needed(ctx.text(), env);
 
             if !is_select_all {
                 self.update_hscroll();
@@ -374,7 +374,7 @@ impl Widget<String> for TextBox {
             LifeCycle::WidgetAdded => {
                 ctx.register_for_focus();
                 self.text.set_text(data.clone());
-                self.text.rebuild_if_needed(&mut ctx.text(), env);
+                self.text.rebuild_if_needed(ctx.text(), env);
             }
             // an open question: should we be able to schedule timers here?
             LifeCycle::FocusChanged(true) => ctx.submit_command(RESET_BLINK.to(ctx.widget_id())),
@@ -400,7 +400,7 @@ impl Widget<String> for TextBox {
             }
         }
 
-        self.text.rebuild_if_needed(&mut ctx.text(), env);
+        self.text.rebuild_if_needed(ctx.text(), env);
         ctx.request_paint();
     }
 


### PR DESCRIPTION
Currently we create a copy of the PietText object every time we
need one. This changes that so that there is a single instance
in the ContextState, and the various contexts just pass out
a reference to this object as needed.

This should have few practical implications, except that in
trees with lots of text we will save a few microseconds. It's
mostly an API improvement, since the methods that tend to use
a PietText object generally want it passed by ref anyway.