### PR TITLE
Fix bug with textbox placeholder selectable

### DIFF
--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -434,13 +434,11 @@ impl Widget<String> for TextBox {
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &String, env: &Env) {
         // Guard against changes in data following `event`
-        let content = if data.is_empty() {
-            &self.placeholder
+        if data.is_empty() {
+            self.selection = Selection::caret(0);
         } else {
-            data
+            self.selection = self.selection.constrain_to(data);
         };
-
-        self.selection = self.selection.constrain_to(content);
 
         let height = ctx.size().height;
         let background_color = env.get(theme::BACKGROUND_LIGHT);

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -362,6 +362,7 @@ impl Widget<String> for TextBox {
             self.reset_cursor_blink(ctx);
             if data.is_empty() {
                 self.text.set_text(self.placeholder.as_str());
+                self.selection = Selection::caret(0);
             } else {
                 self.text.set_text(data.as_str());
             }
@@ -434,12 +435,13 @@ impl Widget<String> for TextBox {
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &String, env: &Env) {
         // Guard against changes in data following `event`
-        if data.is_empty() {
-            self.selection = Selection::caret(0);
-            self.hscroll_offset = 0.;
+        let content = if data.is_empty() {
+            &self.placeholder
         } else {
-            self.selection = self.selection.constrain_to(data);
+            data
         };
+
+        self.selection = self.selection.constrain_to(content);
 
         let height = ctx.size().height;
         let background_color = env.get(theme::BACKGROUND_LIGHT);

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -436,6 +436,7 @@ impl Widget<String> for TextBox {
         // Guard against changes in data following `event`
         if data.is_empty() {
             self.selection = Selection::caret(0);
+            self.hscroll_offset = 0.;
         } else {
             self.selection = self.selection.constrain_to(data);
         };


### PR DESCRIPTION
This fixes an issue where the `TextBox` placeholder was selectable.

Before this fix:
![Untitled](https://user-images.githubusercontent.com/6944095/93002168-1275c000-f535-11ea-914b-7dbfccf78452.gif)
