### PR TITLE
Use reverse-DNS notation for all built-in keys and selectors

### DIFF
--- a/docs/book_examples/src/env_md.rs
+++ b/docs/book_examples/src/env_md.rs
@@ -2,8 +2,7 @@ use druid::widget::Label;
 use druid::{Color, Key, WidgetExt};
 
 // ANCHOR: key_or_value
-const IMPORTANT_LABEL_COLOR: Key<Color> =
-    Key::new("org.linebender.druid.theme.my-app.important-label-color");
+const IMPORTANT_LABEL_COLOR: Key<Color> = Key::new("org.linebender.example.important-label-color");
 const RED: Color = Color::rgb8(0xFF, 0, 0);
 
 fn make_labels() {

--- a/docs/book_examples/src/env_md.rs
+++ b/docs/book_examples/src/env_md.rs
@@ -2,7 +2,8 @@ use druid::widget::Label;
 use druid::{Color, Key, WidgetExt};
 
 // ANCHOR: key_or_value
-const IMPORTANT_LABEL_COLOR: Key<Color> = Key::new("my-app.important-label-color");
+const IMPORTANT_LABEL_COLOR: Key<Color> =
+    Key::new("org.linebender.druid.theme.my-app.important-label-color");
 const RED: Color = Color::rgb8(0xFF, 0, 0);
 
 fn make_labels() {

--- a/druid/examples/styled_text.rs
+++ b/druid/examples/styled_text.rs
@@ -22,8 +22,7 @@ use druid::{
 use std::fmt::Display;
 
 // This is a custom key we'll use with Env to set and get our font.
-const MY_CUSTOM_FONT: Key<FontDescriptor> =
-    Key::new("org.linebender.druid.theme.styled_text.custom_font");
+const MY_CUSTOM_FONT: Key<FontDescriptor> = Key::new("org.linebender.example.my-custom-font");
 
 #[derive(Clone, Lens, Data)]
 struct AppData {

--- a/druid/examples/styled_text.rs
+++ b/druid/examples/styled_text.rs
@@ -22,7 +22,8 @@ use druid::{
 use std::fmt::Display;
 
 // This is a custom key we'll use with Env to set and get our font.
-const MY_CUSTOM_FONT: Key<FontDescriptor> = Key::new("styled_text.custom_font");
+const MY_CUSTOM_FONT: Key<FontDescriptor> =
+    Key::new("org.linebender.druid.theme.styled_text.custom_font");
 
 #[derive(Clone, Lens, Data)]
 struct AppData {

--- a/druid/src/env.rs
+++ b/druid/src/env.rs
@@ -68,7 +68,7 @@ struct EnvImpl {
 ///
 /// ```
 ///# use druid::{Key, Color, WindowDesc, AppLauncher, widget::Label};
-/// const IMPORTANT_LABEL_COLOR: Key<Color> = Key::new("org.linebender.druid.theme.my-app.important-label-color");
+/// const IMPORTANT_LABEL_COLOR: Key<Color> = Key::new("org.linebender.example.important-label-color");
 ///
 /// fn important_label() -> Label<()> {
 ///     Label::new("Warning!").with_text_color(IMPORTANT_LABEL_COLOR)
@@ -167,7 +167,7 @@ impl Env {
     /// Set by the `debug_paint_layout()` method on [`WidgetExt`]'.
     ///
     /// [`WidgetExt`]: trait.WidgetExt.html
-    pub(crate) const DEBUG_PAINT: Key<bool> = Key::new("org.linebender.druid.theme.debug-paint");
+    pub(crate) const DEBUG_PAINT: Key<bool> = Key::new("org.linebender.druid.built-in.debug-paint");
 
     /// State for whether or not to paint `WidgetId`s, for event debugging.
     ///
@@ -175,7 +175,7 @@ impl Env {
     ///
     /// [`WidgetExt`]: trait.WidgetExt.html
     pub(crate) const DEBUG_WIDGET_ID: Key<bool> =
-        Key::new("org.linebender.druid.theme.debug-widget-id");
+        Key::new("org.linebender.druid.built-in.debug-widget-id");
 
     /// A key used to tell widgets to print additional debug information.
     ///
@@ -198,7 +198,7 @@ impl Env {
     /// ```
     ///
     /// [`WidgetExt::debug_widget`]: trait.WidgetExt.html#method.debug_widget
-    pub const DEBUG_WIDGET: Key<bool> = Key::new("org.linebender.druid.theme.debug-widget");
+    pub const DEBUG_WIDGET: Key<bool> = Key::new("org.linebender.druid.built-in.debug-widget");
 
     /// Gets a value from the environment, expecting it to be present.
     ///
@@ -328,8 +328,8 @@ impl<T> Key<T> {
     /// use druid::Key;
     /// use druid::piet::Color;
     ///
-    /// let float_key: Key<f64> = Key::new("org.linebender.druid.theme.a.very.good.float");
-    /// let color_key: Key<Color> = Key::new("org.linebender.druid.theme.a.very.nice.color");
+    /// let float_key: Key<f64> = Key::new("org.linebender.example.a.very.good.float");
+    /// let color_key: Key<Color> = Key::new("org.linebender.example.a.very.nice.color");
     /// ```
     pub const fn new(key: &'static str) -> Self {
         Key {
@@ -575,7 +575,7 @@ mod tests {
 
     #[test]
     fn string_key_or_value() {
-        const MY_KEY: Key<ArcStr> = Key::new("org.linebender.druid.theme.test.my-string-key");
+        const MY_KEY: Key<ArcStr> = Key::new("org.linebender.test.my-string-key");
         let env = Env::default().adding(MY_KEY, "Owned");
         assert_eq!(env.get(MY_KEY).as_ref(), "Owned");
 

--- a/druid/src/env.rs
+++ b/druid/src/env.rs
@@ -68,7 +68,7 @@ struct EnvImpl {
 ///
 /// ```
 ///# use druid::{Key, Color, WindowDesc, AppLauncher, widget::Label};
-/// const IMPORTANT_LABEL_COLOR: Key<Color> = Key::new("my-app.important-label-color");
+/// const IMPORTANT_LABEL_COLOR: Key<Color> = Key::new("org.linebender.druid.theme.my-app.important-label-color");
 ///
 /// fn important_label() -> Label<()> {
 ///     Label::new("Warning!").with_text_color(IMPORTANT_LABEL_COLOR)
@@ -167,14 +167,15 @@ impl Env {
     /// Set by the `debug_paint_layout()` method on [`WidgetExt`]'.
     ///
     /// [`WidgetExt`]: trait.WidgetExt.html
-    pub(crate) const DEBUG_PAINT: Key<bool> = Key::new("druid.built-in.debug-paint");
+    pub(crate) const DEBUG_PAINT: Key<bool> = Key::new("org.linebender.druid.theme.debug-paint");
 
     /// State for whether or not to paint `WidgetId`s, for event debugging.
     ///
     /// Set by the `debug_widget_id()` method on [`WidgetExt`].
     ///
     /// [`WidgetExt`]: trait.WidgetExt.html
-    pub(crate) const DEBUG_WIDGET_ID: Key<bool> = Key::new("druid.built-in.debug-widget-id");
+    pub(crate) const DEBUG_WIDGET_ID: Key<bool> =
+        Key::new("org.linebender.druid.theme.debug-widget-id");
 
     /// A key used to tell widgets to print additional debug information.
     ///
@@ -197,7 +198,7 @@ impl Env {
     /// ```
     ///
     /// [`WidgetExt::debug_widget`]: trait.WidgetExt.html#method.debug_widget
-    pub const DEBUG_WIDGET: Key<bool> = Key::new("druid.built-in.debug-widget");
+    pub const DEBUG_WIDGET: Key<bool> = Key::new("org.linebender.druid.theme.debug-widget");
 
     /// Gets a value from the environment, expecting it to be present.
     ///
@@ -327,8 +328,8 @@ impl<T> Key<T> {
     /// use druid::Key;
     /// use druid::piet::Color;
     ///
-    /// let float_key: Key<f64> = Key::new("a.very.good.float");
-    /// let color_key: Key<Color> = Key::new("a.very.nice.color");
+    /// let float_key: Key<f64> = Key::new("org.linebender.druid.theme.a.very.good.float");
+    /// let color_key: Key<Color> = Key::new("org.linebender.druid.theme.a.very.nice.color");
     /// ```
     pub const fn new(key: &'static str) -> Self {
         Key {
@@ -574,7 +575,7 @@ mod tests {
 
     #[test]
     fn string_key_or_value() {
-        const MY_KEY: Key<ArcStr> = Key::new("test.my-string-key");
+        const MY_KEY: Key<ArcStr> = Key::new("org.linebender.druid.theme.test.my-string-key");
         let env = Env::default().adding(MY_KEY, "Owned");
         assert_eq!(env.get(MY_KEY).as_ref(), "Owned");
 

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -19,49 +19,59 @@ use crate::piet::Color;
 
 use crate::{Env, FontDescriptor, FontFamily, Key};
 
-pub const WINDOW_BACKGROUND_COLOR: Key<Color> = Key::new("window_background_color");
+pub const WINDOW_BACKGROUND_COLOR: Key<Color> =
+    Key::new("org.linebender.druid.theme.window_background_color");
 
-pub const LABEL_COLOR: Key<Color> = Key::new("label_color");
-pub const PLACEHOLDER_COLOR: Key<Color> = Key::new("placeholder_color");
+pub const LABEL_COLOR: Key<Color> = Key::new("org.linebender.druid.theme.label_color");
+pub const PLACEHOLDER_COLOR: Key<Color> = Key::new("org.linebender.druid.theme.placeholder_color");
 
-pub const PRIMARY_LIGHT: Key<Color> = Key::new("primary_light");
-pub const PRIMARY_DARK: Key<Color> = Key::new("primary_dark");
-pub const PROGRESS_BAR_RADIUS: Key<f64> = Key::new("progress_bar_radius");
-pub const BACKGROUND_LIGHT: Key<Color> = Key::new("background_light");
-pub const BACKGROUND_DARK: Key<Color> = Key::new("background_dark");
-pub const FOREGROUND_LIGHT: Key<Color> = Key::new("foreground_light");
-pub const FOREGROUND_DARK: Key<Color> = Key::new("foreground_dark");
-pub const BUTTON_DARK: Key<Color> = Key::new("button_dark");
-pub const BUTTON_LIGHT: Key<Color> = Key::new("button_light");
-pub const BUTTON_BORDER_RADIUS: Key<f64> = Key::new("button_radius");
-pub const BUTTON_BORDER_WIDTH: Key<f64> = Key::new("button_border_width");
-pub const BORDER_DARK: Key<Color> = Key::new("border");
-pub const BORDER_LIGHT: Key<Color> = Key::new("border_light");
-pub const SELECTION_COLOR: Key<Color> = Key::new("selection_color");
-pub const SELECTION_TEXT_COLOR: Key<Color> = Key::new("selection_text_color");
-pub const CURSOR_COLOR: Key<Color> = Key::new("cursor_color");
+pub const PRIMARY_LIGHT: Key<Color> = Key::new("org.linebender.druid.theme.primary_light");
+pub const PRIMARY_DARK: Key<Color> = Key::new("org.linebender.druid.theme.primary_dark");
+pub const PROGRESS_BAR_RADIUS: Key<f64> =
+    Key::new("org.linebender.druid.theme.progress_bar_radius");
+pub const BACKGROUND_LIGHT: Key<Color> = Key::new("org.linebender.druid.theme.background_light");
+pub const BACKGROUND_DARK: Key<Color> = Key::new("org.linebender.druid.theme.background_dark");
+pub const FOREGROUND_LIGHT: Key<Color> = Key::new("org.linebender.druid.theme.foreground_light");
+pub const FOREGROUND_DARK: Key<Color> = Key::new("org.linebender.druid.theme.foreground_dark");
+pub const BUTTON_DARK: Key<Color> = Key::new("org.linebender.druid.theme.button_dark");
+pub const BUTTON_LIGHT: Key<Color> = Key::new("org.linebender.druid.theme.button_light");
+pub const BUTTON_BORDER_RADIUS: Key<f64> = Key::new("org.linebender.druid.theme.button_radius");
+pub const BUTTON_BORDER_WIDTH: Key<f64> =
+    Key::new("org.linebender.druid.theme.button_border_width");
+pub const BORDER_DARK: Key<Color> = Key::new("org.linebender.druid.theme.border_dark");
+pub const BORDER_LIGHT: Key<Color> = Key::new("org.linebender.druid.theme.border_light");
+pub const SELECTION_COLOR: Key<Color> = Key::new("org.linebender.druid.theme.selection_color");
+pub const SELECTION_TEXT_COLOR: Key<Color> =
+    Key::new("org.linebender.druid.theme.selection_text_color");
+pub const CURSOR_COLOR: Key<Color> = Key::new("org.linebender.druid.theme.cursor_color");
 
-pub const TEXT_SIZE_NORMAL: Key<f64> = Key::new("text_size_normal");
-pub const TEXT_SIZE_LARGE: Key<f64> = Key::new("text_size_large");
-pub const BASIC_WIDGET_HEIGHT: Key<f64> = Key::new("basic_widget_height");
+pub const TEXT_SIZE_NORMAL: Key<f64> = Key::new("org.linebender.druid.theme.text_size_normal");
+pub const TEXT_SIZE_LARGE: Key<f64> = Key::new("org.linebender.druid.theme.text_size_large");
+pub const BASIC_WIDGET_HEIGHT: Key<f64> =
+    Key::new("org.linebender.druid.theme.basic_widget_height");
 
 /// The default font for labels, buttons, text boxes, and other UI elements.
-pub const UI_FONT: Key<FontDescriptor> = Key::new("druid.builtin.ui-font-descriptor");
+pub const UI_FONT: Key<FontDescriptor> = Key::new("org.linebender.druid.theme.ui-font");
 
 /// The default minimum width for a 'wide' widget; a textbox, slider, progress bar, etc.
-pub const WIDE_WIDGET_WIDTH: Key<f64> = Key::new("druid.widgets.long-widget-width");
-pub const BORDERED_WIDGET_HEIGHT: Key<f64> = Key::new("bordered_widget_height");
+pub const WIDE_WIDGET_WIDTH: Key<f64> = Key::new("org.linebender.druid.theme.long-widget-width");
+pub const BORDERED_WIDGET_HEIGHT: Key<f64> =
+    Key::new("org.linebender.druid.theme.bordered_widget_height");
 
-pub const TEXTBOX_BORDER_RADIUS: Key<f64> = Key::new("textbox_radius");
+pub const TEXTBOX_BORDER_RADIUS: Key<f64> = Key::new("org.linebender.druid.theme.textbox_radius");
 
-pub const SCROLLBAR_COLOR: Key<Color> = Key::new("scrollbar_color");
-pub const SCROLLBAR_BORDER_COLOR: Key<Color> = Key::new("scrollbar_border_color");
-pub const SCROLLBAR_MAX_OPACITY: Key<f64> = Key::new("scrollbar_max_opacity");
-pub const SCROLLBAR_FADE_DELAY: Key<u64> = Key::new("scrollbar_fade_time");
-pub const SCROLLBAR_WIDTH: Key<f64> = Key::new("scrollbar_width");
-pub const SCROLLBAR_PAD: Key<f64> = Key::new("scrollbar_pad");
-pub const SCROLLBAR_RADIUS: Key<f64> = Key::new("scrollbar_radius");
-pub const SCROLLBAR_EDGE_WIDTH: Key<f64> = Key::new("scrollbar_edge_width");
+pub const SCROLLBAR_COLOR: Key<Color> = Key::new("org.linebender.druid.theme.scrollbar_color");
+pub const SCROLLBAR_BORDER_COLOR: Key<Color> =
+    Key::new("org.linebender.druid.theme.scrollbar_border_color");
+pub const SCROLLBAR_MAX_OPACITY: Key<f64> =
+    Key::new("org.linebender.druid.theme.scrollbar_max_opacity");
+pub const SCROLLBAR_FADE_DELAY: Key<u64> =
+    Key::new("org.linebender.druid.theme.scrollbar_fade_time");
+pub const SCROLLBAR_WIDTH: Key<f64> = Key::new("org.linebender.druid.theme.scrollbar_width");
+pub const SCROLLBAR_PAD: Key<f64> = Key::new("org.linebender.druid.theme.scrollbar_pad");
+pub const SCROLLBAR_RADIUS: Key<f64> = Key::new("org.linebender.druid.theme.scrollbar_radius");
+pub const SCROLLBAR_EDGE_WIDTH: Key<f64> =
+    Key::new("org.linebender.druid.theme.scrollbar_edge_width");
 
 /// An initial theme.
 pub fn init() -> Env {


### PR DESCRIPTION
Fixes #1217