### PR TITLE
Add TextAlignment support to TextLayout and Label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - `TextLayout` type simplifies drawing text ([#1182] by [@cmyr])
 - Implementation of `Data` trait for `i128` and `u128` primitive data types. ([#1214] by [@koutoftimer])
 - `LineBreaking` enum allows configuration of label line-breaking ([#1195] by [@cmyr])
+- `TextAlignment` support in `TextLayout` and `Label` ([#1210] by [@cmyr])`
 
 ### Changed
 
@@ -442,6 +443,7 @@ Last release without a changelog :(
 [#1195]: https://github.com/linebender/druid/pull/1195
 [#1204]: https://github.com/linebender/druid/pull/1204
 [#1205]: https://github.com/linebender/druid/pull/1205
+[#1210]: https://github.com/linebender/druid/pull/1210
 [#1214]: https://github.com/linebender/druid/pull/1214
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master

--- a/druid/examples/text.rs
+++ b/druid/examples/text.rs
@@ -16,7 +16,8 @@
 
 use druid::widget::{Controller, Flex, Label, LineBreaking, RadioGroup, Scroll};
 use druid::{
-    AppLauncher, Color, Data, Env, Lens, LocalizedString, UpdateCtx, Widget, WidgetExt, WindowDesc,
+    AppLauncher, Color, Data, Env, Lens, LocalizedString, TextAlignment, UpdateCtx, Widget,
+    WidgetExt, WindowDesc,
 };
 
 const WINDOW_TITLE: LocalizedString<AppState> = LocalizedString::new("Text Options");
@@ -28,8 +29,8 @@ const SPACER_SIZE: f64 = 8.0;
 
 #[derive(Clone, Data, Lens)]
 struct AppState {
-    ///  the width at which to wrap lines.
     line_break_mode: LineBreaking,
+    alignment: TextAlignment,
 }
 
 /// A controller that sets properties on a label.
@@ -49,6 +50,9 @@ impl Controller<AppState, Label<AppState>> for LabelController {
             child.set_line_break_mode(data.line_break_mode);
             ctx.request_layout();
         }
+        if old_data.alignment != data.alignment {
+            child.set_text_alignment(data.alignment);
+        }
         child.update(ctx, old_data, data, env);
     }
 }
@@ -62,6 +66,7 @@ pub fn main() {
     // create the initial app state
     let initial_state = AppState {
         line_break_mode: LineBreaking::Clip,
+        alignment: Default::default(),
     };
 
     // start the application
@@ -93,9 +98,26 @@ fn build_root_widget() -> impl Widget<AppState> {
         ]))
         .lens(AppState::line_break_mode);
 
-    Flex::column()
+    let alignment_picker = Flex::column()
+        .with_child(Label::new("Justification"))
+        .with_spacer(SPACER_SIZE)
+        .with_child(RadioGroup::new(vec![
+            ("Start", TextAlignment::Start),
+            ("End", TextAlignment::End),
+            ("Center", TextAlignment::Center),
+            ("Justified", TextAlignment::Justified),
+        ]))
+        .lens(AppState::alignment);
+
+    let controls = Flex::row()
+        .cross_axis_alignment(druid::widget::CrossAxisAlignment::Start)
+        .with_child(alignment_picker)
         .with_spacer(SPACER_SIZE)
         .with_child(line_break_chooser)
-        .with_spacer(SPACER_SIZE)
+        .padding(SPACER_SIZE);
+
+    Flex::column()
+        .cross_axis_alignment(druid::widget::CrossAxisAlignment::Start)
+        .with_child(controls)
         .with_flex_child(label, 1.0)
 }

--- a/druid/src/data.rs
+++ b/druid/src/data.rs
@@ -415,6 +415,12 @@ impl Data for piet::FontStyle {
     }
 }
 
+impl Data for piet::TextAlignment {
+    fn same(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
 #[cfg(feature = "im")]
 impl<T: Data> Data for im::Vector<T> {
     fn same(&self, other: &Self) -> bool {

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -172,7 +172,7 @@ mod window;
 pub use kurbo::{Affine, Insets, Point, Rect, Size, Vec2};
 pub use piet::{
     Color, FontFamily, FontStyle, FontWeight, LinearGradient, RadialGradient, RenderContext,
-    UnitPoint,
+    TextAlignment, UnitPoint,
 };
 // these are the types from shell that we expose; others we only use internally.
 pub use shell::keyboard_types;

--- a/druid/src/text/layout.rs
+++ b/druid/src/text/layout.rs
@@ -18,7 +18,7 @@ use std::ops::Range;
 
 use crate::kurbo::{Line, Point, Rect, Size};
 use crate::piet::{
-    Color, PietText, PietTextLayout, Text as _, TextAttribute, TextLayout as _,
+    Color, PietText, PietTextLayout, Text as _, TextAlignment, TextAttribute, TextLayout as _,
     TextLayoutBuilder as _,
 };
 use crate::{ArcStr, Data, Env, FontDescriptor, KeyOrValue, PaintCtx, RenderContext};
@@ -55,6 +55,7 @@ pub struct TextLayout {
     // the underlying layout object. This is constructed lazily.
     layout: Option<PietTextLayout>,
     wrap_width: f64,
+    alignment: TextAlignment,
 }
 
 impl TextLayout {
@@ -75,6 +76,7 @@ impl TextLayout {
             cached_text_size: None,
             layout: None,
             wrap_width: f64::INFINITY,
+            alignment: Default::default(),
         }
     }
 
@@ -134,6 +136,14 @@ impl TextLayout {
         if let Some(layout) = self.layout.as_mut() {
             let _ = layout.update_width(width);
         }
+    }
+
+    /// Set the [`TextAlignment`] for this layout.
+    ///
+    /// [`TextAlignment`]: enum.TextAlignment.html
+    pub fn set_text_alignment(&mut self, alignment: TextAlignment) {
+        self.alignment = alignment;
+        self.layout = None;
     }
 
     /// The size of the laid-out text.
@@ -239,6 +249,7 @@ impl TextLayout {
                 factory
                     .new_text_layout(self.text.clone())
                     .max_width(self.wrap_width)
+                    .alignment(self.alignment)
                     .font(descriptor.family.clone(), descriptor.size)
                     .default_attribute(descriptor.weight)
                     .default_attribute(descriptor.style)

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -17,7 +17,8 @@
 use crate::piet::{Color, PietText};
 use crate::widget::prelude::*;
 use crate::{
-    BoxConstraints, Data, FontDescriptor, KeyOrValue, LocalizedString, Point, Size, TextLayout,
+    BoxConstraints, Data, FontDescriptor, KeyOrValue, LocalizedString, Point, Size, TextAlignment,
+    TextLayout,
 };
 
 // added padding between the edges of the widget and the text.
@@ -162,6 +163,14 @@ impl<T: Data> Label<T> {
         self
     }
 
+    /// Builder-style method to set the [`TextAlignment`].
+    ///
+    /// [`TextAlignment`]: enum.TextAlignment.html
+    pub fn with_text_alignment(mut self, alignment: TextAlignment) -> Self {
+        self.set_text_alignment(alignment);
+        self
+    }
+
     /// Set the label's text.
     ///
     /// If you change this property, you are responsible for calling
@@ -232,6 +241,14 @@ impl<T: Data> Label<T> {
     /// [`LineBreaking`]: enum.LineBreaking.html
     pub fn set_line_break_mode(&mut self, mode: LineBreaking) {
         self.line_break_mode = mode;
+    }
+
+    /// Set the [`TextAlignment`] for this layout.
+    ///
+    /// [`TextAlignment`]: enum.TextAlignment.html
+    pub fn set_text_alignment(&mut self, alignment: TextAlignment) {
+        self.layout.set_text_alignment(alignment);
+        self.needs_rebuild = true;
     }
 
     fn rebuild_if_needed(&mut self, factory: &mut PietText, data: &T, env: &Env) {


### PR DESCRIPTION
This also updates the 'text' example to demonstrate this feature.

![Screen Shot 2020-09-10 at 12 25 40 PM](https://user-images.githubusercontent.com/3330916/92762594-be19e700-f360-11ea-9c90-5809f6265360.png)
![Screen Shot 2020-09-10 at 12 25 44 PM](https://user-images.githubusercontent.com/3330916/92762609-c07c4100-f360-11ea-8931-a21fa67b3bd8.png)
![Screen Shot 2020-09-10 at 12 25 49 PM](https://user-images.githubusercontent.com/3330916/92762623-c3773180-f360-11ea-9e4c-4ce13ace3ec0.png)
![Screen Shot 2020-09-10 at 12 25 53 PM](https://user-images.githubusercontent.com/3330916/92762636-c540f500-f360-11ea-908d-a8ac811059dd.png)
