### PR TITLE
Set default label line break mode to Overflow to avoid Clip perf overhead

### DIFF
--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -92,7 +92,7 @@ impl<T: Data> Label<T> {
         Self {
             text,
             layout,
-            line_break_mode: LineBreaking::Clip,
+            line_break_mode: LineBreaking::Overflow,
             needs_rebuild: true,
         }
     }


### PR DESCRIPTION
Addresses https://github.com/linebender/piet/issues/289#issuecomment-691416962 (kinda).