### PR TITLE
Make GTK dependency optional.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - Switch widget: Toggle animation being window refresh rate dependent ([#1145] by [@ForLoveOfCats])
 - Multi-click on Windows, partial fix for #859 ([#1157] by [@raphlinus])
 - Windows: fix crash on resize from incompatible resources ([#1191 by [@raphlinus]])
+- GTK: Related dependencies are now optional, facilitating a pure X11 build. ([#1241] by [@finnerale])
 
 ### Visual
 
@@ -459,6 +460,7 @@ Last release without a changelog :(
 [#1231]: https://github.com/linebender/druid/pull/1231
 [#1220]: https://github.com/linebender/druid/pull/1220
 [#1238]: https://github.com/linebender/druid/pull/1238
+[#1241]: https://github.com/linebender/druid/pull/1241
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master
 [0.6.0]: https://github.com/linebender/druid/compare/v0.5.0...v0.6.0

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -14,8 +14,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 default-target = "x86_64-pc-windows-msvc"
 
 [features]
-x11 = ["x11rb", "nix", "cairo-sys-rs", "cairo-rs"]
-gtk = ["cairo-rs", "gio", "gdk", "gdk-sys", "glib", "glib-sys", "gtk-sys", "gtk-rs"]
+x11 = ["x11rb", "nix", "cairo-sys-rs"]
+gtk = ["gio", "gdk", "gdk-sys", "glib", "glib-sys", "gtk-sys", "gtk-rs"]
 default = ["gtk"]
 
 [dependencies]
@@ -32,9 +32,6 @@ instant = { version = "0.1.6", features = ["wasm-bindgen"] }
 anyhow = "1.0.32"
 keyboard-types = { version = "0.5.0", default_features = false }
 
-# TODO(x11/dependencies): only use feature "xcb" if using X11
-cairo-rs = { version = "0.9.1", default_features = false, features = ["xcb"], optional = true }
-
 [target.'cfg(target_os="windows")'.dependencies]
 wio = "0.2.2"
 
@@ -50,8 +47,11 @@ objc = "0.2.7"
 core-graphics = "0.22.0"
 foreign-types = "0.3.2"
 bitflags = "1.2.1"
+cairo-rs = { version = "0.9.1", default_features = false, optional = true }
 
 [target.'cfg(target_os="linux")'.dependencies]
+# TODO(x11/dependencies): only use feature "xcb" if using X11
+cairo-rs = { version = "0.9.1", default_features = false, features = ["xcb"] }
 cairo-sys-rs = { version = "0.10.0", default_features = false, optional = true }
 gio = { version = "0.9.1", optional = true }
 gdk = { version = "0.13.2", optional = true }

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -15,8 +15,8 @@ default-target = "x86_64-pc-windows-msvc"
 
 [features]
 x11 = ["x11rb", "nix", "cairo-sys-rs", "cairo-rs"]
-GTK = ["cairo-rs", "gio", "gdk", "gdk-sys", "glib", "glib-sys", "gtk-sys", "gtk"]
-default = ["GTK"]
+gtk = ["cairo-rs", "gio", "gdk", "gdk-sys", "glib", "glib-sys", "gtk-sys", "gtk-rs"]
+default = ["gtk"]
 
 [dependencies]
 # NOTE: When changing the piet or kurbo versions, ensure that
@@ -31,6 +31,9 @@ cfg-if = "0.1.10"
 instant = { version = "0.1.6", features = ["wasm-bindgen"] }
 anyhow = "1.0.32"
 keyboard-types = { version = "0.5.0", default_features = false }
+
+# TODO(x11/dependencies): only use feature "xcb" if using X11
+cairo-rs = { version = "0.9.1", default_features = false, features = ["xcb"], optional = true }
 
 [target.'cfg(target_os="windows")'.dependencies]
 wio = "0.2.2"
@@ -49,13 +52,12 @@ foreign-types = "0.3.2"
 bitflags = "1.2.1"
 
 [target.'cfg(target_os="linux")'.dependencies]
-# TODO(x11/dependencies): only use feature "xcb" if using X11
-cairo-rs = { version = "0.9.1", default_features = false, features = ["xcb"], optional = true }
 cairo-sys-rs = { version = "0.10.0", default_features = false, optional = true }
 gio = { version = "0.9.1", optional = true }
 gdk = { version = "0.13.2", optional = true }
 gdk-sys = { version = "0.10.0", optional = true }
-gtk = { version = "0.9.2", features = ["v3_22"], optional = true }
+# `gtk` gets renamed to `gtk-rs` so that we can use `gtk` as the feature name.
+gtk-rs = { version = "0.9.2", features = ["v3_22"], package = "gtk", optional = true }
 glib = { version = "0.10.1", optional = true }
 glib-sys = { version = "0.10.0", optional = true }
 gtk-sys = { version = "0.10.0", optional = true }

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -14,7 +14,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 default-target = "x86_64-pc-windows-msvc"
 
 [features]
-x11 = ["x11rb", "nix", "cairo-sys-rs"]
+x11 = ["x11rb", "nix", "cairo-sys-rs", "cairo-rs"]
+GTK = ["cairo-rs", "gio", "gdk", "gdk-sys", "glib", "glib-sys", "gtk-sys", "gtk"]
+default = ["GTK"]
 
 [dependencies]
 # NOTE: When changing the piet or kurbo versions, ensure that
@@ -29,19 +31,6 @@ cfg-if = "0.1.10"
 instant = { version = "0.1.6", features = ["wasm-bindgen"] }
 anyhow = "1.0.32"
 keyboard-types = { version = "0.5.0", default_features = false }
-
-# Optional dependencies
-cairo-rs = { version = "0.9.1", default_features = false, optional = true }
-cairo-sys-rs = { version = "0.10.0", default_features = false, optional = true }
-gio = { version = "0.9.1", optional = true }
-gdk = { version = "0.13.2", optional = true }
-gdk-sys = { version = "0.10.0", optional = true }
-gtk = { version = "0.9.2", optional = true }
-glib = { version = "0.10.1", optional = true }
-glib-sys = { version = "0.10.0", optional = true }
-gtk-sys = { version = "0.10.0", optional = true }
-nix = { version = "0.18.0", optional = true }
-x11rb = { version = "0.6.0", features = ["allow-unsafe-code", "present", "randr", "xfixes"], optional = true }
 
 [target.'cfg(target_os="windows")'.dependencies]
 wio = "0.2.2"
@@ -59,16 +48,19 @@ core-graphics = "0.22.0"
 foreign-types = "0.3.2"
 bitflags = "1.2.1"
 
-# TODO(x11/dependencies): only use feature "xcb" if using X11
 [target.'cfg(target_os="linux")'.dependencies]
-cairo-rs = { version = "0.9.1", default_features = false, features = ["xcb"] }
-gio = "0.9.1"
-gdk = "0.13.2"
-gdk-sys = "0.10.0"
-glib = "0.10.1"
-glib-sys = "0.10.0"
-gtk-sys = "0.10.0"
-gtk = { version = "0.9.2", features = ["v3_22"] }
+# TODO(x11/dependencies): only use feature "xcb" if using X11
+cairo-rs = { version = "0.9.1", default_features = false, features = ["xcb"], optional = true }
+cairo-sys-rs = { version = "0.10.0", default_features = false, optional = true }
+gio = { version = "0.9.1", optional = true }
+gdk = { version = "0.13.2", optional = true }
+gdk-sys = { version = "0.10.0", optional = true }
+gtk = { version = "0.9.2", features = ["v3_22"], optional = true }
+glib = { version = "0.10.1", optional = true }
+glib-sys = { version = "0.10.0", optional = true }
+gtk-sys = { version = "0.10.0", optional = true }
+nix = { version = "0.18.0", optional = true }
+x11rb = { version = "0.6.0", features = ["allow-unsafe-code", "present", "randr", "xfixes"], optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 wasm-bindgen = "0.2.67"

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -30,6 +30,11 @@
 #![allow(clippy::new_without_default)]
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
+// Rename `gtk_rs` back to `gtk`.
+// This allows us to use `gtk` as the feature name.
+#[cfg(feature = "gtk")]
+extern crate gtk_rs as gtk;
+
 pub use kurbo;
 pub use piet_common as piet;
 

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -32,7 +32,8 @@
 
 // Rename `gtk_rs` back to `gtk`.
 // This allows us to use `gtk` as the feature name.
-#[cfg(feature = "gtk")]
+// The `target_os` requirement is there to exclude anything `wasm` like.
+#[cfg(all(target_os = "linux", feature = "gtk"))]
 extern crate gtk_rs as gtk;
 
 pub use kurbo;

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -21,10 +21,12 @@ default-target = "x86_64-pc-windows-msvc"
 
 [features]
 x11 = ["druid-shell/x11"]
+GTK = ["druid-shell/GTK"]
 svg = ["usvg", "harfbuzz-sys"]
+default = ["GTK"]
 
 [dependencies]
-druid-shell = { version = "0.6.0", path = "../druid-shell" }
+druid-shell = { version = "0.6.0", default-features = false, path = "../druid-shell" }
 druid-derive = { version = "0.3.1", path = "../druid-derive" }
 
 log = "0.4.11"

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -21,9 +21,9 @@ default-target = "x86_64-pc-windows-msvc"
 
 [features]
 x11 = ["druid-shell/x11"]
-GTK = ["druid-shell/GTK"]
+gtk = ["druid-shell/gtk"]
 svg = ["usvg", "harfbuzz-sys"]
-default = ["GTK"]
+default = ["gtk"]
 
 [dependencies]
 druid-shell = { version = "0.6.0", default-features = false, path = "../druid-shell" }


### PR DESCRIPTION
This adds a new feature `GTK` that gates all its related dependencies, which allows building the X11 backend without GTK.

`GTK` is a default feature, which means this won't change anything for existing usages, but with
```toml
druid = { version = "0.7", default-features = false, features = ["x11"] }
```
one can use Druid with X11 and no GTK bits involved :tada: 

This seems like a simple working solution, if it compiles on Windows and Mac.

Also, I had to give the feature an upper case name, otherwise it would have conflicted with the `gtk` feature...
Maybe a different name would be less ambiguous, but I could not come up with one.