### PR TITLE
Add `Button::from_label`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - Implementation of `Data` trait for `i128` and `u128` primitive data types. ([#1214] by [@koutoftimer])
 - `LineBreaking` enum allows configuration of label line-breaking ([#1195] by [@cmyr])
 - `TextAlignment` support in `TextLayout` and `Label` ([#1210] by [@cmyr])`
+- `Button::from_label` to construct a `Button` with a provided `Label`. ([#1226] by [@ForLoveOfCats])
 
 ### Changed
 
@@ -447,6 +448,7 @@ Last release without a changelog :(
 [#1205]: https://github.com/linebender/druid/pull/1205
 [#1210]: https://github.com/linebender/druid/pull/1210
 [#1214]: https://github.com/linebender/druid/pull/1214
+[#1226]: https://github.com/linebender/druid/pull/1226
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master
 [0.6.0]: https://github.com/linebender/druid/compare/v0.5.0...v0.6.0

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -33,7 +33,7 @@ pub struct Button<T> {
 impl<T: Data> Button<T> {
     /// Create a new button with a text label.
     ///
-    /// Use the `.on_click` method to provide a closure to be called when the
+    /// Use the [`.on_click`] method to provide a closure to be called when the
     /// button is clicked.
     ///
     /// # Examples
@@ -45,9 +45,33 @@ impl<T: Data> Button<T> {
     ///     *data += 1;
     /// });
     /// ```
+    ///
+    /// [`.on_click`]: #method.on_click
     pub fn new(text: impl Into<LabelText<T>>) -> Button<T> {
+        Button::from_label(Label::new(text))
+    }
+
+    /// Create a new button with the provided [`Label`].
+    ///
+    /// Use the [`.on_click`] method to provide a closure to be called when the
+    /// button is clicked.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use druid::Color;
+    /// use druid::widget::{Button, Label};
+    ///
+    /// let button = Button::from_label(Label::new("Increment").with_text_color(Color::grey(0.5))).on_click(|_ctx, data: &mut u32, _env| {
+    ///     *data += 1;
+    /// });
+    /// ```
+    ///
+    /// [`Label`]: struct.Label.html
+    /// [`.on_click`]: #method.on_click
+    pub fn from_label(label: Label<T>) -> Button<T> {
         Button {
-            label: Label::new(text),
+            label,
             label_size: Size::ZERO,
         }
     }


### PR DESCRIPTION
When using Button I wanted to be able to use the builder fns on Label. Rather than stub them all on Button and try to keep it up to date with Label as new fns are added it felt much simpler and cleaner to simply allow constructing a Button with a provided Label. There is no corresponding `dynamic_from_label`, one can use `Label::dynamic` to achieve that.