### PR TITLE
Unit lens.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - `LineBreaking` enum allows configuration of label line-breaking ([#1195] by [@cmyr])
 - `TextAlignment` support in `TextLayout` and `Label` ([#1210] by [@cmyr])`
 - `Button::from_label` to construct a `Button` with a provided `Label`. ([#1226] by [@ForLoveOfCats])
+- Lens: Added Unit lens for type erased / display only widgets that do not need data. ([#1232] by [@rjwittams]) 
 
 ### Changed
 
@@ -449,6 +450,7 @@ Last release without a changelog :(
 [#1210]: https://github.com/linebender/druid/pull/1210
 [#1214]: https://github.com/linebender/druid/pull/1214
 [#1226]: https://github.com/linebender/druid/pull/1226
+[#1232]: https://github.com/linebender/druid/pull/1232
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master
 [0.6.0]: https://github.com/linebender/druid/compare/v0.5.0...v0.6.0

--- a/druid/src/lens/lens.rs
+++ b/druid/src/lens/lens.rs
@@ -575,3 +575,29 @@ where
         v
     }
 }
+
+/// A `Lens` that always yields ().
+///
+/// This is useful when you wish to have a display only widget, require a type-erased widget, or
+/// obtain app data out of band and ignore your input. (E.g sub-windows)
+#[derive(Debug, Copy, Clone)]
+pub struct Unit<T> {
+    phantom_t: PhantomData<T>,
+}
+
+impl<T> Default for Unit<T> {
+    fn default() -> Self {
+        Unit {
+            phantom_t: Default::default(),
+        }
+    }
+}
+
+impl<T> Lens<T, ()> for Unit<T> {
+    fn with<V, F: FnOnce(&()) -> V>(&self, _data: &T, f: F) -> V {
+        f(&())
+    }
+    fn with_mut<V, F: FnOnce(&mut ()) -> V>(&self, _data: &mut T, f: F) -> V {
+        f(&mut ())
+    }
+}

--- a/druid/src/lens/mod.rs
+++ b/druid/src/lens/mod.rs
@@ -48,6 +48,6 @@
 
 #[allow(clippy::module_inception)]
 mod lens;
-pub use lens::{Deref, Field, Id, InArc, Index, Map, Ref, Then};
+pub use lens::{Deref, Field, Id, InArc, Index, Map, Ref, Then, Unit};
 #[doc(hidden)]
 pub use lens::{Lens, LensExt, LensWrap};


### PR DESCRIPTION
From sub windows branch.
Used to allow the sub window host to be a direct child of the app state.