### PR TITLE
Implement request_close() support for Windows in druid-shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - `ScrollComponent` for ease of adding consistent, customized, scrolling behavior to a widget. ([#1107] by [@ForLoveOfCats])
 - Selection text color to textbox. ([#1093] by [@sysint64])
 - `BoxConstraints::UNBOUNDED` constant. ([#1126] by [@danieldulaney])
-- Close requests from the shell can now be intercepted ([#1118] by [@jneem], [#1204] by [@psychon])
+- Close requests from the shell can now be intercepted ([#1118] by [@jneem], [#1204] by [@psychon], [#1238] by [@tay64])
 - The Lens derive now supports an `ignore` attribute. ([#1133] by [@jneem])
 - `request_update` in `EventCtx`. ([#1128] by [@raphlinus])
 - `ExtEventSink`s can now be obtained from widget methods. ([#1152] by [@jneem])
@@ -307,6 +307,7 @@ Last release without a changelog :(
 [@rjwittams]: https://github.com/rjwittams
 [@rhzk]: https://github.com/rhzk
 [@koutoftimer]: https://github.com/koutoftimer
+[@tay64]: https://github.com/tay64
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611
@@ -453,13 +454,11 @@ Last release without a changelog :(
 [#1207]: https://github.com/linebender/druid/pull/1207
 [#1210]: https://github.com/linebender/druid/pull/1210
 [#1214]: https://github.com/linebender/druid/pull/1214
-<<<<<<< HEAD
 [#1226]: https://github.com/linebender/druid/pull/1226
 [#1232]: https://github.com/linebender/druid/pull/1232
 [#1231]: https://github.com/linebender/druid/pull/1231
-=======
 [#1220]: https://github.com/linebender/druid/pull/1220
->>>>>>> fb98400c... Add default horizontal & vertical padding to theme
+[#1238]: https://github.com/linebender/druid/pull/1238
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master
 [0.6.0]: https://github.com/linebender/druid/compare/v0.5.0...v0.6.0

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -1062,6 +1062,15 @@ impl WndProc for MyWndProc {
 
                 Some(0)
             }
+            WM_CLOSE => {
+                if let Ok(mut s) = self.state.try_borrow_mut() {
+                    let s = s.as_mut().unwrap();
+                    s.handler.request_close();
+                    Some(0)
+                } else {
+                    None
+                }
+            }
             DS_REQUEST_DESTROY => {
                 unsafe {
                     DestroyWindow(hwnd);


### PR DESCRIPTION
This PR implements the Windows part of [#1159 "Implement close request interception"](https://github.com/linebender/druid/issues/1159).

----

This is my first PR for this project; hope my submitting a PR without an introduction or any warning is OK?
I've just encountered the non-working CLOSE_WINDOW while working on an app I'm building as an exercise to grok the Rust way, and fixing it seemed straightforward.
Hope it can be of use.
