### PR TITLE
Mac and GTK implementation of Screen module and related window methods

### DIFF
--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -68,7 +68,7 @@ gdk-sys = "0.10.0"
 glib = "0.10.1"
 glib-sys = "0.10.0"
 gtk-sys = "0.10.0"
-gtk = { version = "0.9.2", features = ["v3_20"] }
+gtk = { version = "0.9.2", features = ["v3_22"] }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 wasm-bindgen = "0.2.67"

--- a/druid-shell/src/platform/gtk/screen.rs
+++ b/druid-shell/src/platform/gtk/screen.rs
@@ -15,8 +15,25 @@
 //! GTK Monitors and Screen information.
 
 use crate::screen::Monitor;
+use kurbo::{Size, Rect, Point};
+use gdk::{Display};
+
+
+fn translate_gdk_rectangle(r: gdk::Rectangle)->Rect{
+    Rect::from_origin_size( Point::new(r.x as f64, r.y as f64), Size::new ( r.width as f64, r.height as f64) )
+}
+
+fn translate_gdk_monitor(mon: gdk::Monitor)->Monitor{
+    let area = translate_gdk_rectangle( mon.get_geometry() );
+    Monitor::new(mon.is_primary(),
+                 area,
+                 mon.get_property_workarea().map(translate_gdk_rectangle).unwrap_or(area) )
+}
 
 pub(crate) fn get_monitors() -> Vec<Monitor> {
-    log::warn!("Screen::get_monitors() is currently unimplemented for gtk.");
-    Vec::new()
+    gdk::DisplayManager::get().list_displays().iter().flat_map(|display: &Display|{
+        (0..display.get_n_monitors()).map(move |i| {
+            display.get_monitor(i).map(translate_gdk_monitor)
+        } ).flatten()
+    }).collect()
 }

--- a/druid-shell/src/platform/mac/screen.rs
+++ b/druid-shell/src/platform/mac/screen.rs
@@ -15,8 +15,104 @@
 //! macOS Monitors and Screen information.
 
 use crate::screen::Monitor;
+use crate::kurbo::Rect;
+use cocoa::foundation::NSArray;
+use cocoa::base::{id};
+use objc::{class, msg_send, sel, sel_impl};
+use cocoa::appkit::NSScreen;
 
 pub(crate) fn get_monitors() -> Vec<Monitor> {
-    log::warn!("Screen::get_monitors() is currently unimplemented for Mac.");
-    Vec::new()
+    unsafe {
+        let screens: id = msg_send![class![NSScreen], screens];
+        let mut monitors = Vec::<(Rect, Rect)>::new();
+        let mut total_rect = Rect::ZERO;
+
+        for idx in 0..screens.count() {
+            let screen = screens.objectAtIndex(idx);
+            let frame =  NSScreen::frame(screen);
+
+            let frame_r = Rect::from_origin_size((frame.origin.x, frame.origin.y), (frame.size.width,  frame.size.height));
+            let vis_frame = NSScreen::visibleFrame(screen);
+            let vis_frame_r = Rect::from_origin_size(  (vis_frame.origin.x, vis_frame.origin.y), (vis_frame.size.width,  vis_frame.size.height) );
+            monitors.push( (frame_r, vis_frame_r) );
+            total_rect = total_rect.union(frame_r)
+        }
+        // TODO save this total_rect.y1 for screen coord transformations in get_position/set_position
+        // and invalidate on monitor changes
+        transform_coords(monitors, total_rect.y1)
+    }
+}
+
+fn transform_coords(monitors_build: Vec<(Rect, Rect)>, max_y: f64) -> Vec<Monitor> {
+
+    //Flip y and move to opposite horizontal edges (On mac, Y goes up and origin is bottom left corner)
+    let fix_rect = |frame: &Rect| Rect::new(frame.x0, (max_y - frame.y0) - frame.height(),
+                                           frame.x1, (max_y - frame.y1) + frame.height());
+
+    monitors_build.iter().enumerate().map(|(idx, (frame, vis_frame))|{
+        Monitor::new(idx == 0, fix_rect(frame), fix_rect(vis_frame))
+    }).collect()
+}
+
+#[cfg(test)]
+mod test{
+    use kurbo::Rect;
+    use crate::platform::mac::screen::transform_coords;
+    use crate::Monitor;
+
+    fn pair(rect: Rect)->(Rect, Rect){
+        (rect, rect)
+    }
+
+    fn monitor(primary: bool, rect:Rect)->Monitor{
+        Monitor::new(primary, rect, rect)
+    }
+
+    #[test]
+    fn test_transform_coords_1(){
+        let mons = transform_coords(
+            vec![
+                pair(Rect::new(0., 0., 100., 100.))
+            ] , 100. );
+
+        assert_eq!(vec![monitor(true, Rect::new(0., 0., 100., 100.))],
+                   mons)
+    }
+
+    #[test]
+    fn test_transform_coords_2_right(){
+        let mons = transform_coords(
+            vec![
+                pair(Rect::new(0., 0., 100., 100.)),
+                pair(Rect::new(100., 0., 200., 100.)),
+            ] ,
+            100. );
+
+        assert_eq!(vec![
+            monitor(true, Rect::new(0., 0., 100., 100.), ),
+            monitor(false, Rect::new(100., 0., 200., 100.))
+
+        ],
+                   mons)
+    }
+
+    #[test]
+    fn test_transform_coords_2_up(){
+        let mons = transform_coords(
+            vec![
+                pair(Rect::new(0., 0., 100., 100.)),
+                pair(Rect::new(0., 100., 0., 200.)),
+            ] ,
+             100. );
+
+        assert_eq!(vec![
+            monitor(true, Rect::new(0., 0., 100., 100.), ),
+            monitor(false, Rect::new(0., -100., 0., 0.0))
+
+        ],
+                   mons)
+    }
+
+
+
 }

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -56,8 +56,7 @@ use crate::keyboard_types::KeyState;
 use crate::mouse::{Cursor, MouseButton, MouseButtons, MouseEvent};
 use crate::region::Region;
 use crate::scale::Scale;
