### PR TITLE
Baseline alignment

### DIFF
--- a/druid/examples/flex.rs
+++ b/druid/examples/flex.rs
@@ -146,6 +146,7 @@ fn make_control_row() -> impl Widget<AppState> {
                         ("Start", CrossAxisAlignment::Start),
                         ("Center", CrossAxisAlignment::Center),
                         ("End", CrossAxisAlignment::End),
+                        ("Baseline", CrossAxisAlignment::Baseline),
                     ])
                     .lens(Params::cross_alignment),
                 ),
@@ -261,11 +262,13 @@ fn build_widget(state: &Params) -> Box<dyn Widget<AppState>> {
 
     space_if_needed(&mut flex, state);
 
-    flex.add_child(Label::new(|data: &DemoState, _: &Env| {
-        data.input_text.clone()
-    }));
+    flex.add_child(
+        Label::new(|data: &DemoState, _: &Env| data.input_text.clone()).with_text_size(32.0),
+    );
     space_if_needed(&mut flex, state);
     flex.add_child(Checkbox::new("Demo").lens(DemoState::enabled));
+    space_if_needed(&mut flex, state);
+    flex.add_child(Switch::new().lens(DemoState::enabled));
     space_if_needed(&mut flex, state);
     flex.add_child(Slider::new().lens(DemoState::volume));
     space_if_needed(&mut flex, state);
@@ -278,8 +281,6 @@ fn build_widget(state: &Params) -> Box<dyn Widget<AppState>> {
             .with_wraparound(true)
             .lens(DemoState::volume),
     );
-    space_if_needed(&mut flex, state);
-    flex.add_child(Switch::new().lens(DemoState::enabled));
 
     let mut flex = SizedBox::new(flex);
     if state.fix_minor_axis {

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -595,6 +595,19 @@ impl LayoutCtx<'_, '_> {
     pub fn set_paint_insets(&mut self, insets: impl Into<Insets>) {
         self.widget_state.paint_insets = insets.into().nonnegative();
     }
+
+    /// Set an explicit baseline position for this widget.
+    ///
+    /// The baseline position is used to align widgets that contain text,
+    /// such as buttons, labels, and other controls. It may also be used
+    /// by other widgets that are opinionated about how they are aligned
+    /// relative to neighbouring text, such as switches or checkboxes.
+    ///
+    /// The provided value should be the distance from the *bottom* of the
+    /// widget to the baseline.
+    pub fn set_baseline_offset(&mut self, baseline: f64) {
+        self.widget_state.baseline_offset = baseline
+    }
 }
 
 impl PaintCtx<'_, '_, '_> {

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -80,6 +80,13 @@ pub(crate) struct WidgetState {
     /// drop shadows or overflowing text.
     pub(crate) paint_insets: Insets,
 
+    /// The offset of the baseline relative to the bottom of the widget.
+    ///
+    /// In general, this will be zero; the bottom of the widget will be considered
+    /// the baseline. Widgets that contain text or controls that expect to be
+    /// laid out alongside text can set this as appropriate.
+    pub(crate) baseline_offset: f64,
+
     // The region that needs to be repainted, relative to the widget's bounds.
     pub(crate) invalid: Region,
 
@@ -311,6 +318,11 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
         let parent_bounds = Rect::ZERO.with_size(parent_size);
         let union_pant_rect = self.paint_rect().union(parent_bounds);
         union_pant_rect - parent_bounds
+    }
+
+    /// The distance from the bottom of this widget to the baseline.
+    pub fn baseline_offset(&self) -> f64 {
+        self.state.baseline_offset
     }
 
     /// Determines if the provided `mouse_pos` is inside `rect`
@@ -884,6 +896,7 @@ impl WidgetState {
             paint_insets: Insets::ZERO,
             invalid: Region::EMPTY,
             viewport_offset: Vec2::ZERO,
+            baseline_offset: 0.0,
             is_hot: false,
             needs_layout: false,
             is_active: false,

--- a/druid/src/text/layout.rs
+++ b/druid/src/text/layout.rs
@@ -1,5 +1,6 @@
 // Copyright 2020 The xi-editor Authors.
 //
+///// Return the distance from
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -55,6 +56,16 @@ pub struct TextLayout<T> {
     layout: Option<PietTextLayout>,
     wrap_width: f64,
     alignment: TextAlignment,
+}
+
+/// Metrics describing the layout text.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LayoutMetrics {
+    /// The nominal size of the layout.
+    pub size: Size,
+    /// The distance from the nominal top of the layout to the first baseline.
+    pub first_baseline: f64,
+    //TODO: add inking_rect
 }
 
 impl<T> TextLayout<T> {
@@ -191,6 +202,31 @@ impl<T: TextStorage> TextLayout<T> {
             .as_ref()
             .map(|layout| layout.size())
             .unwrap_or_default()
+    }
+
+    /// Return the text's [`LayoutMetrics`].
+    ///
+    /// This is not meaningful until [`rebuild_if_needed`] has been called.
+    ///
+    /// [`rebuild_if_needed`]: #method.rebuild_if_needed
+    /// [`LayoutMetrics`]: struct.LayoutMetrics.html
+    pub fn layout_metrics(&self) -> LayoutMetrics {
+        debug_assert!(
+            self.layout.is_some(),
+            "TextLayout::layout_metrics called without rebuilding layout object. Text was '{}'",
+            self.text().as_ref().map(|s| s.as_str()).unwrap_or_default()
+        );
+
+        if let Some(layout) = self.layout.as_ref() {
+            let first_baseline = layout.line_metric(0).unwrap().baseline;
+            let size = layout.size();
+            LayoutMetrics {
+                size,
+                first_baseline,
+            }
+        } else {
+            LayoutMetrics::default()
+        }
     }
 
     /// For a given `Point` (relative to this object's origin), returns index

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -137,20 +137,16 @@ impl<T: Data> Widget<T> for Button<T> {
         self.label.update(ctx, old_data, data, env)
     }
 
-    fn layout(
-        &mut self,
-        layout_ctx: &mut LayoutCtx,
-        bc: &BoxConstraints,
-        data: &T,
-        env: &Env,
-    ) -> Size {
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         bc.debug_check("Button");
         let padding = Size::new(LABEL_INSETS.x_value(), LABEL_INSETS.y_value());
         let label_bc = bc.shrink(padding).loosen();
-        self.label_size = self.label.layout(layout_ctx, &label_bc, data, env);
+        self.label_size = self.label.layout(ctx, &label_bc, data, env);
         // HACK: to make sure we look okay at default sizes when beside a textbox,
         // we make sure we will have at least the same height as the default textbox.
         let min_height = env.get(theme::BORDERED_WIDGET_HEIGHT);
+        let baseline = self.label.baseline_offset();
+        ctx.set_baseline_offset(baseline + LABEL_INSETS.y1);
 
         bc.constrain(Size::new(
             self.label_size.width + padding.width,

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -79,7 +79,10 @@ impl Widget<bool> for Checkbox {
             check_size + x_padding + label_size.width,
             check_size.max(label_size.height),
         );
-        bc.constrain(desired_size)
+        let our_size = bc.constrain(desired_size);
+        let baseline = self.child_label.baseline_offset() + (our_size.height - label_size.height);
+        ctx.set_baseline_offset(baseline);
+        our_size
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &bool, env: &Env) {

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -294,6 +294,13 @@ pub enum CrossAxisAlignment {
     /// In a vertical container, widgets are bottom aligned. In a horiziontal
     /// container, their trailing edges are aligned.
     End,
+    /// Align on the baseline.
+    ///
+    /// In a horizontal container, widgets are aligned along the calculated
+    /// baseline. In a vertical container, this is equivalent to `End`.
+    ///
+    /// The calculated baseline is the maximum baseline offset of the children.
+    Baseline,
 }
 
 /// Arrangement of children on the main axis.
@@ -607,15 +614,21 @@ impl<T: Data> Widget<T> for Flex<T> {
         // we loosen our constraints when passing to children.
         let loosened_bc = bc.loosen();
 
+        // minor-axis values for all children
+        let mut minor = self.direction.minor(bc.min());
+        // these two are calculated but only used if we're baseline aligned
+        let mut max_above_baseline = 0f64;
+        let mut max_below_baseline = 0f64;
+
         // Measure non-flex children.
         let mut major_non_flex = 0.0;
-        let mut minor = self.direction.minor(bc.min());
         for child in &mut self.children {
             if child.params.flex == 0.0 {
                 let child_bc = self
                     .direction
                     .constraints(&loosened_bc, 0., std::f64::INFINITY);
                 let child_size = child.widget.layout(ctx, &child_bc, data, env);
+                let baseline_offset = child.widget.baseline_offset();
 
                 if child_size.width.is_infinite() {
                     log::warn!("A non-Flex child has an infinite width.");
@@ -627,6 +640,8 @@ impl<T: Data> Widget<T> for Flex<T> {
 
                 major_non_flex += self.direction.major(child_size).expand();
                 minor = minor.max(self.direction.minor(child_size).expand());
+                max_above_baseline = max_above_baseline.max(child_size.height - baseline_offset);
+                max_below_baseline = max_below_baseline.max(baseline_offset);
                 // Stash size.
                 let rect = child_size.to_rect();
                 child.widget.set_layout_rect(ctx, data, env, rect);
@@ -651,9 +666,12 @@ impl<T: Data> Widget<T> for Flex<T> {
                     .direction
                     .constraints(&loosened_bc, min_major, actual_major);
                 let child_size = child.widget.layout(ctx, &child_bc, data, env);
+                let baseline_offset = child.widget.baseline_offset();
 
                 major_flex += self.direction.major(child_size).expand();
                 minor = minor.max(self.direction.minor(child_size).expand());
+                max_above_baseline = max_above_baseline.max(child_size.height - baseline_offset);
+                max_below_baseline = max_below_baseline.max(baseline_offset);
                 // Stash size.
                 let rect = child_size.to_rect();
                 child.widget.set_layout_rect(ctx, data, env, rect);
@@ -670,21 +688,39 @@ impl<T: Data> Widget<T> for Flex<T> {
         };
 
         let mut spacing = Spacing::new(self.main_alignment, extra, self.children.len());
-        // Finalize layout, assigning positions to each child.
+
+        // the actual size needed to tightly fit the children on the minor axis.
+        // Unlike the 'minor' var, this ignores the incoming constraints.
+        let minor_dim = match self.direction {
+            Axis::Horizontal => max_below_baseline + max_above_baseline,
+            Axis::Vertical => minor,
+        };
+
         let mut major = spacing.next().unwrap_or(0.);
         let mut child_paint_rect = Rect::ZERO;
         for child in &mut self.children {
-            let rect = child.widget.layout_rect();
-            let extra_minor = minor - self.direction.minor(rect.size());
+            let child_size = child.widget.layout_rect().size();
             let alignment = child.params.alignment.unwrap_or(self.cross_alignment);
-            let align_minor = alignment.align(extra_minor);
-            let pos: Point = self.direction.pack(major, align_minor).into();
+            let child_minor_offset = match alignment {
+                // This will ignore baseline alignment if it is overridden on children,
+                // but is not the default for the container. Is this okay?
+                CrossAxisAlignment::Baseline if matches!(self.direction, Axis::Horizontal) => {
+                    let extra_height = minor - minor_dim.min(minor);
+                    let child_baseline = child.widget.baseline_offset();
+                    let child_above_baseline = child_size.height - child_baseline;
+                    extra_height + (max_above_baseline - child_above_baseline)
+                }
+                _ => {
+                    let extra_minor = minor_dim - self.direction.minor(child_size);
+                    alignment.align(extra_minor)
+                }
+            };
 
-            child
-                .widget
-                .set_layout_rect(ctx, data, env, rect.with_origin(pos));
+            let child_pos: Point = self.direction.pack(major, child_minor_offset).into();
+            let child_frame = Rect::from_origin_size(child_pos, child_size);
+            child.widget.set_layout_rect(ctx, data, env, child_frame);
             child_paint_rect = child_paint_rect.union(child.widget.paint_rect());
-            major += self.direction.major(rect.size()).expand();
+            major += self.direction.major(child_size).expand();
             major += spacing.next().unwrap_or(0.);
         }
 
@@ -696,7 +732,7 @@ impl<T: Data> Widget<T> for Flex<T> {
             major = total_major;
         }
 
-        let my_size: Size = self.direction.pack(major, minor).into();
+        let my_size: Size = self.direction.pack(major, minor_dim).into();
 
         // if we don't have to fill the main axis, we loosen that axis before constraining
         let my_size = if !self.fill_major_axis {
@@ -711,12 +747,36 @@ impl<T: Data> Widget<T> for Flex<T> {
         let my_bounds = Rect::ZERO.with_size(my_size);
         let insets = child_paint_rect - my_bounds;
         ctx.set_paint_insets(insets);
+
+        let baseline_offset = match self.direction {
+            Axis::Horizontal => max_below_baseline,
+            Axis::Vertical => self
+                .children
+                .last()
+                .map(|last| {
+                    let child_bl = last.widget.baseline_offset();
+                    let child_max_y = last.widget.layout_rect().max_y();
+                    let extra_bottom_padding = my_size.height - child_max_y;
+                    child_bl + extra_bottom_padding
+                })
+                .unwrap_or(0.0),
+        };
+
+        ctx.set_baseline_offset(baseline_offset);
         my_size
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         for child in &mut self.children {
             child.widget.paint(ctx, data, env);
+        }
+
+        // paint the baseline if we're debugging layout
+        if env.get(Env::DEBUG_PAINT) && ctx.widget_state.baseline_offset != 0.0 {
+            let my_baseline = ctx.size().height - ctx.widget_state.baseline_offset;
+            let line = crate::kurbo::Line::new((0.0, my_baseline), (ctx.size().width, my_baseline));
+            let stroke_style = crate::piet::StrokeStyle::new().dash(vec![4.0, 4.0], 0.0);
+            ctx.stroke_styled(line, &env.get_debug_color(2), 1.0, &stroke_style);
         }
     }
 }
@@ -728,7 +788,8 @@ impl CrossAxisAlignment {
     fn align(self, val: f64) -> f64 {
         match self {
             CrossAxisAlignment::Start => 0.0,
-            CrossAxisAlignment::Center => (val / 2.0).round(),
+            // in vertical layout, baseline is equivalent to center
+            CrossAxisAlignment::Center | CrossAxisAlignment::Baseline => (val / 2.0).round(),
             CrossAxisAlignment::End => val,
         }
     }

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -268,6 +268,12 @@ impl<T: TextStorage> RawLabel<T> {
     pub fn draw_at(&self, ctx: &mut PaintCtx, origin: impl Into<Point>) {
         self.layout.draw(ctx, origin)
     }
+
+    /// Return the offset of the first baseline relative to the bottom of the widget.
+    pub fn baseline_offset(&self) -> f64 {
+        let text_metrics = self.layout.layout_metrics();
+        text_metrics.size.height - text_metrics.first_baseline
+    }
 }
 
 impl<T: TextStorage> Label<T> {
@@ -533,9 +539,12 @@ impl<T: TextStorage> Widget<T> for RawLabel<T> {
         self.layout.set_wrap_width(width);
         self.layout.rebuild_if_needed(ctx.text(), env);
 
-        let mut text_size = self.layout.size();
-        text_size.width += 2. * LABEL_X_PADDING;
-        bc.constrain(text_size)
+        let text_metrics = self.layout.layout_metrics();
+        ctx.set_baseline_offset(text_metrics.size.height - text_metrics.first_baseline);
+        bc.constrain(Size::new(
+            text_metrics.size.width + 2. * LABEL_X_PADDING,
+            text_metrics.size.height,
+        ))
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, _data: &T, _env: &Env) {

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -18,6 +18,10 @@ use crate::kurbo::{Circle, Shape};
 use crate::widget::prelude::*;
 use crate::{theme, LinearGradient, Point, Rect, UnitPoint};
 
+const TRACK_THICKNESS: f64 = 4.0;
+const BORDER_WIDTH: f64 = 2.0;
+const KNOB_STROKE_WIDTH: f64 = 2.0;
+
 /// A slider, allowing interactive update of a numeric value.
 ///
 /// This slider implements `Widget<f64>`, and works on values clamped
@@ -117,16 +121,12 @@ impl Widget<f64> for Slider {
         ctx.request_paint();
     }
 
-    fn layout(
-        &mut self,
-        _layout_ctx: &mut LayoutCtx,
-        bc: &BoxConstraints,
-        _data: &f64,
-        env: &Env,
-    ) -> Size {
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, _data: &f64, env: &Env) -> Size {
         bc.debug_check("Slider");
         let height = env.get(theme::BASIC_WIDGET_HEIGHT);
         let width = env.get(theme::WIDE_WIDGET_WIDTH);
+        let baseline_offset = (height / 2.0) - TRACK_THICKNESS;
+        ctx.set_baseline_offset(baseline_offset);
         bc.constrain((width, height))
     }
 
@@ -134,16 +134,13 @@ impl Widget<f64> for Slider {
         let clamped = self.normalize(*data);
         let rect = ctx.size().to_rect();
         let knob_size = env.get(theme::BASIC_WIDGET_HEIGHT);
-        let track_thickness = 4.;
-        let border_width = 2.;
-        let knob_stroke_width = 2.;
 
         //Paint the background
         let background_width = rect.width() - knob_size;
-        let background_origin = Point::new(knob_size / 2., (knob_size - track_thickness) / 2.);
-        let background_size = Size::new(background_width, track_thickness);
+        let background_origin = Point::new(knob_size / 2., (knob_size - TRACK_THICKNESS) / 2.);
+        let background_size = Size::new(background_width, TRACK_THICKNESS);
         let background_rect = Rect::from_origin_size(background_origin, background_size)
-            .inset(-border_width / 2.)
+            .inset(-BORDER_WIDTH / 2.)
             .to_rounded_rect(2.);
 
         let background_gradient = LinearGradient::new(
@@ -155,7 +152,7 @@ impl Widget<f64> for Slider {
             ),
         );
 
-        ctx.stroke(background_rect, &env.get(theme::BORDER_DARK), border_width);
+        ctx.stroke(background_rect, &env.get(theme::BORDER_DARK), BORDER_WIDTH);
 
         ctx.fill(background_rect, &background_gradient);
 
@@ -165,7 +162,7 @@ impl Widget<f64> for Slider {
 
         let knob_position = (rect.width() - knob_size) * clamped + knob_size / 2.;
         self.knob_pos = Point::new(knob_position, knob_size / 2.);
-        let knob_circle = Circle::new(self.knob_pos, (knob_size - knob_stroke_width) / 2.);
+        let knob_circle = Circle::new(self.knob_pos, (knob_size - KNOB_STROKE_WIDTH) / 2.);
 
         let normal_knob_gradient = LinearGradient::new(
             UnitPoint::TOP,
@@ -197,7 +194,7 @@ impl Widget<f64> for Slider {
             env.get(theme::FOREGROUND_DARK)
         };
 
-        ctx.stroke(knob_circle, &border_color, knob_stroke_width);
+        ctx.stroke(knob_circle, &border_color, KNOB_STROKE_WIDTH);
 
         //Actually paint the knob
         ctx.fill(knob_circle, &knob_gradient);

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -169,9 +169,16 @@ impl Widget<bool> for Switch {
         }
     }
 
-    fn layout(&mut self, _ctx: &mut LayoutCtx, bc: &BoxConstraints, _: &bool, env: &Env) -> Size {
-        let width = env.get(theme::BORDERED_WIDGET_HEIGHT) * SWITCH_WIDTH_RATIO;
-        bc.constrain(Size::new(width, env.get(theme::BORDERED_WIDGET_HEIGHT)))
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, _: &bool, env: &Env) -> Size {
+        let text_metrics = self.on_text.layout_metrics();
+        let height = env.get(theme::BORDERED_WIDGET_HEIGHT);
+        let width = height * SWITCH_WIDTH_RATIO;
+
+        let label_y = (height - text_metrics.size.height).max(0.0) / 2.0;
+        let text_bottom_padding = height - (text_metrics.size.height + label_y);
+        let text_baseline_offset = text_metrics.size.height - text_metrics.first_baseline;
+        ctx.set_baseline_offset(text_bottom_padding + text_baseline_offset);
+        bc.constrain(Size::new(width, height))
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &bool, env: &Env) {

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -268,21 +268,27 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, _data: &T, env: &Env) -> Size {
+        let width = env.get(theme::WIDE_WIDGET_WIDTH);
+        let min_height = env.get(theme::BORDERED_WIDGET_HEIGHT);
+
         self.placeholder.rebuild_if_needed(ctx.text(), env);
         if self.multiline {
             self.editor
                 .set_wrap_width(bc.max().width - TEXT_INSETS.x_value());
         }
         self.editor.rebuild_if_needed(ctx.text(), env);
-        let size = self.editor.layout().size();
 
-        let width = env.get(theme::WIDE_WIDGET_WIDTH);
-        let min_height = env.get(theme::BORDERED_WIDGET_HEIGHT);
-
-        let text_height = size.height + TEXT_INSETS.y_value();
+        let text_metrics = self.editor.layout().layout_metrics();
+        let text_height = text_metrics.size.height + TEXT_INSETS.y_value();
         let height = text_height.max(min_height);
 
-        bc.constrain((width, height))
+        let size = bc.constrain((width, height));
+        let bottom_padding = (size.height - text_metrics.size.height) / 2.0;
+        let baseline_off =
+            bottom_padding + (text_metrics.size.height - text_metrics.first_baseline);
+        ctx.set_baseline_offset(baseline_off);
+
+        size
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {


### PR DESCRIPTION
This is a first draft at supporting baseline alignment. This would be principally used as an option (eventually maybe the default option) for aligning items in a `Flex::row`. The `Flex` example is the best place to look at this:

![Screen Shot 2020-09-17 at 12 45 32 PM](https://user-images.githubusercontent.com/3330916/93501613-aeac1800-f8e3-11ea-85ae-44ad14a4901a.png)
![Screen Shot 2020-09-17 at 12 45 52 PM](https://user-images.githubusercontent.com/3330916/93501641-ba97da00-f8e3-11ea-83f1-6a467d60e32f.png)
![Screen Shot 2020-09-17 at 12 46 13 PM](https://user-images.githubusercontent.com/3330916/93501677-c6839c00-f8e3-11ea-8542-f4fce8b76535.png)

This PR has some problems:

- existing widgets were not designed with the idea of baseline alignment, and some of them might now look weird. This is particularly true of the `Stepper`, which I think needs to be reworked; I think it should be combined with a `TextField` into some kind of `NumericalTextField` or similar, and then should be laid out to look good with the `TextField`'s baseline
- Some widgets should be reworked to use a common set of drawing metrics; in particular the text field and the button should have the same geometry.
- This only adds 'First Baseline'; I would like to also have 'Last Baseline', but the code starts to get bad, which motivates:
- This makes me wonder if we should have a new return type for `Widget::layout`, that would include size, paint insets, baseline offsets, and potentially other things.
- The layout code for this in `Flex` doesn't feel very robust; this would be easier if we made the change above, because we could take advantage of the widgetpod stashing all of the layout metrics, and not only size.
