### PR TITLE
Use ArcStr in LocalizedString and LabelText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - `TextLayout` type simplifies drawing text ([#1182] by [@cmyr])
 - Implementation of `Data` trait for `i128` and `u128` primitive data types. ([#1214] by [@koutoftimer])
 - `LineBreaking` enum allows configuration of label line-breaking ([#1195] by [@cmyr])
-- `TextAlignment` support in `TextLayout` and `Label` ([#1210] by [@cmyr])`
+- `TextAlignment` support in `TextLayout` and `Label` ([#1210] by [@cmyr])
 - `UpdateCtx` gets `env_changed` and `env_key_changed` methods ([#1207] by [@cmyr])
 - `Button::from_label` to construct a `Button` with a provided `Label`. ([#1226] by [@ForLoveOfCats])
 - Lens: Added Unit lens for type erased / display only widgets that do not need data. ([#1232] by [@rjwittams])
@@ -60,6 +60,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - `AnimFrame` was moved from `lifecycle` to `event` ([#1155] by [@jneem])
 - Contexts' `text()` methods return `&mut PietText` instead of cloning ([#1205] by [@cmyr])
 - Window construction: WindowDesc decomposed to PendingWindow and WindowConfig to allow for sub-windows and reconfiguration. ([#1235] by [@rjwittams])
+- `LocalizedString` and `LabelText` use `ArcStr` instead of String ([#1245] by [@cmyr])
 - `LensWrap` widget moved into widget module ([#1251] by [@cmyr])
 
 ### Deprecated
@@ -464,6 +465,7 @@ Last release without a changelog :(
 [#1220]: https://github.com/linebender/druid/pull/1220
 [#1238]: https://github.com/linebender/druid/pull/1238
 [#1241]: https://github.com/linebender/druid/pull/1241
+[#1245]: https://github.com/linebender/druid/pull/1245
 [#1251]: https://github.com/linebender/druid/pull/1251
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master

--- a/druid/src/menu.rs
+++ b/druid/src/menu.rs
@@ -347,7 +347,7 @@ impl<T: Data> MenuDesc<T> {
                     item.platform_id = MenuItemId::next();
                     menu.add_item(
                         item.platform_id.as_u32(),
-                        item.title.localized_str(),
+                        &item.title.localized_str(),
                         item.hotkey.as_ref(),
                         item.enabled,
                         item.selected,

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -700,7 +700,7 @@ impl<T: Data> AppState<T> {
         let env = self.env();
 
         pending.title.resolve(&data, &env);
-        builder.set_title(pending.title.display_text());
+        builder.set_title(pending.title.display_text().to_string());
 
         let platform_menu = pending
             .menu

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -423,7 +423,7 @@ impl<T: Data> Window<T> {
 
     pub(crate) fn update_title(&mut self, data: &T, env: &Env) {
         if self.title.resolve(data, env) {
-            self.handle.set_title(self.title.display_text());
+            self.handle.set_title(&self.title.display_text());
         }
     }
 


### PR DESCRIPTION
This lets us share our text between druid and the piet layout
object, and starts the process of moving us away from using String
where possible.

This was motivated by explorations around making Label optionally work
as a `Widget<ArcStr>`, and using lens-like adapters to generate
that text from some other data types as needed; this would be a small
improvement of the label API.