### PR TITLE
Introduce WindowLevel, plus Mac and GTK implementations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - `TextAlignment` support in `TextLayout` and `Label` ([#1210] by [@cmyr])`
 - `Button::from_label` to construct a `Button` with a provided `Label`. ([#1226] by [@ForLoveOfCats])
 - Lens: Added Unit lens for type erased / display only widgets that do not need data. ([#1232] by [@rjwittams]) 
+- `WindowLevel` to control system window Z order, with Mac and GTK implementations  ([#1231] by [@rjwittams])
 
 ### Changed
 
@@ -451,6 +452,7 @@ Last release without a changelog :(
 [#1214]: https://github.com/linebender/druid/pull/1214
 [#1226]: https://github.com/linebender/druid/pull/1226
 [#1232]: https://github.com/linebender/druid/pull/1232
+[#1231]: https://github.com/linebender/druid/pull/1231
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master
 [0.6.0]: https://github.com/linebender/druid/compare/v0.5.0...v0.6.0

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -64,7 +64,8 @@ pub use region::Region;
 pub use scale::{Scalable, Scale, ScaledArea};
 pub use screen::{Monitor, Screen};
 pub use window::{
-    IdleHandle, IdleToken, TimerToken, WinHandler, WindowBuilder, WindowHandle, WindowState,
+    IdleHandle, IdleToken, TimerToken, WinHandler, WindowBuilder, WindowHandle, WindowLevel,
+    WindowState,
 };
 
 pub use keyboard_types;

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -27,7 +27,7 @@ use std::time::Instant;
 
 use anyhow::anyhow;
 use cairo::Surface;
-use gdk::{EventKey, EventMask, ModifierType, ScrollDirection, WindowExt};
+use gdk::{EventKey, EventMask, ModifierType, ScrollDirection, WindowExt, WindowTypeHint};
 use gio::ApplicationExt;
 use gtk::prelude::*;
 use gtk::{AccelGroup, ApplicationWindow, DrawingArea};
@@ -42,8 +42,8 @@ use crate::keyboard::{KbKey, KeyEvent, KeyState, Modifiers};
 use crate::mouse::{Cursor, MouseButton, MouseButtons, MouseEvent};
 use crate::region::Region;
 use crate::scale::{Scalable, Scale, ScaledArea};
-use crate::window::{IdleToken, TimerToken, WinHandler};
 use crate::window;
+use crate::window::{IdleToken, TimerToken, WinHandler, WindowLevel};
 
 use super::application::Application;
 use super::dialog;
@@ -98,6 +98,7 @@ pub(crate) struct WindowBuilder {
     title: String,
     menu: Option<Menu>,
     position: Option<Point>,
+    level: Option<WindowLevel>,
     state: Option<window::WindowState>,
     size: Size,
     min_size: Option<Size>,
@@ -154,6 +155,7 @@ impl WindowBuilder {
             menu: None,
             size: Size::new(500.0, 400.0),
             position: None,
+            level: None,
             state: None,
             min_size: None,
             resizable: true,
@@ -183,6 +185,10 @@ impl WindowBuilder {
 
     pub fn set_position(&mut self, position: Point) {
         self.position = Some(position);
+    }
+
+    pub fn set_level(&mut self, level: WindowLevel) {
+        self.level = Some(level);
     }
 
     pub fn set_window_state(&mut self, state: window::WindowState) {
@@ -250,6 +256,9 @@ impl WindowBuilder {
         let mut handle = WindowHandle {
             state: Arc::downgrade(&win_state),
         };
+        if let Some(level) = self.level {
+            handle.set_level(level);
+        }
         if let Some(pos) = self.position {
             handle.set_position(pos);
         }
@@ -692,41 +701,54 @@ impl WindowHandle {
     }
 
     pub fn get_position(&self) -> Point {
-        if let Some(state) = self.state.upgrade(){
+        if let Some(state) = self.state.upgrade() {
             let (x, y) = state.window.get_position();
             Point::new(x as f64, y as f64)
-        }else{
+        } else {
             Point::new(0.0, 0.0)
         }
     }
 
+    pub fn set_level(&self, level: WindowLevel) {
+        if let Some(state) = self.state.upgrade() {
+            let hint = match level {
+                WindowLevel::AppWindow => WindowTypeHint::Normal,
+                WindowLevel::Tooltip => WindowTypeHint::Tooltip,
+                WindowLevel::DropDown => WindowTypeHint::DropdownMenu,
+                WindowLevel::Modal => WindowTypeHint::Dialog,
+            };
+
+            state.window.set_type_hint(hint);
+        }
+    }
+
     pub fn set_size(&self, size: Size) {
-        if let Some(state) = self.state.upgrade(){
+        if let Some(state) = self.state.upgrade() {
             state.window.resize(size.width as i32, size.height as i32)
         }
     }
 
     pub fn get_size(&self) -> Size {
-        if let Some(state) = self.state.upgrade(){
+        if let Some(state) = self.state.upgrade() {
             let (x, y) = state.window.get_size();
             Size::new(x as f64, y as f64)
-        } else{
+        } else {
             log::warn!("Could not get size for GTK window");
-            Size::new(0. , 0.)
+            Size::new(0., 0.)
         }
     }
 
     pub fn set_window_state(&mut self, size_state: window::WindowState) {
-        use window::WindowState::{MINIMIZED, MAXIMIZED, RESTORED};
+        use window::WindowState::{MAXIMIZED, MINIMIZED, RESTORED};
         let cur_size_state = self.get_window_state();
-        if let Some(state) = self.state.upgrade(){
+        if let Some(state) = self.state.upgrade() {
             match (size_state, cur_size_state) {
                 (s1, s2) if s1 == s2 => (),
                 (MAXIMIZED, _) => state.window.maximize(),
                 (MINIMIZED, _) => state.window.iconify(),
                 (RESTORED, MAXIMIZED) => state.window.unmaximize(),
                 (RESTORED, MINIMIZED) => state.window.deiconify(),
-                (RESTORED, RESTORED) => () // Unreachable
+                (RESTORED, RESTORED) => (), // Unreachable
             }
 
             state.window.unmaximize();
@@ -734,14 +756,14 @@ impl WindowHandle {
     }
 
     pub fn get_window_state(&self) -> window::WindowState {
-        use window::WindowState::{MINIMIZED, MAXIMIZED, RESTORED};
+        use window::WindowState::{MAXIMIZED, MINIMIZED, RESTORED};
         if let Some(state) = self.state.upgrade() {
             if state.window.is_maximized() {
-                return MAXIMIZED
+                return MAXIMIZED;
             } else if let Some(window) = state.window.get_parent_window() {
                 let state = window.get_state();
                 if (state & gdk::WindowState::ICONIFIED) == gdk::WindowState::ICONIFIED {
-                    return MINIMIZED
+                    return MINIMIZED;
                 }
             }
         }

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -56,12 +56,38 @@ use crate::keyboard_types::KeyState;
 use crate::mouse::{Cursor, MouseButton, MouseButtons, MouseEvent};
 use crate::region::Region;
 use crate::scale::Scale;
-use crate::window::{IdleToken, TimerToken, WinHandler, WindowState};
+use crate::window::{IdleToken, TimerToken, WinHandler, WindowLevel, WindowState};
 use crate::Error;
-
 
 #[allow(non_upper_case_globals)]
 const NSWindowDidBecomeKeyNotification: &str = "NSWindowDidBecomeKeyNotification";
+
+#[allow(dead_code)]
+#[allow(non_upper_case_globals)]
+mod levels {
+    use crate::window::WindowLevel;
+
+    // These are the levels that AppKit seems to have.
+    pub const NSModalPanelLevel: i32 = 24;
+    pub const NSNormalWindowLevel: i32 = 0;
+    pub const NSFloatingWindowLevel: i32 = 3;
+    pub const NSTornOffMenuWindowLevel: i32 = NSFloatingWindowLevel;
+    pub const NSSubmenuWindowLevel: i32 = NSFloatingWindowLevel;
+    pub const NSModalPanelWindowLevel: i32 = 8;
+    pub const NSStatusWindowLevel: i32 = 25;
+    pub const NSPopUpMenuWindowLevel: i32 = 101;
+    pub const NSScreenSaverWindowLevel: i32 = 1000;
+
+    pub fn as_raw_window_level(window_level: WindowLevel) -> i32 {
+        use WindowLevel::*;
+        match window_level {
+            AppWindow => NSNormalWindowLevel,
+            Tooltip => NSFloatingWindowLevel,
+            DropDown => NSFloatingWindowLevel,
+            Modal => NSModalPanelWindowLevel,
+        }
+    }
+}
 
 #[derive(Clone)]
 pub(crate) struct WindowHandle {
@@ -88,6 +114,7 @@ pub(crate) struct WindowBuilder {
     size: Size,
     min_size: Option<Size>,
     position: Option<Point>,
+    level: Option<WindowLevel>,
     window_state: Option<WindowState>,
     resizable: bool,
     show_titlebar: bool,
@@ -127,6 +154,7 @@ impl WindowBuilder {
             size: Size::new(500.0, 400.0),
             min_size: None,
             position: None,
+            level: None,
             window_state: None,
             resizable: true,
             show_titlebar: true,
@@ -150,10 +178,12 @@ impl WindowBuilder {
     }
 
     pub fn show_titlebar(&mut self, show_titlebar: bool) {
-        // TODO: Use this in `self.build`
         self.show_titlebar = show_titlebar;
     }
 
+    pub fn set_level(&mut self, level: WindowLevel) {
+        self.level = Some(level);
+    }
 
     pub fn set_position(&mut self, position: Point) {
         self.position = Some(position)
@@ -174,9 +204,8 @@ impl WindowBuilder {
     pub fn build(self) -> Result<WindowHandle, Error> {
         assert_main_thread();
         unsafe {
-
             let mut style_mask = NSWindowStyleMask::NSClosableWindowMask
-                        | NSWindowStyleMask::NSMiniaturizableWindowMask;
+                | NSWindowStyleMask::NSMiniaturizableWindowMask;
 
             if self.show_titlebar {
                 style_mask |= NSWindowStyleMask::NSTitledWindowMask;
@@ -191,7 +220,8 @@ impl WindowBuilder {
                 NSSize::new(self.size.width, self.size.height),
             );
 
-            let window = NSWindow::alloc(nil).initWithContentRect_styleMask_backing_defer_(
+            let window: id = msg_send![WINDOW_CLASS.0, alloc];
+            let window = window.initWithContentRect_styleMask_backing_defer_(
                 rect,
                 style_mask,
                 NSBackingStoreBuffered,
@@ -225,11 +255,15 @@ impl WindowBuilder {
                 idle_queue,
             };
 
-            if let Some(pos) = self.position{
+            if let Some(pos) = self.position {
                 handle.set_position(pos);
             }
             if let Some(window_state) = self.window_state {
                 handle.set_window_state(window_state);
+            }
+
+            if let Some(level) = self.level {
+                handle.set_level(level)
             }
 
             (*view_state).handler.connect(&handle.clone().into());
@@ -419,6 +453,24 @@ fn make_view(handler: Box<dyn WinHandler>) -> (id, Weak<Mutex<Vec<IdleKind>>>) {
 
         (view.autorelease(), queue_handle)
     }
+}
+
+struct WindowClass(*const Class);
+unsafe impl Sync for WindowClass {}
+
+lazy_static! {
+    static ref WINDOW_CLASS: WindowClass = unsafe {
+        let mut decl =
+            ClassDecl::new("DruidWindow", class!(NSWindow)).expect("Window class defined");
+        decl.add_method(
+            sel!(canBecomeKeyWindow),
+            canBecomeKeyWindow as extern "C" fn(&Object, Sel) -> BOOL,
+        );
+        extern "C" fn canBecomeKeyWindow(_this: &Object, _sel: Sel) -> BOOL {
+            YES
+        }
+        WindowClass(decl.register())
+    };
 }
 
 extern "C" fn set_frame_size(this: &mut Object, _: Sel, size: NSSize) {
@@ -897,13 +949,13 @@ impl WindowHandle {
         unsafe {
             // TODO this should be the max y in orig mac coords
             let screen_height = crate::Screen::get_display_rect().height();
-            let window: id =  msg_send![*self.nsview.load(), window];
-            let frame :NSRect = msg_send![ window , frame];
+            let window: id = msg_send![*self.nsview.load(), window];
+            let frame: NSRect = msg_send![window, frame];
 
             let mut new_frame = frame;
             new_frame.origin.x = position.x;
-            new_frame.origin.y = screen_height - position.y - frame.size.height ; // Flip back
-            let  () = msg_send![window, setFrame: new_frame display: YES];
+            new_frame.origin.y = screen_height - position.y - frame.size.height; // Flip back
+            let () = msg_send![window, setFrame: new_frame display: YES];
         }
     }
 
@@ -912,42 +964,53 @@ impl WindowHandle {
             // TODO this should be the max y in orig mac coords
             let screen_height = crate::Screen::get_display_rect().height();
 
-            let window: id =  msg_send![*self.nsview.load(), window];
-            let current_frame:NSRect = msg_send![ window , frame];
+            let window: id = msg_send![*self.nsview.load(), window];
+            let current_frame: NSRect = msg_send![window, frame];
 
-            Point::new(current_frame.origin.x, screen_height - current_frame.origin.y - current_frame.size.height )
+            Point::new(
+                current_frame.origin.x,
+                screen_height - current_frame.origin.y - current_frame.size.height,
+            )
+        }
+    }
+
+    pub fn set_level(&self, level: WindowLevel) {
+        unsafe {
+            let level = levels::as_raw_window_level(level);
+            let window: id = msg_send![*self.nsview.load(), window];
+            let () = msg_send![window, setLevel: level];
         }
     }
 
     pub fn set_size(&self, size: Size) {
         unsafe {
             let window: id = msg_send![*self.nsview.load(), window];
-            let current_frame: NSRect = msg_send![ window , frame];
+            let current_frame: NSRect = msg_send![window, frame];
             let mut new_frame = current_frame;
             new_frame.size.width = size.width;
             new_frame.size.height = size.height;
-            let  () = msg_send![window, setFrame: new_frame display: YES];
+            let () = msg_send![window, setFrame: new_frame display: YES];
         }
     }
 
     pub fn get_size(&self) -> Size {
         unsafe {
             let window: id = msg_send![*self.nsview.load(), window];
-            let current_frame: NSRect = msg_send![ window , frame];
+            let current_frame: NSRect = msg_send![window, frame];
             Size::new(current_frame.size.width, current_frame.size.height)
         }
     }
 
     pub fn get_window_state(&self) -> WindowState {
-        unsafe{
+        unsafe {
             let window: id = msg_send![*self.nsview.load(), window];
             let isMin: BOOL = msg_send![window, isMiniaturized];
             if isMin != NO {
-                return WindowState::MINIMIZED
+                return WindowState::MINIMIZED;
             }
             let isZoomed: BOOL = msg_send![window, isZoomed];
             if isZoomed != NO {
-                return WindowState::MAXIMIZED
+                return WindowState::MAXIMIZED;
             }
         }
         WindowState::RESTORED
@@ -957,19 +1020,19 @@ impl WindowHandle {
         let cur_state = self.get_window_state();
         unsafe {
             let window: id = msg_send![*self.nsview.load(), window];
-            match (state, cur_state){
+            match (state, cur_state) {
                 (s1, s2) if s1 == s2 => (),
-                (WindowState::MINIMIZED,_)=>{
-                    let () = msg_send![window, performMiniaturize:self];
-                },
-                (WindowState::MAXIMIZED,_)=>{
-                    let () = msg_send![window, performZoom:self];
+                (WindowState::MINIMIZED, _) => {
+                    let () = msg_send![window, performMiniaturize: self];
+                }
+                (WindowState::MAXIMIZED, _) => {
+                    let () = msg_send![window, performZoom: self];
                 }
                 (WindowState::RESTORED, WindowState::MAXIMIZED) => {
-                    let () = msg_send![window, performZoom:self];
+                    let () = msg_send![window, performZoom: self];
                 }
                 (WindowState::RESTORED, WindowState::MINIMIZED) => {
-                    let () = msg_send![window, deminiaturize:self];
+                    let () = msg_send![window, deminiaturize: self];
                 }
                 (WindowState::RESTORED, WindowState::RESTORED) => {} // Can't be reached
             }

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -27,7 +27,7 @@ use wasm_bindgen::JsCast;
 
 use crate::kurbo::{Point, Rect, Size, Vec2};
 
-use crate::piet::{RenderContext, PietText};
+use crate::piet::{PietText, RenderContext};
 
 use super::application::Application;
 use super::error::Error;
@@ -41,8 +41,8 @@ use crate::scale::{Scale, ScaledArea};
 use crate::keyboard::{KbKey, KeyState, Modifiers};
 use crate::mouse::{Cursor, MouseButton, MouseButtons, MouseEvent};
 use crate::region::Region;
-use crate::window::{IdleToken, TimerToken, WinHandler};
 use crate::window;
+use crate::window::{IdleToken, TimerToken, WinHandler, WindowLevel};
 
 // This is a macro instead of a function since KeyboardEvent and MouseEvent has identical functions
 // to query modifier key states.
@@ -357,6 +357,10 @@ impl WindowBuilder {
         // Ignored
     }
 
+    pub fn set_level(&mut self, _level: WindowLevel) {
+        // ignored
+    }
+
     pub fn set_title<S: Into<String>>(&mut self, title: S) {
         self.title = title.into();
     }
@@ -444,6 +448,10 @@ impl WindowHandle {
 
     pub fn set_position(&self, _position: Point) {
         log::warn!("WindowHandle::set_position unimplemented for web");
+    }
+
+    pub fn set_level(&self, _level: WindowLevel) {
+        log::warn!("WindowHandle::set_level  is currently unimplemented for web.");
     }
 
     pub fn get_position(&self) -> Point {

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -63,7 +63,7 @@ use crate::keyboard::{KbKey, KeyState};
 use crate::mouse::{Cursor, MouseButton, MouseButtons, MouseEvent};
 use crate::region::Region;
 use crate::scale::{Scalable, Scale, ScaledArea};
-use crate::window::{IdleToken, TimerToken, WinHandler};
+use crate::window::{IdleToken, TimerToken, WinHandler, WindowLevel};
 use crate::window;
 
 /// The platform target DPI.
@@ -1153,6 +1153,10 @@ impl WindowBuilder {
         self.state = state;
     }
 
+    pub fn set_level(&mut self, _level:WindowLevel) {
+        log::warn!("WindowBuilder::set_level  is currently unimplemented for Windows platforms.");
+    }
+
     pub fn build(self) -> Result<WindowHandle, Error> {
         unsafe {
             let class_name = super::util::CLASS_NAME.to_wide();
@@ -1523,6 +1527,10 @@ impl WindowHandle {
     pub fn set_position(&self, position: Point) {
         DeferredQueue::add(self.state.clone(), DeferredOp::SetWindowSizeState(window::WindowState::RESTORED));
         DeferredQueue::add(self.state.clone(), DeferredOp::SetPosition(position));
+    }
+
+    pub fn set_level(&self, _level:WindowLevel) {
+        warn!("Window level unimplemented for Windows!");
     }
 
     // Gets the position of the window in virtual screen coordinates

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -45,14 +45,13 @@ use crate::mouse::{Cursor, MouseButton, MouseButtons, MouseEvent};
 use crate::piet::{Piet, PietText, RenderContext};
 use crate::region::Region;
 use crate::scale::Scale;
-use crate::window::{IdleToken, TimerToken, WinHandler};
 use crate::window;
+use crate::window::{IdleToken, TimerToken, WinHandler, WindowLevel};
 
 use super::application::Application;
 use super::keycodes;
 use super::menu::Menu;
 use super::util::{self, Timer};
-
 
 /// A version of XCB's `xcb_visualtype_t` struct. This was copied from the [example] in x11rb; it
 /// is used to interoperate with cairo.
@@ -131,6 +130,10 @@ impl WindowBuilder {
 
     pub fn set_position(&mut self, _position: Point) {
         log::warn!("WindowBuilder::set_position is currently unimplemented for X11 platforms.");
+    }
+
+    pub fn set_level(&mut self, _level: window::WindowLevel) {
+        log::warn!("WindowBuilder::set_level  is currently unimplemented for X11 platforms.");
     }
 
     pub fn set_window_state(&self, _state: window::WindowState) {
@@ -1367,6 +1370,10 @@ impl WindowHandle {
     pub fn get_position(&self) -> Point {
         log::warn!("WindowHandle::get_position is currently unimplemented for X11 platforms.");
         Point::new(0.0, 0.0)
+    }
+
+    pub fn set_level(&self, _level: WindowLevel) {
+        log::warn!("WindowHandle::set_level  is currently unimplemented for X11 platforms.");
     }
 
     pub fn set_size(&self, _size: Size) {

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -92,6 +92,21 @@ impl IdleToken {
     }
 }
 
+/// Levels in the window system - Z order for display purposes.
+/// Describes the purpose of a window and should be mapped appropriately to match platform
+/// conventions.
+#[derive(Copy, Clone, Debug)]
+pub enum WindowLevel {
+    /// A top level app window.
+    AppWindow,
+    /// A window that should stay above app windows - like a tooltip
+    Tooltip,
+    /// A user interface element such as a dropdown menu or combo box
+    DropDown,
+    /// A modal dialog
+    Modal,
+}
+
 /// Contains the different states a Window can be in.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum WindowState {
@@ -195,6 +210,17 @@ impl WindowHandle {
     /// [`Size`]: struct.Size.html
     pub fn get_size(&self) -> Size {
         self.0.get_size()
+    }
+
+    /// Sets the [`WindowLevel`] - ie Z order in the Window system / compositor
+    ///
+    /// We do not currently have a getter method - because it may imply keeping extra state in the WindowHandle if
+    /// multiple Druid levels map to one underlying system level.
+    /// If there is a use case it can be added.
+    ///
+    /// [`WindowLevel`]: enum.WindowLevel.html
+    pub fn set_level(&self, level: WindowLevel) {
+        self.0.set_level(level)
     }
 
     /// Bring this window to the front of the window stack and give it focus.
@@ -361,6 +387,13 @@ impl WindowBuilder {
     /// [`position`]: struct.Point.html
     pub fn set_position(&mut self, position: Point) {
         self.0.set_position(position);
+    }
+
+    /// Sets the initial [`WindowLevel`]
+    ///
+    /// [`WindowLevel`]: enum.WindowLevel.html
+    pub fn set_level(&mut self, level: WindowLevel) {
+        self.0.set_level(level);
     }
 
     /// Set the window's initial title.


### PR DESCRIPTION
For tooltips etc. Extracted from sub-windows.

I have an example in sub-windows that uses this (via sub windows). 

I also have an extremely basic druid shell example I think is unlikely to be useful going forward.