### PR TITLE
Standardize checkbox and radio padding

### DIFF
--- a/druid/examples/flex.rs
+++ b/druid/examples/flex.rs
@@ -128,16 +128,19 @@ fn make_control_row() -> impl Widget<AppState> {
         .with_child(
             Flex::column()
                 .cross_axis_alignment(CrossAxisAlignment::Start)
-                .with_child(Label::new("Type:").padding(5.0))
+                .with_child(Label::new("Type:"))
+                .with_default_spacer()
                 .with_child(
                     RadioGroup::new(vec![("Row", FlexType::Row), ("Column", FlexType::Column)])
                         .lens(Params::axis),
                 ),
         )
+        .with_default_spacer()
         .with_child(
             Flex::column()
                 .cross_axis_alignment(CrossAxisAlignment::Start)
-                .with_child(Label::new("CrossAxis:").padding(5.0))
+                .with_child(Label::new("CrossAxis:"))
+                .with_default_spacer()
                 .with_child(
                     RadioGroup::new(vec![
                         ("Start", CrossAxisAlignment::Start),
@@ -147,10 +150,12 @@ fn make_control_row() -> impl Widget<AppState> {
                     .lens(Params::cross_alignment),
                 ),
         )
+        .with_default_spacer()
         .with_child(
             Flex::column()
                 .cross_axis_alignment(CrossAxisAlignment::Start)
-                .with_child(Label::new("MainAxis:").padding(5.0))
+                .with_child(Label::new("MainAxis:"))
+                .with_default_spacer()
                 .with_child(
                     RadioGroup::new(vec![
                         ("Start", MainAxisAlignment::Start),
@@ -163,20 +168,23 @@ fn make_control_row() -> impl Widget<AppState> {
                     .lens(Params::main_alignment),
                 ),
         )
+        .with_default_spacer()
         .with_child(make_spacer_select())
+        .with_default_spacer()
         .with_child(
             Flex::column()
                 .cross_axis_alignment(CrossAxisAlignment::Start)
-                .with_child(Label::new("Misc:").padding((0., 0., 0., 10.)))
+                .with_child(Label::new("Misc:"))
+                .with_default_spacer()
                 .with_child(Checkbox::new("Debug layout").lens(Params::debug_layout))
                 .with_default_spacer()
                 .with_child(Checkbox::new("Fill main axis").lens(Params::fill_major_axis))
                 .with_default_spacer()
                 .with_child(Checkbox::new("Fix minor axis size").lens(Params::fix_minor_axis))
                 .with_default_spacer()
-                .with_child(Checkbox::new("Fix major axis size").lens(Params::fix_major_axis))
-                .padding(5.0),
+                .with_child(Checkbox::new("Fix major axis size").lens(Params::fix_major_axis)),
         )
+        .padding(10.0)
         .border(Color::grey(0.6), 2.0)
         .rounded(5.0)
         .lens(AppState::params)
@@ -185,7 +193,8 @@ fn make_control_row() -> impl Widget<AppState> {
 fn make_spacer_select() -> impl Widget<Params> {
     Flex::column()
         .cross_axis_alignment(CrossAxisAlignment::Start)
-        .with_child(Label::new("Insert Spacers:").padding(5.0))
+        .with_child(Label::new("Insert Spacers:"))
+        .with_default_spacer()
         .with_child(
             RadioGroup::new(vec![
                 ("None", Spacers::None),
@@ -195,6 +204,7 @@ fn make_spacer_select() -> impl Widget<Params> {
             ])
             .lens(Params::spacers),
         )
+        .with_default_spacer()
         .with_child(
             Flex::row()
                 .with_child(
@@ -206,13 +216,13 @@ fn make_spacer_select() -> impl Widget<Params> {
                         )
                         .fix_width(60.0),
                 )
+                .with_spacer(druid::theme::WIDGET_CONTROL_COMPONENT_PADDING)
                 .with_child(
                     Stepper::new()
                         .with_range(2.0, 50.0)
                         .with_step(2.0)
                         .lens(Params::spacer_size),
-                )
-                .padding((8.0, 5.0)),
+                ),
         )
 }
 

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -66,6 +66,10 @@ pub const WIDGET_PADDING_HORIZONTAL: Key<f64> =
 /// The default vertical spacing between widgets.
 pub const WIDGET_PADDING_VERTICAL: Key<f64> =
     Key::new("org.linebender.druid.theme.widget-padding-v");
+/// The default internal (horizontal) padding for visually distinct components
+/// of a widget; for instance between a checkbox and its label.
+pub const WIDGET_CONTROL_COMPONENT_PADDING: Key<f64> =
+    Key::new("org.linebender.druid.theme.widget-padding-control-label");
 
 pub const SCROLLBAR_COLOR: Key<Color> = Key::new("org.linebender.druid.theme.scrollbar_color");
 pub const SCROLLBAR_BORDER_COLOR: Key<Color> =
@@ -118,6 +122,7 @@ pub fn init() -> Env {
         .adding(SCROLLBAR_EDGE_WIDTH, 1.)
         .adding(WIDGET_PADDING_VERTICAL, 10.0)
         .adding(WIDGET_PADDING_HORIZONTAL, 8.0)
+        .adding(WIDGET_CONTROL_COMPONENT_PADDING, 4.0)
         .adding(
             UI_FONT,
             FontDescriptor::new(FontFamily::SYSTEM_UI).with_size(15.0),

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -48,7 +48,43 @@ pub struct Dynamic<T> {
     resolved: String,
 }
 
-/// A label that displays some text.
+/// A label that draws some text.
+///
+/// A label is the easiest way to display text in Druid. A label is instantiated
+/// with some [`LabelText`] type, such as a `String` or a [`LocalizedString`],
+/// and also has methods for setting the default font, font-size, text color,
+/// and other attributes.
+///
+/// In addition to being a [`Widget`], `Label` is also regularly used as a
+/// component in other widgets that wish to display text; to facilitate this
+/// it has a [`draw_at`] method that allows the caller to easily draw the label's
+/// text at the desired position on screen.
+///
+/// # Examples
+///
+/// Make a label to say something **very** important:
+///
+/// ```
+/// # use druid::widget::{Label, SizedBox};
+/// # use druid::*;
+///
+/// let font = FontDescriptor::new(FontFamily::SYSTEM_UI)
+///     .with_weight(FontWeight::BOLD)
+///     .with_size(48.0);
+///
+/// let important_label = Label::new("WATCH OUT!")
+///     .with_font(font)
+///     .with_text_color(Color::rgb(1.0, 0.2, 0.2));
+/// # // our data type T isn't known; this is just a trick for the compiler
+/// # // to keep our example clean
+/// # let _ = SizedBox::<()>::new(important_label);
+/// ```
+///
+///
+/// [`LabelText`]: struct.LabelText.html
+/// [`LocalizedString`]: ../struct.LocalizedString.html
+/// [`draw_at`]: #method.draw_at
+/// [`Widget`]: ../trait.Widget.html
 pub struct Label<T> {
     text: LabelText<T>,
     layout: TextLayout,
@@ -251,6 +287,15 @@ impl<T: Data> Label<T> {
         self.needs_rebuild = true;
     }
 
+    /// Draw this label's text at the provided `Point`, without internal padding.
+    ///
+    /// This is a convenience for widgets that want to use Label as a way
+    /// of managing a dynamic or localized string, but want finer control
+    /// over where the text is drawn.
+    pub fn draw_at(&self, ctx: &mut PaintCtx, origin: impl Into<Point>) {
+        self.layout.draw(ctx, origin)
+    }
+
     fn rebuild_if_needed(&mut self, factory: &mut PietText, data: &T, env: &Env) {
         if self.needs_rebuild {
             self.text.resolve(data, env);
@@ -337,7 +382,7 @@ impl<T: Data> Widget<T> for Label<T> {
         if self.line_break_mode == LineBreaking::Clip {
             ctx.clip(label_size.to_rect());
         }
-        self.layout.draw(ctx, origin)
+        self.draw_at(ctx, origin)
     }
 }
 


### PR DESCRIPTION
This is based off of #1216; these two widgets now use padding constants from the environment internally, and so you can manually mimic the look of `RadioGroup` by creating a `Flex::column()` and then adding default spacers between each child.

This also includes some other cleanup in these two widgets; in particular they no longer user `WidgetPod` internally (which was only used so they could position their labels) and instead I've added a `draw_at` method to label to handle this case, and updated the documentation to mention it.

If anyone is confused: all of this layout and padding stuff is motivated by wanting to implement baseline alignment; that's going to touch a bunch of layout code, and so I'm trying to clean it up a bit before hand.