### PR TITLE
Adds a viewport widget.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,11 @@ You can find its changes [documented below](#060---2020-06-01).
 - `TextLayout` type simplifies drawing text ([#1182] by [@cmyr])
 - Implementation of `Data` trait for `i128` and `u128` primitive data types. ([#1214] by [@koutoftimer])
 - `LineBreaking` enum allows configuration of label line-breaking ([#1195] by [@cmyr])
-- `TextAlignment` support in `TextLayout` and `Label` ([#1210] by [@cmyr])`
+- `TextAlignment` support in `TextLayout` and `Label` ([#1210] by [@cmyr])
 - `Button::from_label` to construct a `Button` with a provided `Label`. ([#1226] by [@ForLoveOfCats])
 - Lens: Added Unit lens for type erased / display only widgets that do not need data. ([#1232] by [@rjwittams]) 
 - `WindowLevel` to control system window Z order, with Mac and GTK implementations  ([#1231] by [@rjwittams])
+- New `Viewport` widget ([#1233] by [@jneem])
 
 ### Changed
 
@@ -451,8 +452,9 @@ Last release without a changelog :(
 [#1210]: https://github.com/linebender/druid/pull/1210
 [#1214]: https://github.com/linebender/druid/pull/1214
 [#1226]: https://github.com/linebender/druid/pull/1226
-[#1232]: https://github.com/linebender/druid/pull/1232
 [#1231]: https://github.com/linebender/druid/pull/1231
+[#1232]: https://github.com/linebender/druid/pull/1232
+[#1233]: https://github.com/linebender/druid/pull/1233
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master
 [0.6.0]: https://github.com/linebender/druid/compare/v0.5.0...v0.6.0

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -47,6 +47,7 @@ mod svg;
 mod switch;
 mod textbox;
 mod view_switcher;
+mod viewport;
 #[allow(clippy::module_inception)]
 mod widget;
 mod widget_ext;
@@ -82,6 +83,7 @@ pub use svg::{Svg, SvgData};
 pub use switch::Switch;
 pub use textbox::TextBox;
 pub use view_switcher::ViewSwitcher;
+pub use viewport::Viewport;
 #[doc(hidden)]
 pub use widget::{Widget, WidgetId};
 #[doc(hidden)]

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -14,12 +14,11 @@
 
 //! A container that scrolls its contents.
 
-use std::f64::INFINITY;
-
-use crate::kurbo::{Point, Rect, Size, Vec2};
+use crate::kurbo::{Size, Vec2};
+use crate::widget::Viewport;
 use crate::{
     scroll_component::*, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle,
-    LifeCycleCtx, PaintCtx, UpdateCtx, Widget, WidgetPod,
+    LifeCycleCtx, PaintCtx, UpdateCtx, Widget,
 };
 
 #[derive(Debug, Clone)]
@@ -42,7 +41,7 @@ enum ScrollDirection {
 /// [`vertical`]: struct.Scroll.html#method.vertical
 /// [`horizontal`]: struct.Scroll.html#method.horizontal
 pub struct Scroll<T, W> {
-    child: WidgetPod<T, W>,
+    viewport: Viewport<T, W>,
     scroll_component: ScrollComponent,
     direction: ScrollDirection,
 }
@@ -55,7 +54,7 @@ impl<T, W: Widget<T>> Scroll<T, W> {
     /// [horizontal](#method.horizontal) methods to limit scrolling to a specific axis.
     pub fn new(child: W) -> Scroll<T, W> {
         Scroll {
-            child: WidgetPod::new(child),
+            viewport: Viewport::new(child),
             scroll_component: ScrollComponent::new(),
             direction: ScrollDirection::Bidirectional,
         }
@@ -64,101 +63,84 @@ impl<T, W: Widget<T>> Scroll<T, W> {
     /// Restrict scrolling to the vertical axis while locking child width.
     pub fn vertical(mut self) -> Self {
         self.direction = ScrollDirection::Vertical;
+        self.viewport.set_constrain_vertical(false);
+        self.viewport.set_constrain_horizontal(true);
         self
     }
 
     /// Restrict scrolling to the horizontal axis while locking child height.
     pub fn horizontal(mut self) -> Self {
         self.direction = ScrollDirection::Horizontal;
+        self.viewport.set_constrain_vertical(true);
+        self.viewport.set_constrain_horizontal(false);
         self
     }
 
     /// Returns a reference to the child widget.
     pub fn child(&self) -> &W {
-        self.child.widget()
+        self.viewport.child()
     }
 
     /// Returns a mutable reference to the child widget.
     pub fn child_mut(&mut self) -> &mut W {
-        self.child.widget_mut()
+        self.viewport.child_mut()
     }
 
     /// Returns the size of the child widget.
     pub fn child_size(&self) -> Size {
-        self.scroll_component.content_size
+        self.viewport.content_size()
     }
 
     /// Returns the current scroll offset.
     pub fn offset(&self) -> Vec2 {
-        self.scroll_component.scroll_offset
+        self.viewport.viewport_offset()
     }
 
     /// Scroll `delta` units.
     ///
     /// Returns `true` if the scroll offset has changed.
-    pub fn scroll(&mut self, delta: Vec2, layout_size: Size) -> bool {
-        let scrolled = self.scroll_component.scroll(delta, layout_size);
-        self.child.set_viewport_offset(self.offset());
-        scrolled
+    pub fn scroll_by(&mut self, delta: Vec2) -> bool {
+        self.viewport.scroll_by(delta)
     }
 }
 
 impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
-        self.scroll_component.event(ctx, event, env);
+        self.scroll_component
+            .event(&mut self.viewport, ctx, event, env);
         if !ctx.is_handled() {
-            let viewport = Rect::from_origin_size(Point::ORIGIN, ctx.size());
-
-            let force_event = self.child.is_hot() || self.child.is_active();
-            let child_event =
-                event.transform_scroll(self.scroll_component.scroll_offset, viewport, force_event);
-            if let Some(child_event) = child_event {
-                self.child.event(ctx, &child_event, data, env);
-            };
+            self.viewport.event(ctx, event, data, env);
         }
 
-        self.scroll_component.handle_scroll(ctx, event, env);
-        // In order to ensure that invalidation regions are correctly propagated up the tree,
-        // we need to set the viewport offset on our child whenever we change our scroll offset.
-        self.child.set_viewport_offset(self.offset());
+        self.scroll_component
+            .handle_scroll(&mut self.viewport, ctx, event, env);
     }
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         self.scroll_component.lifecycle(ctx, event, env);
-        self.child.lifecycle(ctx, event, data, env);
+        self.viewport.lifecycle(ctx, event, data, env);
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
-        self.child.update(ctx, data, env);
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
+        self.viewport.update(ctx, old_data, data, env);
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         bc.debug_check("Scroll");
 
-        let max_bc = match self.direction {
-            ScrollDirection::Bidirectional => Size::new(INFINITY, INFINITY),
-            ScrollDirection::Vertical => Size::new(bc.max().width, INFINITY),
-            ScrollDirection::Horizontal => Size::new(INFINITY, bc.max().height),
-        };
-
-        let child_bc = BoxConstraints::new(Size::ZERO, max_bc);
-        let child_size = self.child.layout(ctx, &child_bc, data, env);
+        let child_size = self.viewport.layout(ctx, &bc, data, env);
         log_size_warnings(child_size);
-        self.scroll_component.content_size = child_size;
-        self.child
-            .set_layout_rect(ctx, data, env, child_size.to_rect());
 
         let self_size = bc.constrain(child_size);
-        let _ = self.scroll_component.scroll(Vec2::new(0.0, 0.0), self_size);
-        self.child.set_viewport_offset(self.offset());
+        // The new size might have made the current scroll offset invalid. This makes it valid
+        // again.
+        let _ = self.scroll_by(Vec2::ZERO);
         self_size
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
-        self.scroll_component
-            .paint_content(ctx, env, |visible, ctx| {
-                ctx.with_child_ctx(visible, |ctx| self.child.paint_raw(ctx, data, env));
-            });
+        self.viewport.paint(ctx, data, env);
+        self.scroll_component.draw_bars(ctx, &self.viewport, env);
     }
 }
 

--- a/druid/src/widget/viewport.rs
+++ b/druid/src/widget/viewport.rs
@@ -1,0 +1,207 @@
+// Copyright 2020 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::kurbo::{Affine, Size, Vec2};
+use crate::widget::prelude::*;
+use crate::{Data, WidgetPod};
+
+/// A widget exposing a rectangular view into its child, which can be used as a building block for
+/// widgets that scroll their child.
+pub struct Viewport<T, W> {
+    child: WidgetPod<T, W>,
+    offset: Vec2,
+    viewport_size: Size,
+    content_size: Size,
+    constrain_horizontal: bool,
+    constrain_vertical: bool,
+}
+
+impl<T, W: Widget<T>> Viewport<T, W> {
+    /// Creates a new `Viewport` wrapping `child`.
+    pub fn new(child: W) -> Self {
+        Viewport {
+            child: WidgetPod::new(child),
+            offset: Vec2::ZERO,
+            viewport_size: Size::ZERO,
+            content_size: Size::ZERO,
+            constrain_horizontal: false,
+            constrain_vertical: false,
+        }
+    }
+
+    /// Returns a reference to the child widget.
+    pub fn child(&self) -> &W {
+        self.child.widget()
+    }
+
+    /// Returns a mutable reference to the child widget.
+    pub fn child_mut(&mut self) -> &mut W {
+        self.child.widget_mut()
+    }
+
+    /// Returns the size of the rectangular viewport into the child widget.
+    /// To get the offset of the viewport, see [`viewport_offset`].
+    ///
+    /// [`viewport_offset`]: struct.Viewport.html#method.viewport_offset
+    pub fn viewport_size(&self) -> Size {
+        self.viewport_size
+    }
+
+    /// Returns the size of the child widget.
+    pub fn content_size(&self) -> Size {
+        self.content_size
+    }
+
+    /// Builder-style method for deciding whether to constrain the child horizontally. The default
+    /// is `false`. See [`constrain_vertical`] for more details.
+    ///
+    /// [`constrain_vertical`]: struct.Viewport.html#constrain_vertical
+    pub fn constrain_horizontal(mut self, constrain: bool) -> Self {
+        self.constrain_horizontal = constrain;
+        self
+    }
+
+    /// Determine whether to constrain the child horizontally.
+    ///
+    /// See [`constrain_vertical`] for more details.
+    ///
+    /// [`constrain_vertical`]: struct.Viewport.html#constrain_vertical
+    pub fn set_constrain_horizontal(&mut self, constrain: bool) {
+        self.constrain_horizontal = constrain;
+    }
+
+    /// Builder-style method for deciding whether to constrain the child vertically. The default
+    /// is `false`.
+    ///
+    /// This setting affects how a `Viewport` lays out its child.
+    ///
+    /// - When it is `false` (the default), the child does receive any upper bound on its height:
+    ///   the idea is that the child can be as tall as it wants, and the viewport will somehow get
+    ///   moved around to see all of it.
+    /// - When it is `true`, the viewport's maximum height will be passed down as an upper bound on
+    ///   the height of the child, and the viewport will set its own height to be the same as its
+    ///   child's height.
+    pub fn constrain_vertical(mut self, constrain: bool) -> Self {
+        self.constrain_vertical = constrain;
+        self
+    }
+
+    /// Determine whether to constrain the child vertically.
+    ///
+    /// See [`constrain_vertical`] for more details.
+    ///
+    /// [`constrain_vertical`]: struct.Viewport.html#constrain_vertical
+    pub fn set_constrain_vertical(&mut self, constrain: bool) {
+        self.constrain_vertical = constrain;
+    }
+
+    /// Changes the viewport offset by `delta`.
+    ///
+    /// Returns true if the offset actually changed. Even if `delta` is non-zero, the offset might
+    /// not change. For example, if you try to move the viewport down but it is already at the
+    /// bottom of the child widget, then the offset will not change and this function will return
+    /// false.
+    pub fn scroll_by(&mut self, delta: Vec2) -> bool {
+        self.scroll_to(self.offset + delta)
+    }
+
+    fn clamp_offset(&self, offset: Vec2) -> Vec2 {
+        let x = offset
+            .x
+            .min(self.content_size.width - self.viewport_size.width)
+            .max(0.0);
+        let y = offset
+            .y
+            .min(self.content_size.height - self.viewport_size.height)
+            .max(0.0);
+        Vec2::new(x, y)
+    }
+
+    /// Sets the viewport offset to `offset`.
+    ///
+    /// Returns true if the offset changed. Note that the valid values for the viewport offset are
+    /// constrained by the size of the child, and so the offset might not get set to exactly
+    /// `offset`.
+    pub fn scroll_to(&mut self, offset: Vec2) -> bool {
+        let new_offset = self.clamp_offset(offset);
+        if (new_offset - self.offset).hypot2() > 1e-12 {
+            self.offset = new_offset;
+            self.child.set_viewport_offset(new_offset);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns the offset of the viewport.
+    pub fn viewport_offset(&self) -> Vec2 {
+        self.offset
+    }
+}
+
+impl<T: Data, W: Widget<T>> Widget<T> for Viewport<T, W> {
+    fn event(&mut self, ctx: &mut EventCtx, ev: &Event, data: &mut T, env: &Env) {
+        let viewport = ctx.size().to_rect();
+        let force_event = self.child.is_hot() || self.child.is_active();
+        if let Some(child_event) = ev.transform_scroll(self.offset, viewport, force_event) {
+            self.child.event(ctx, &child_event, data, env);
+        }
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, ev: &LifeCycle, data: &T, env: &Env) {
+        self.child.lifecycle(ctx, ev, data, env);
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
+        self.child.update(ctx, data, env);
+    }
+
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
+        bc.debug_check("Viewport");
+
+        let max_child_width = if self.constrain_horizontal {
+            bc.max().width
+        } else {
+            f64::INFINITY
+        };
+        let max_child_height = if self.constrain_vertical {
+            bc.max().height
+        } else {
+            f64::INFINITY
+        };
+        let child_bc =
+            BoxConstraints::new(Size::ZERO, Size::new(max_child_width, max_child_height));
+
+        self.content_size = self.child.layout(ctx, &child_bc, data, env);
+        self.child
+            .set_layout_rect(ctx, data, env, self.content_size.to_rect());
+
+        self.viewport_size = bc.constrain(self.content_size);
+        let new_offset = self.clamp_offset(self.offset);
+        self.scroll_to(new_offset);
+        self.viewport_size
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
+        let viewport = ctx.size().to_rect();
+        ctx.with_save(|ctx| {
+            ctx.clip(viewport);
+            ctx.transform(Affine::translate(-self.offset));
+
+            let mut visible = ctx.region().clone();
+            visible += self.offset;
+            ctx.with_child_ctx(visible, |ctx| self.child.paint_raw(ctx, data, env));
+        });
+    }
+}


### PR DESCRIPTION
This is my first stab at adding a Viewport widget.

The idea is that `Viewport` will be a building-block for various scroll-like widgets, and it will correctly handle the bits that are easy to mess up or impossible to do out-of-tree (like correctly propagating invalid regions).