### PR TITLE
Make sure the default Target is Global when calling process_ext_events

### DIFF
--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -525,7 +525,7 @@ impl<T: Data> AppState<T> {
         loop {
             let ext_cmd = self.inner.borrow_mut().ext_event_host.recv();
             match ext_cmd {
-                Some(cmd) => self.handle_cmd(cmd),
+                Some(cmd) => self.handle_cmd(cmd.default_to(Target::Global)),
                 None => break,
             }
         }


### PR DESCRIPTION
`ExtEventSink::submit_command` was before when using with `Target::Auto` not calling the Widget Controllers. This behaviour was before implementing `Target::*` expected to happen.

(As discussed in zulip. This change was suggested by @cmyr )