### PR TITLE
Fix issues with placeholder TextBox text

### DIFF
--- a/druid/examples/styled_text.rs
+++ b/druid/examples/styled_text.rs
@@ -118,7 +118,7 @@ fn ui_builder() -> impl Widget<AppData> {
     let mono_checkbox = Checkbox::new("Monospace").lens(AppData::mono);
 
     let input = TextBox::new()
-        .with_text_size(38.0)
+        .with_placeholder("Your sample text here :)")
         .fix_width(200.0)
         .lens(AppData::text);
 
@@ -133,5 +133,4 @@ fn ui_builder() -> impl Widget<AppData> {
         .with_child(mono_checkbox)
         .with_spacer(8.0)
         .with_child(input.padding(5.0))
-        .debug_widget_id()
 }

--- a/druid/src/text/layout.rs
+++ b/druid/src/text/layout.rs
@@ -181,7 +181,7 @@ impl TextLayout {
                 let line_metrics = layout.line_metric(pos.line).unwrap();
                 let p1 = (pos.point.x, line_metrics.y_offset);
                 let p2 = (pos.point.x, (line_metrics.y_offset + line_metrics.height));
-                dbg!(Line::new(p1, p2))
+                Line::new(p1, p2)
             })
             .unwrap_or_else(|| Line::new(Point::ZERO, Point::ZERO))
     }

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -360,7 +360,11 @@ impl Widget<String> for TextBox {
 
             self.do_edit_action(edit_action, data);
             self.reset_cursor_blink(ctx);
-            self.text.set_text(data.as_str());
+            if data.is_empty() {
+                self.text.set_text(self.placeholder.as_str());
+            } else {
+                self.text.set_text(data.as_str());
+            }
             self.text.rebuild_if_needed(ctx.text(), env);
 
             if !is_select_all {
@@ -373,7 +377,12 @@ impl Widget<String> for TextBox {
         match event {
             LifeCycle::WidgetAdded => {
                 ctx.register_for_focus();
-                self.text.set_text(data.clone());
+                if data.is_empty() {
+                    self.text.set_text(self.placeholder.as_str());
+                    self.text.set_text_color(theme::PLACEHOLDER_COLOR);
+                } else {
+                    self.text.set_text(data.as_str());
+                }
                 self.text.rebuild_if_needed(ctx.text(), env);
             }
             // an open question: should we be able to schedule timers here?


### PR DESCRIPTION
This was broken slightly by #1182. This patch also cleans up a few
changes from that patch in the styled_text example that I had
not intended to commit.

As reported by @totsteps