-use crate::window::{IdleToken, TimerToken, WinHandler};
-use crate::window;
+use crate::window::{IdleToken, TimerToken, WinHandler, WindowState};
 use crate::Error;
 
 
@@ -88,6 +87,8 @@ pub(crate) struct WindowBuilder {
     menu: Option<Menu>,
     size: Size,
     min_size: Option<Size>,
+    position: Option<Point>,
+    window_state: Option<WindowState>,
     resizable: bool,
     show_titlebar: bool,
 }
@@ -125,6 +126,8 @@ impl WindowBuilder {
             menu: None,
             size: Size::new(500.0, 400.0),
             min_size: None,
+            position: None,
+            window_state: None,
             resizable: true,
             show_titlebar: true,
         }
@@ -151,12 +154,13 @@ impl WindowBuilder {
         self.show_titlebar = show_titlebar;
     }
 
-    pub fn set_position(&mut self, _position: Point) {
-        log::warn!("WindowBuilder::set_position is currently unimplemented for mac platforms.");
+
+    pub fn set_position(&mut self, position: Point) {
+        self.position = Some(position)
     }
 
-    pub fn set_window_state(&self, _state: window::WindowState) {
-        log::warn!("WindowBuilder::set_window_state is currently unimplemented for mac platforms.");
+    pub fn set_window_state(&mut self, state: WindowState) {
+        self.window_state = Some(state);
     }
 
     pub fn set_title(&mut self, title: impl Into<String>) {
@@ -170,9 +174,13 @@ impl WindowBuilder {
     pub fn build(self) -> Result<WindowHandle, Error> {
         assert_main_thread();
         unsafe {
-            let mut style_mask = NSWindowStyleMask::NSTitledWindowMask
-                | NSWindowStyleMask::NSClosableWindowMask
-                | NSWindowStyleMask::NSMiniaturizableWindowMask;
+
+            let mut style_mask = NSWindowStyleMask::NSClosableWindowMask
+                        | NSWindowStyleMask::NSMiniaturizableWindowMask;
+
+            if self.show_titlebar {
+                style_mask |= NSWindowStyleMask::NSTitledWindowMask;
+            }
 
             if self.resizable {
                 style_mask |= NSWindowStyleMask::NSResizableWindowMask;
@@ -212,10 +220,18 @@ impl WindowBuilder {
             content_view.addSubview_(view);
             let view_state: *mut c_void = *(*view).get_ivar("viewState");
             let view_state = &mut *(view_state as *mut ViewState);
-            let handle = WindowHandle {
+            let mut handle = WindowHandle {
                 nsview: view_state.nsview.clone(),
                 idle_queue,
             };
+
+            if let Some(pos) = self.position{
+                handle.set_position(pos);
+            }
+            if let Some(window_state) = self.window_state {
+                handle.set_window_state(window_state);
+            }
+
             (*view_state).handler.connect(&handle.clone().into());
             (*view_state).handler.scale(Scale::default());
             (*view_state)
@@ -876,31 +892,88 @@ impl WindowHandle {
     // TODO: Implement this
     pub fn show_titlebar(&self, _show_titlebar: bool) {}
 
-    pub fn set_position(&self, _position: Point) {
-        log::warn!("WindowHandle::set_position is currently unimplemented for Mac.");
+    // Need to translate mac y coords, as they start from bottom left
+    pub fn set_position(&self, position: Point) {
+        unsafe {
+            // TODO this should be the max y in orig mac coords
+            let screen_height = crate::Screen::get_display_rect().height();
+            let window: id =  msg_send![*self.nsview.load(), window];
+            let frame :NSRect = msg_send![ window , frame];
+
+            let mut new_frame = frame;
+            new_frame.origin.x = position.x;
+            new_frame.origin.y = screen_height - position.y - frame.size.height ; // Flip back
+            let  () = msg_send![window, setFrame: new_frame display: YES];
+        }
     }
 
     pub fn get_position(&self) -> Point {
-        log::warn!("WindowHandle::get_position is currently unimplemented for Mac.");
-        Point::new(0.0, 0.0)
+        unsafe {
+            // TODO this should be the max y in orig mac coords
+            let screen_height = crate::Screen::get_display_rect().height();
+
+            let window: id =  msg_send![*self.nsview.load(), window];
+            let current_frame:NSRect = msg_send![ window , frame];
+
+            Point::new(current_frame.origin.x, screen_height - current_frame.origin.y - current_frame.size.height )
+        }
     }
 
-    pub fn set_size(&self, _size: Size) {
-        log::warn!("WindowHandle::set_size is currently unimplemented for Mac.");
+    pub fn set_size(&self, size: Size) {
+        unsafe {
+            let window: id = msg_send![*self.nsview.load(), window];
+            let current_frame: NSRect = msg_send![ window , frame];
+            let mut new_frame = current_frame;
+            new_frame.size.width = size.width;
+            new_frame.size.height = size.height;
+            let  () = msg_send![window, setFrame: new_frame display: YES];
+        }
     }
 
     pub fn get_size(&self) -> Size {
-        log::warn!("WindowHandle::get_size is currently unimplemented for Mac.");
-        Size::new(0.0, 0.0)
+        unsafe {
+            let window: id = msg_send![*self.nsview.load(), window];
+            let current_frame: NSRect = msg_send![ window , frame];
+            Size::new(current_frame.size.width, current_frame.size.height)
+        }
     }
 
-    pub fn set_window_state(&self, _state: window::WindowState) {
-        log::warn!("WindowHandle::set_window_state is currently unimplemented for Mac.");
+    pub fn get_window_state(&self) -> WindowState {
+        unsafe{
+            let window: id = msg_send![*self.nsview.load(), window];
+            let isMin: BOOL = msg_send![window, isMiniaturized];
+            if isMin != NO {
+                return WindowState::MINIMIZED
+            }
+            let isZoomed: BOOL = msg_send![window, isZoomed];
+            if isZoomed != NO {
+                return WindowState::MAXIMIZED
+            }
+        }
+        WindowState::RESTORED
     }
 
-    pub fn get_window_state(&self) -> window::WindowState {
-        log::warn!("WindowHandle::get_window_state is currently unimplemented for Mac.");
-        window::WindowState::RESTORED
+    pub fn set_window_state(&mut self, state: WindowState) {
+        let cur_state = self.get_window_state();
+        unsafe {
+            let window: id = msg_send![*self.nsview.load(), window];
+            match (state, cur_state){
+                (s1, s2) if s1 == s2 => (),
+                (WindowState::MINIMIZED,_)=>{
+                    let () = msg_send![window, performMiniaturize:self];
+                },
+                (WindowState::MAXIMIZED,_)=>{
+                    let () = msg_send![window, performZoom:self];
+                }
+                (WindowState::RESTORED, WindowState::MAXIMIZED) => {
+                    let () = msg_send![window, performZoom:self];
+                }
+                (WindowState::RESTORED, WindowState::MINIMIZED) => {
+                    let () = msg_send![window, deminiaturize:self];
+                }
+                (WindowState::RESTORED, WindowState::RESTORED) => {} // Can't be reached
+            }
+        }
     }
 
     pub fn handle_titlebar(&self, _val: bool) {

--- a/druid-shell/src/screen.rs
+++ b/druid-shell/src/screen.rs
@@ -22,7 +22,7 @@ use std::fmt::Display;
 /// Monitor struct containing data about a monitor on the system
 ///
 /// Use Screen::get_monitors() to return a Vec<Monitor> of all the monitors on the system
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Monitor {
     primary: bool,
     rect: Rect,

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -126,7 +126,7 @@ impl WindowHandle {
     /// Sets the state of the window.
     ///
     /// [`state`]: enum.WindowState.html
-    pub fn set_window_state(&self, state: WindowState) {
+    pub fn set_window_state(&mut self, state: WindowState) {
         self.0.set_window_state(state);
     }
 


### PR DESCRIPTION
This is extracted from sub-windows and was a fairly minimal implementation to work for those.

The main caveat that I know of here is that the mac implementation of get_position / set_position won't work properly if you have multiple monitors with a large monitors baseline lower than the first monitors baseline . I plan to fix this, but would prefer to do it after sub-windows as I have a decent example there (but it relies on sub-windows). 
