### PR TITLE
Fix placeholder not showing in TextBox

### DIFF
--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -392,7 +392,7 @@ impl Widget<String> for TextBox {
         // setting text color rebuilds layout, so don't do it if we don't have to
         if !old_data.same(data) {
             self.selection = self.selection.constrain_to(content);
-            self.text.set_text(data.as_str());
+            self.text.set_text(content.as_str());
             if data.is_empty() {
                 self.text.set_text_color(theme::PLACEHOLDER_COLOR);
             } else {


### PR DESCRIPTION
This is a fix that I guess was a typo in [#1182](https://github.com/linebender/druid/commit/861bfbff5023a2ade607cf431621519e436f0ad8#diff-ca50d42ad035423650acfaa2096af327R395).