### PR TITLE
Split up WindowDesc to allow sub-windows and window reconfiguration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - Lens: Added Unit lens for type erased / display only widgets that do not need data. ([#1232] by [@rjwittams])
 - `WindowLevel` to control system window Z order, with Mac and GTK implementations  ([#1231] by [@rjwittams])
 - WIDGET_PADDING items added to theme and `Flex::with_default_spacer`/`Flex::add_default_spacer` ([#1220] by [@cmyr])
+- CONFIGURE_WINDOW command to allow reconfiguration of an existing window. ([#1235] by [@rjwittams])
 
 ### Changed
 
@@ -58,6 +59,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - `Movement::RightOfLine` to `Movement::NextLineBreak`, and `Movement::LeftOfLine` to `Movement::PrecedingLineBreak`. ([#1092] by [@sysint64])
 - `AnimFrame` was moved from `lifecycle` to `event` ([#1155] by [@jneem])
 - Contexts' `text()` methods return `&mut PietText` instead of cloning ([#1205] by [@cmyr])
+- Window construction: WindowDesc decomposed to PendingWindow and WindowConfig to allow for sub-windows and reconfiguration. ([#1235] by [@rjwittams])
 - `LensWrap` widget moved into widget module ([#1251] by [@cmyr])
 
 ### Deprecated

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -146,7 +146,7 @@ pub mod sys {
     use std::any::Any;
 
     use super::Selector;
-    use crate::{FileDialogOptions, FileInfo, SingleUse};
+    use crate::{FileDialogOptions, FileInfo, SingleUse, WindowConfig};
 
     /// Quit the running application. This command is handled by the druid library.
     pub const QUIT_APP: Selector = Selector::new("druid-builtin.quit-app");
@@ -177,6 +177,10 @@ pub mod sys {
     /// When calling `submit_command` on a `Widget`s context, passing `None` as target
     /// will automatically target the window containing the widget.
     pub const SHOW_WINDOW: Selector = Selector::new("druid-builtin.show-window");
+
+    /// Apply the configuration payload to an existing window. The target should be a WindowId.
+    pub const CONFIGURE_WINDOW: Selector<WindowConfig> =
+        Selector::new("druid-builtin.configure-window");
 
     /// Display a context (right-click) menu. The payload must be the [`ContextMenu`]
     /// object to be displayed.

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -184,7 +184,7 @@ pub use shell::{
 };
 
 pub use crate::core::WidgetPod;
-pub use app::{AppLauncher, WindowDesc};
+pub use app::{AppLauncher, WindowConfig, WindowDesc};
 pub use app_delegate::{AppDelegate, DelegateCtx};
 pub use box_constraints::BoxConstraints;
 pub use command::{sys as commands, Command, Selector, SingleUse, Target};

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -16,6 +16,7 @@
 
 use std::path::Path;
 
+use crate::app::PendingWindow;
 use crate::core::{CommandQueue, WidgetState};
 use crate::ext_event::ExtEventHost;
 use crate::piet::{BitmapTarget, Device, Error, ImageFormat, Piet};
@@ -144,8 +145,8 @@ impl<T: Data> Harness<'_, T> {
         {
             let piet = target.0.as_mut().unwrap().render_context();
 
-            let desc = WindowDesc::new(|| root);
-            let window = Window::new(WindowId::next(), Default::default(), desc, ext_handle);
+            let pending = PendingWindow::new(|| root);
+            let window = Window::new(WindowId::next(), Default::default(), pending, ext_handle);
 
             let inner = Inner {
                 data,

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -29,11 +29,13 @@ use crate::ext_event::{ExtEventHost, ExtEventSink};
 use crate::menu::ContextMenu;
 use crate::window::Window;
 use crate::{
-    Command, Data, Env, Event, InternalEvent, KeyEvent, MenuDesc, Target, TimerToken, WindowDesc,
-    WindowId,
+    Command, Data, Env, Event, InternalEvent, KeyEvent, MenuDesc, PlatformError, Target,
+    TimerToken, WindowDesc, WindowId,
 };
 
+use crate::app::{PendingWindow, WindowConfig};
 use crate::command::sys as sys_cmd;
+use druid_shell::WindowBuilder;
 
 pub(crate) const RUN_COMMANDS_TOKEN: IdleToken = IdleToken::new(1);
 
@@ -84,7 +86,7 @@ struct Inner<T> {
 
 /// All active windows.
 struct Windows<T> {
-    pending: HashMap<WindowId, WindowDesc<T>>,
+    pending: HashMap<WindowId, PendingWindow<T>>,
     windows: HashMap<WindowId, Window<T>>,
 }
 
@@ -98,7 +100,7 @@ impl<T> Windows<T> {
         }
     }
 
-    fn add(&mut self, id: WindowId, win: WindowDesc<T>) {
+    fn add(&mut self, id: WindowId, win: PendingWindow<T>) {
         assert!(self.pending.insert(id, win).is_none(), "duplicate pending");
     }
 
@@ -292,6 +294,12 @@ impl<T: Data> Inner<T> {
         }
     }
 
+    fn configure_window(&mut self, config: &WindowConfig, id: WindowId) {
+        if let Some(win) = self.windows.get_mut(id) {
+            config.apply_to_handle(&mut win.handle);
+        }
+    }
+
     fn prepare_paint(&mut self, window_id: WindowId) {
         if let Some(win) = self.windows.get_mut(window_id) {
             win.prepare_paint(&mut self.command_queue, &mut self.data, &self.env);
@@ -459,7 +467,7 @@ impl<T: Data> AppState<T> {
         self.inner.borrow().env.clone()
     }
 
-    pub(crate) fn add_window(&self, id: WindowId, window: WindowDesc<T>) {
+    pub(crate) fn add_window(&self, id: WindowId, window: PendingWindow<T>) {
         self.inner.borrow_mut().windows.add(id, window);
     }
 
@@ -571,6 +579,7 @@ impl<T: Data> AppState<T> {
             // FIXME: we need to be able to open a file without a window handle
             T::Window(id) if cmd.is(sys_cmd::SHOW_OPEN_PANEL) => self.show_open_panel(cmd, id),
             T::Window(id) if cmd.is(sys_cmd::SHOW_SAVE_PANEL) => self.show_save_panel(cmd, id),
+            T::Window(id) if cmd.is(sys_cmd::CONFIGURE_WINDOW) => self.configure_window(cmd, id),
             T::Window(id) if cmd.is(sys_cmd::CLOSE_WINDOW) => {
                 if !self.inner.borrow_mut().dispatch_cmd(cmd) {
                     self.request_close_window(id);
@@ -653,6 +662,12 @@ impl<T: Data> AppState<T> {
         self.inner.borrow_mut().show_window(id);
     }
 
+    fn configure_window(&mut self, cmd: Command, id: WindowId) {
+        if let Some(config) = cmd.get(sys_cmd::CONFIGURE_WINDOW) {
+            self.inner.borrow_mut().configure_window(config, id);
+        }
+    }
+
     fn do_paste(&mut self, window_id: WindowId) {
         let event = Event::Paste(self.inner.borrow().app.clipboard());
         self.inner.borrow_mut().do_window_event(window_id, event);
@@ -670,6 +685,36 @@ impl<T: Data> AppState<T> {
     fn hide_others(&mut self) {
         #[cfg(target_os = "macos")]
         self.inner.borrow().app.hide_others()
+    }
+
+    pub(crate) fn build_native_window(
+        &mut self,
+        id: WindowId,
+        mut pending: PendingWindow<T>,
+        config: WindowConfig,
+    ) -> Result<WindowHandle, PlatformError> {
+        let mut builder = WindowBuilder::new(self.app());
+        config.apply_to_builder(&mut builder);
+
+        let data = self.data();
+        let env = self.env();
+
+        pending.title.resolve(&data, &env);
+        builder.set_title(pending.title.display_text());
+
+        let platform_menu = pending
+            .menu
+            .as_mut()
+            .map(|m| m.build_window_menu(&data, &env));
+        if let Some(menu) = platform_menu {
+            builder.set_menu(menu);
+        }
+
+        let handler = DruidHandler::new_shared((*self).clone(), id);
+        builder.set_handler(Box::new(handler));
+
+        self.add_window(id, pending);
+        builder.build()
     }
 }
 


### PR DESCRIPTION
This is extracted from sub-windows. 

It allows reconfiguration of windows and paves the way for construction of non-top level ones. 