### PR TITLE
Fix the invalidation region for Scroll.

### DIFF
--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -97,7 +97,9 @@ impl<T, W: Widget<T>> Scroll<T, W> {
     ///
     /// Returns `true` if the scroll offset has changed.
     pub fn scroll(&mut self, delta: Vec2, layout_size: Size) -> bool {
-        self.scroll_component.scroll(delta, layout_size)
+        let scrolled = self.scroll_component.scroll(delta, layout_size);
+        self.child.set_viewport_offset(self.offset());
+        scrolled
     }
 }
 
@@ -116,6 +118,9 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
         }
 
         self.scroll_component.handle_scroll(ctx, event, env);
+        // In order to ensure that invalidation regions are correctly propagated up the tree,
+        // we need to set the viewport offset on our child whenever we change our scroll offset.
+        self.child.set_viewport_offset(self.offset());
     }
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
@@ -145,6 +150,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
 
         let self_size = bc.constrain(child_size);
         let _ = self.scroll_component.scroll(Vec2::new(0.0, 0.0), self_size);
+        self.child.set_viewport_offset(self.offset());
         self_size
     }
 


### PR DESCRIPTION
The scroll widget needs to call `child.set_viewport_offset` every time the scroll offset changes.