### PR TITLE
derive Widget proposal

### DIFF
--- a/druid-derive/src/lens.rs
+++ b/druid-derive/src/lens.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::utils::*;
 use super::attr::{FieldKind, Fields, LensAttrs};
+use crate::utils::*;
 use proc_macro2::{Ident, Span};
 use quote::quote;
 use std::collections::HashSet;

--- a/druid-derive/src/lens.rs
+++ b/druid-derive/src/lens.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::utils::*;
 use super::attr::{FieldKind, Fields, LensAttrs};
 use proc_macro2::{Ident, Span};
 use quote::quote;
@@ -140,55 +141,4 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
     };
 
     Ok(expanded)
-}
-
-//I stole these from rustc!
-fn char_has_case(c: char) -> bool {
-    c.is_lowercase() || c.is_uppercase()
-}
-
-fn is_camel_case(name: &str) -> bool {
-    let name = name.trim_matches('_');
-    if name.is_empty() {
-        return true;
-    }
-
-    // start with a non-lowercase letter rather than non-uppercase
-    // ones (some scripts don't have a concept of upper/lowercase)
-    !name.chars().next().unwrap().is_lowercase()
-        && !name.contains("__")
-        && !name.chars().collect::<Vec<_>>().windows(2).any(|pair| {
-            // contains a capitalisable character followed by, or preceded by, an underscore
-            char_has_case(pair[0]) && pair[1] == '_' || char_has_case(pair[1]) && pair[0] == '_'
-        })
-}
-
-fn to_snake_case(mut str: &str) -> String {
-    let mut words = vec![];
-    // Preserve leading underscores
-    str = str.trim_start_matches(|c: char| {
-        if c == '_' {
-            words.push(String::new());
-            true
-        } else {
-            false
-        }
-    });
-    for s in str.split('_') {
-        let mut last_upper = false;
-        let mut buf = String::new();
-        if s.is_empty() {
-            continue;
-        }
-        for ch in s.chars() {
-            if !buf.is_empty() && buf != "'" && ch.is_uppercase() && !last_upper {
-                words.push(buf);
-                buf = String::new();
-            }
-            last_upper = ch.is_uppercase();
-            buf.extend(ch.to_lowercase());
-        }
-        words.push(buf);
-    }
-    words.join("_")
 }

--- a/druid-derive/src/lib.rs
+++ b/druid-derive/src/lib.rs
@@ -21,6 +21,7 @@ extern crate proc_macro;
 mod attr;
 mod data;
 mod lens;
+mod utils;
 mod widget;
 
 use proc_macro::TokenStream;

--- a/druid-derive/src/lib.rs
+++ b/druid-derive/src/lib.rs
@@ -21,6 +21,7 @@ extern crate proc_macro;
 mod attr;
 mod data;
 mod lens;
+mod widget;
 
 use proc_macro::TokenStream;
 use syn::parse_macro_input;
@@ -92,6 +93,14 @@ pub fn derive_data(input: TokenStream) -> TokenStream {
 pub fn derive_lens(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as syn::DeriveInput);
     lens::derive_lens_impl(input)
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
+}
+
+#[proc_macro_derive(Widget, attributes(widget))]
+pub fn derive_widget(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as syn::DeriveInput);
+    widget::derive_widget_impl(input)
         .unwrap_or_else(|err| err.to_compile_error())
         .into()
 }

--- a/druid-derive/src/lib.rs
+++ b/druid-derive/src/lib.rs
@@ -98,6 +98,47 @@ pub fn derive_lens(input: TokenStream) -> TokenStream {
         .into()
 }
 
+/// Generates implementations of the `Widget` trait.
+///
+/// An associated constant is defined on the struct for each field,
+/// having the same name as the field.
+///
+/// This macro supports a `widget` field attribute with the following arguments:
+///
+/// - `#[widget(meta)]` required attribute to mark field as meta information.
+///
+/// # Example
+///
+/// ```rust
+/// use druid_derive::Widget;
+/// use druid::widget::{
+///     Align, CompositeMeta, CrossAxisAlignment, Flex, Label, TextBox, Widget, WidgetExt,
+/// };
+///
+/// #[derive(Widget)]
+/// pub struct TextBoxWithLabel {
+///     #[widget(meta)]
+///     meta: CompositeMeta<String>,
+///     label: String,
+/// }
+///
+/// impl TextBoxWithLabel {
+///     fn new(label: impl Into<String>) -> Self {
+///         TextBoxWithLabel {
+///             meta: CompositeMeta::default(),
+///             label: label.into(),
+///         }
+///     }
+///
+///     fn build(&self) -> impl Widget<String> + 'static {
+///         Flex::column()
+///             .cross_axis_alignment(CrossAxisAlignment::Start)
+///             .with_child(Label::new(self.label.clone()))
+///             .with_spacer(4.)
+///             .with_child(TextBox::new().with_placeholder(String::from("Test")))
+///     }
+/// }
+/// ```
 #[proc_macro_derive(Widget, attributes(widget))]
 pub fn derive_widget(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as syn::DeriveInput);

--- a/druid-derive/src/utils.rs
+++ b/druid-derive/src/utils.rs
@@ -1,0 +1,51 @@
+// NOTE(Milller): I stole these from rustc!
+
+pub(crate) fn char_has_case(c: char) -> bool {
+    c.is_lowercase() || c.is_uppercase()
+}
+
+pub(crate) fn is_camel_case(name: &str) -> bool {
+    let name = name.trim_matches('_');
+    if name.is_empty() {
+        return true;
+    }
+
+    // start with a non-lowercase letter rather than non-uppercase
+    // ones (some scripts don't have a concept of upper/lowercase)
+    !name.chars().next().unwrap().is_lowercase()
+        && !name.contains("__")
+        && !name.chars().collect::<Vec<_>>().windows(2).any(|pair| {
+            // contains a capitalisable character followed by, or preceded by, an underscore
+            char_has_case(pair[0]) && pair[1] == '_' || char_has_case(pair[1]) && pair[0] == '_'
+        })
+}
+
+pub(crate) fn to_snake_case(mut str: &str) -> String {
+    let mut words = vec![];
+    // Preserve leading underscores
+    str = str.trim_start_matches(|c: char| {
+        if c == '_' {
+            words.push(String::new());
+            true
+        } else {
+            false
+        }
+    });
+    for s in str.split('_') {
+        let mut last_upper = false;
+        let mut buf = String::new();
+        if s.is_empty() {
+            continue;
+        }
+        for ch in s.chars() {
+            if !buf.is_empty() && buf != "'" && ch.is_uppercase() && !last_upper {
+                words.push(buf);
+                buf = String::new();
+            }
+            last_upper = ch.is_uppercase();
+            buf.extend(ch.to_lowercase());
+        }
+        words.push(buf);
+    }
+    words.join("_")
+}

--- a/druid-derive/src/widget.rs
+++ b/druid-derive/src/widget.rs
@@ -1,0 +1,216 @@
+// Copyright 2019 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::attr::{FieldIdent, FieldKind, Fields, WidgetAttrs};
+use proc_macro2::{Ident, Span};
+use quote::quote;
+use syn::{spanned::Spanned, Data, GenericArgument, PathArguments, Type};
+
+pub(crate) fn derive_widget_impl(
+    input: syn::DeriveInput,
+) -> Result<proc_macro2::TokenStream, syn::Error> {
+    match &input.data {
+        Data::Struct(_) => derive_struct(&input),
+        Data::Enum(e) => Err(syn::Error::new(
+            e.enum_token.span(),
+            "Widget implementations cannot be derived from enums",
+        )),
+        Data::Union(u) => Err(syn::Error::new(
+            u.union_token.span(),
+            "Widget implementations cannot be derived from unions",
+        )),
+    }
+}
+
+fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, syn::Error> {
+    let ty = &input.ident;
+
+    let twizzled_name = if is_camel_case(&ty.to_string()) {
+        let temp_name = format!("{}_derived_widgets", to_snake_case(&ty.to_string()));
+        proc_macro2::Ident::new(&temp_name, proc_macro2::Span::call_site())
+    } else {
+        return Err(syn::Error::new(
+            ty.span(),
+            "Widget implementations can only be derived from CamelCase types",
+        ));
+    };
+
+    let fields = if let syn::Data::Struct(syn::DataStruct { fields, .. }) = &input.data {
+        Fields::<WidgetAttrs>::parse_ast(fields)?
+    } else {
+        return Err(syn::Error::new(
+            input.span(),
+            "Widget implementations can only be derived from structs with named fields",
+        ));
+    };
+
+    if fields.kind != FieldKind::Named {
+        return Err(syn::Error::new(
+            input.span(),
+            "Widget implementations can only be derived from structs with named fields",
+        ));
+    }
+
+    let meta_iter = fields.iter().filter(|f| f.attrs.meta);
+    let count = meta_iter.count();
+
+    if count == 0 {
+        return Err(syn::Error::new(
+            input.span(),
+            "Widget implementations should have meta information",
+        ));
+    }
+
+    if count > 1 {
+        return Err(syn::Error::new(
+            input.span(),
+            "Widget implementations can't have more than one meta information",
+        ));
+    }
+
+    let meta_field = fields.iter().filter(|f| f.attrs.meta).next().unwrap();
+    let meta_ident = if let FieldIdent::Named(ident) = &meta_field.ident {
+        Ident::new(ident, Span::call_site())
+    } else {
+        return Err(syn::Error::new(
+            input.span(),
+            "Widget implementations can't have more than one meta information",
+        ));
+    };
+
+    let data_ty = match &meta_field.ty {
+        Type::Path(typepath) if typepath.qself.is_none() && typepath.path.segments.len() == 1 => {
+            // Get the first segment of the path (there is only one, in fact: "Option"):
+            let type_params = &typepath.path.segments.iter().next().unwrap().arguments;
+            // It should have only on angle-bracketed param ("<String>"):
+            let generic_arg = match type_params {
+                PathArguments::AngleBracketed(params) => params.args.iter().next().unwrap(),
+                _ => return Err(syn::Error::new(input.span(), "Invalid meta type")),
+            };
+            // This argument must be a type:
+            match generic_arg {
+                GenericArgument::Type(ty) => ty,
+                _ => return Err(syn::Error::new(input.span(), "Invalid meta type")),
+            }
+        }
+        _ => return Err(syn::Error::new(input.span(), "Invalid meta type")),
+    };
+
+    let expanded = quote! {
+        mod #twizzled_name {
+            use super::#ty;
+            use druid::kurbo::{Point, Rect, Size};
+            use druid::{
+                BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
+                UpdateCtx, Widget, WidgetPod,
+            };
+
+            impl Widget<#data_ty> for #ty {
+                fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut #data_ty, env: &Env) {
+                    if let Some(child) = &mut self.#meta_ident.child {
+                        child.event(ctx, event, data, env);
+                    }
+                }
+
+                fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &#data_ty, env: &Env) {
+                    if let LifeCycle::WidgetAdded = event {
+                        self.#meta_ident.child.replace(WidgetPod::new(self.build()).boxed());
+                    }
+
+                    if let Some(child) = &mut self.#meta_ident.child {
+                        child.lifecycle(ctx, event, data, env);
+                    }
+                }
+
+                fn update(&mut self, ctx: &mut UpdateCtx, _: &#data_ty, data: &#data_ty, env: &Env) {
+                    if let Some(child) = &mut self.#meta_ident.child {
+                        child.update(ctx, data, env);
+                    }
+                }
+
+                fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &#data_ty, env: &Env) -> Size {
+                    match &mut self.#meta_ident.child {
+                        Some(child) => {
+                            let size = child.layout(ctx, &bc, data, env);
+                            let rect = Rect::from_origin_size(Point::ORIGIN, size);
+                            child.set_layout_rect(ctx, data, env, rect);
+                            size
+                        }
+                        None => Size::ZERO,
+                    }
+                }
+
+                fn paint(&mut self, ctx: &mut PaintCtx, data: &#data_ty, env: &Env) {
+                    if let Some(child) = &mut self.#meta_ident.child {
+                        child.paint(ctx, data, env);
+                    }
+                }
+            }
+        }
+
+        pub use #twizzled_name::*;
+    };
+
+    Ok(expanded)
+}
+
+fn char_has_case(c: char) -> bool {
+    c.is_lowercase() || c.is_uppercase()
+}
+
+fn is_camel_case(name: &str) -> bool {
+    let name = name.trim_matches('_');
+    if name.is_empty() {
+        return true;
+    }
+
+    // start with a non-lowercase letter rather than non-uppercase
+    // ones (some scripts don't have a concept of upper/lowercase)
+    !name.chars().next().unwrap().is_lowercase()
+        && !name.contains("__")
+        && !name.chars().collect::<Vec<_>>().windows(2).any(|pair| {
+            // contains a capitalisable character followed by, or preceded by, an underscore
+            char_has_case(pair[0]) && pair[1] == '_' || char_has_case(pair[1]) && pair[0] == '_'
+        })
+}
+
+fn to_snake_case(mut str: &str) -> String {
+    let mut words = vec![];
+    // Preserve leading underscores
+    str = str.trim_start_matches(|c: char| {
+        if c == '_' {
+            words.push(String::new());
+            true
+        } else {
+            false
+        }
+    });
+    for s in str.split('_') {
+        let mut last_upper = false;
+        let mut buf = String::new();
+        if s.is_empty() {
+            continue;
+        }
+        for ch in s.chars() {
+            if !buf.is_empty() && buf != "'" && ch.is_uppercase() && !last_upper {
+                words.push(buf);
+                buf = String::new();
+            }
+            last_upper = ch.is_uppercase();
+            buf.extend(ch.to_lowercase());
+        }
+        words.push(buf);
+    }
+    words.join("_")
+}

--- a/druid-derive/src/widget.rs
+++ b/druid-derive/src/widget.rs
@@ -110,7 +110,7 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
 
     let expanded = quote! {
         mod #twizzled_name {
-            use super::#ty;
+            use super::*;
             use druid::kurbo::{Point, Rect, Size};
             use druid::{
                 BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,

--- a/druid-derive/src/widget.rs
+++ b/druid-derive/src/widget.rs
@@ -80,7 +80,7 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
         ));
     }
 
-    let meta_field = fields.iter().filter(|f| f.attrs.meta).next().unwrap();
+    let meta_field = fields.iter().find(|f| f.attrs.meta).unwrap();
     let meta_ident = if let FieldIdent::Named(ident) = &meta_field.ident {
         Ident::new(ident, Span::call_site())
     } else {

--- a/druid-derive/tests/widget.rs
+++ b/druid-derive/tests/widget.rs
@@ -1,0 +1,57 @@
+//! Test #[derive(Widget)]
+
+use druid::widget::{CompositeMeta, CrossAxisAlignment, Flex, Label, TextBox};
+use druid::Widget;
+use druid_derive::Widget;
+
+#[derive(Widget)]
+pub struct TextBoxWithLabel {
+    #[widget(meta)]
+    meta: CompositeMeta<String>,
+    label: String,
+}
+
+mod test {
+    use druid::widget::{CompositeMeta, CrossAxisAlignment, Flex, Label, TextBox};
+    use druid::Widget;
+    use druid_derive::Widget;
+
+    #[derive(Widget)]
+    pub struct Test {
+        #[widget(meta)]
+        meta: CompositeMeta<String>,
+        label: String,
+    }
+
+    impl Test {
+        fn build(&self) -> impl Widget<String> + 'static {
+            Flex::column()
+                .cross_axis_alignment(CrossAxisAlignment::Start)
+                .with_child(Label::new(self.label.clone()))
+                .with_spacer(4.)
+                .with_child(TextBox::new().with_placeholder(String::from("Test")))
+        }
+    }
+}
+
+impl TextBoxWithLabel {
+    fn new(label: impl Into<String>) -> Self {
+        TextBoxWithLabel {
+            meta: CompositeMeta::default(),
+            label: label.into(),
+        }
+    }
+
+    fn build(&self) -> impl Widget<String> + 'static {
+        Flex::column()
+            .cross_axis_alignment(CrossAxisAlignment::Start)
+            .with_child(Label::new(self.label.clone()))
+            .with_spacer(4.)
+            .with_child(TextBox::new().with_placeholder(String::from("Test")))
+    }
+}
+
+#[test]
+fn test_widget_derive() {
+    TextBoxWithLabel::new("Test");
+}

--- a/druid-derive/tests/widget.rs
+++ b/druid-derive/tests/widget.rs
@@ -5,7 +5,7 @@ use druid::Widget;
 use druid_derive::Widget;
 
 #[derive(Widget)]
-pub struct TextBoxWithLabel {
+struct TextBoxWithLabel {
     #[widget(meta)]
     meta: CompositeMeta<String>,
     label: String,

--- a/druid/examples/composite.rs
+++ b/druid/examples/composite.rs
@@ -14,28 +14,28 @@
 
 //! Demonstrates alignment of children in the flex container.
 
-use druid::widget::prelude::*;
 use druid::widget::{
-    Align, Button, Checkbox, CompositeBuild, CompositeWidget, CrossAxisAlignment, Flex, Label,
-    MainAxisAlignment, ProgressBar, RadioGroup, SizedBox, Slider, Stepper, Switch, TextBox,
-    WidgetExt,
+    Align, CompositeMeta, CrossAxisAlignment, Flex, Label, TextBox, Widget, WidgetExt,
 };
 use druid::{AppLauncher, LocalizedString, WindowDesc};
+use druid_derive::Widget;
 
+#[derive(Widget)]
 pub struct TextBoxWithLabel {
+    #[widget(meta)]
+    meta: CompositeMeta<String>,
     label: String,
 }
 
 impl TextBoxWithLabel {
     fn new(label: impl Into<String>) -> Self {
         TextBoxWithLabel {
+            meta: CompositeMeta::default(),
             label: label.into(),
         }
     }
-}
 
-impl CompositeBuild<String, Flex<String>> for TextBoxWithLabel {
-    fn build(&self) -> Flex<String> {
+    fn build(&self) -> impl Widget<String> + 'static {
         Flex::column()
             .cross_axis_alignment(CrossAxisAlignment::Start)
             .with_child(Label::new(self.label.clone()))
@@ -47,7 +47,7 @@ impl CompositeBuild<String, Flex<String>> for TextBoxWithLabel {
 fn make_ui() -> impl Widget<String> {
     Align::centered(
         Flex::column()
-            .with_child(CompositeWidget::new(TextBoxWithLabel::new("My text box")))
+            .with_child(TextBoxWithLabel::new("My text box"))
             .padding(10.0),
     )
 }

--- a/druid/examples/composite.rs
+++ b/druid/examples/composite.rs
@@ -1,0 +1,65 @@
+// Copyright 2020 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Demonstrates alignment of children in the flex container.
+
+use druid::widget::prelude::*;
+use druid::widget::{
+    Align, Button, Checkbox, CompositeBuild, CompositeWidget, CrossAxisAlignment, Flex, Label,
+    MainAxisAlignment, ProgressBar, RadioGroup, SizedBox, Slider, Stepper, Switch, TextBox,
+    WidgetExt,
+};
+use druid::{AppLauncher, LocalizedString, WindowDesc};
+
+pub struct TextBoxWithLabel {
+    label: String,
+}
+
+impl TextBoxWithLabel {
+    fn new(label: impl Into<String>) -> Self {
+        TextBoxWithLabel {
+            label: label.into(),
+        }
+    }
+}
+
+impl CompositeBuild<String, Flex<String>> for TextBoxWithLabel {
+    fn build(&self) -> Flex<String> {
+        Flex::column()
+            .cross_axis_alignment(CrossAxisAlignment::Start)
+            .with_child(Label::new(self.label.clone()))
+            .with_spacer(4.)
+            .with_child(TextBox::new().with_placeholder(String::from("Test")))
+    }
+}
+
+fn make_ui() -> impl Widget<String> {
+    Align::centered(
+        Flex::column()
+            .with_child(CompositeWidget::new(TextBoxWithLabel::new("My text box")))
+            .padding(10.0),
+    )
+}
+
+pub fn main() {
+    let main_window = WindowDesc::new(make_ui)
+        .window_size((720., 600.00))
+        .with_min_size((620., 265.00))
+        .title(LocalizedString::new("Composite widget example"));
+
+    AppLauncher::with_window(main_window)
+        .use_simple_logger()
+        .launch(String::new())
+        .unwrap();
+}

--- a/druid/examples/web/src/lib.rs
+++ b/druid/examples/web/src/lib.rs
@@ -14,7 +14,7 @@
 
 use wasm_bindgen::prelude::*;
 
-// This line includes an automatically generated (in composite) examples module.
+// This line includes an automatically generated (in build.rs) examples module.
 // This particular mechanism is chosen to avoid any kinds of modifications to committed files at
 // build time, keeping the source tree clean from build artifacts.
 include!("examples.in");
@@ -53,7 +53,7 @@ macro_rules! impl_example {
 }
 
 // Below is a list of examples that can be built for the web.
-// Please add the examples that cannot be built to the EXCEPTIONS list in composite.
+// Please add the examples that cannot be built to the EXCEPTIONS list in build.rs.
 impl_example!(anim);
 impl_example!(calc);
 impl_example!(custom_widget);

--- a/druid/examples/web/src/lib.rs
+++ b/druid/examples/web/src/lib.rs
@@ -14,7 +14,7 @@
 
 use wasm_bindgen::prelude::*;
 
-// This line includes an automatically generated (in build.rs) examples module.
+// This line includes an automatically generated (in composite) examples module.
 // This particular mechanism is chosen to avoid any kinds of modifications to committed files at
 // build time, keeping the source tree clean from build artifacts.
 include!("examples.in");
@@ -53,7 +53,7 @@ macro_rules! impl_example {
 }
 
 // Below is a list of examples that can be built for the web.
-// Please add the examples that cannot be built to the EXCEPTIONS list in build.rs.
+// Please add the examples that cannot be built to the EXCEPTIONS list in composite.
 impl_example!(anim);
 impl_example!(calc);
 impl_example!(custom_widget);
@@ -80,3 +80,4 @@ impl_example!(timer);
 impl_example!(view_switcher);
 impl_example!(widget_gallery);
 impl_example!(text);
+impl_example!(composite);

--- a/druid/src/widget/composite.rs
+++ b/druid/src/widget/composite.rs
@@ -6,6 +6,16 @@ use crate::{
     UpdateCtx, Widget, WidgetPod,
 };
 
+pub struct CompositeMeta<T> {
+    pub child: Option<WidgetPod<T, Box<dyn Widget<T>>>>,
+}
+
+impl<T> Default for CompositeMeta<T> {
+    fn default() -> Self {
+        CompositeMeta { child: None }
+    }
+}
+
 /// Composable widget
 pub struct CompositeWidget<T, W: Widget<T> + 'static, B: CompositeBuild<T, W>> {
     child: Option<WidgetPod<T, Box<dyn Widget<T>>>>,

--- a/druid/src/widget/composite.rs
+++ b/druid/src/widget/composite.rs
@@ -1,0 +1,76 @@
+use std::marker::PhantomData;
+
+use crate::kurbo::{Point, Rect, Size};
+use crate::{
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
+    UpdateCtx, Widget, WidgetPod,
+};
+
+/// Composable widget
+pub struct CompositeWidget<T, W: Widget<T> + 'static, B: CompositeBuild<T, W>> {
+    child: Option<WidgetPod<T, Box<dyn Widget<T>>>>,
+    composite_build: B,
+    phantom: PhantomData<W>,
+}
+
+impl<T, W: Widget<T> + 'static, B: CompositeBuild<T, W>> CompositeWidget<T, W, B> {
+    /// Create composite widget
+    pub fn new(composite_build: B) -> Self {
+        CompositeWidget {
+            child: None,
+            composite_build,
+            phantom: PhantomData::default(),
+        }
+    }
+}
+
+/// Trait that build widget
+pub trait CompositeBuild<T, W: Widget<T>> {
+    /// Build composite widget
+    fn build(&self) -> W;
+}
+
+impl<T: Data, W: Widget<T> + 'static, B: CompositeBuild<T, W>> Widget<T>
+    for CompositeWidget<T, W, B>
+{
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
+        if let Some(child) = &mut self.child {
+            child.event(ctx, event, data, env);
+        }
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        if let LifeCycle::WidgetAdded = event {
+            self.child
+                .replace(WidgetPod::new(self.composite_build.build()).boxed());
+        }
+
+        if let Some(child) = &mut self.child {
+            child.lifecycle(ctx, event, data, env);
+        }
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, _: &T, data: &T, env: &Env) {
+        if let Some(child) = &mut self.child {
+            child.update(ctx, data, env);
+        }
+    }
+
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
+        match &mut self.child {
+            Some(child) => {
+                let size = child.layout(ctx, &bc, data, env);
+                let rect = Rect::from_origin_size(Point::ORIGIN, size);
+                child.set_layout_rect(ctx, data, env, rect);
+                size
+            }
+            None => Size::ZERO,
+        }
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
+        if let Some(child) = &mut self.child {
+            child.paint(ctx, data, env);
+        }
+    }
+}

--- a/druid/src/widget/composite.rs
+++ b/druid/src/widget/composite.rs
@@ -1,10 +1,4 @@
-use std::marker::PhantomData;
-
-use crate::kurbo::{Point, Rect, Size};
-use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
-    UpdateCtx, Widget, WidgetPod,
-};
+use crate::{Widget, WidgetPod};
 
 /// Meta information for Widget derive
 pub struct CompositeMeta<T> {
@@ -15,74 +9,5 @@ pub struct CompositeMeta<T> {
 impl<T> Default for CompositeMeta<T> {
     fn default() -> Self {
         CompositeMeta { widget: None }
-    }
-}
-
-/// Composable widget
-pub struct CompositeWidget<T, W: Widget<T> + 'static, B: CompositeBuild<T, W>> {
-    child: Option<WidgetPod<T, Box<dyn Widget<T>>>>,
-    composite_build: B,
-    phantom: PhantomData<W>,
-}
-
-impl<T, W: Widget<T> + 'static, B: CompositeBuild<T, W>> CompositeWidget<T, W, B> {
-    /// Create composite widget
-    pub fn new(composite_build: B) -> Self {
-        CompositeWidget {
-            child: None,
-            composite_build,
-            phantom: PhantomData::default(),
-        }
-    }
-}
-
-/// Trait that build widget
-pub trait CompositeBuild<T, W: Widget<T>> {
-    /// Build composite widget
-    fn build(&self) -> W;
-}
-
-impl<T: Data, W: Widget<T> + 'static, B: CompositeBuild<T, W>> Widget<T>
-    for CompositeWidget<T, W, B>
-{
-    fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
-        if let Some(child) = &mut self.child {
-            child.event(ctx, event, data, env);
-        }
-    }
-
-    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
-        if let LifeCycle::WidgetAdded = event {
-            self.child
-                .replace(WidgetPod::new(self.composite_build.build()).boxed());
-        }
-
-        if let Some(child) = &mut self.child {
-            child.lifecycle(ctx, event, data, env);
-        }
-    }
-
-    fn update(&mut self, ctx: &mut UpdateCtx, _: &T, data: &T, env: &Env) {
-        if let Some(child) = &mut self.child {
-            child.update(ctx, data, env);
-        }
-    }
-
-    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
-        match &mut self.child {
-            Some(child) => {
-                let size = child.layout(ctx, &bc, data, env);
-                let rect = Rect::from_origin_size(Point::ORIGIN, size);
-                child.set_layout_rect(ctx, data, env, rect);
-                size
-            }
-            None => Size::ZERO,
-        }
-    }
-
-    fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
-        if let Some(child) = &mut self.child {
-            child.paint(ctx, data, env);
-        }
     }
 }

--- a/druid/src/widget/composite.rs
+++ b/druid/src/widget/composite.rs
@@ -6,13 +6,15 @@ use crate::{
     UpdateCtx, Widget, WidgetPod,
 };
 
+/// Meta information for Widget derive
 pub struct CompositeMeta<T> {
-    pub child: Option<WidgetPod<T, Box<dyn Widget<T>>>>,
+    /// Built widget
+    pub widget: Option<WidgetPod<T, Box<dyn Widget<T>>>>,
 }
 
 impl<T> Default for CompositeMeta<T> {
     fn default() -> Self {
-        CompositeMeta { child: None }
+        CompositeMeta { widget: None }
     }
 }
 

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -15,11 +15,11 @@
 //! Common widgets.
 
 mod align;
-mod composite;
 mod button;
 mod checkbox;
 mod click;
 mod common;
+mod composite;
 mod container;
 mod controller;
 mod either;
@@ -54,11 +54,11 @@ mod widget_ext;
 
 pub use self::image::{Image, ImageData};
 pub use align::Align;
-pub use composite::{CompositeBuild, CompositeWidget};
 pub use button::Button;
 pub use checkbox::Checkbox;
 pub use click::Click;
 pub use common::FillStrat;
+pub use composite::{CompositeBuild, CompositeMeta, CompositeWidget};
 pub use container::Container;
 pub use controller::{Controller, ControllerHost};
 pub use either::Either;

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -15,6 +15,7 @@
 //! Common widgets.
 
 mod align;
+mod composite;
 mod button;
 mod checkbox;
 mod click;
@@ -53,6 +54,7 @@ mod widget_ext;
 
 pub use self::image::{Image, ImageData};
 pub use align::Align;
+pub use composite::{CompositeBuild, CompositeWidget};
 pub use button::Button;
 pub use checkbox::Checkbox;
 pub use click::Click;

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -58,7 +58,7 @@ pub use button::Button;
 pub use checkbox::Checkbox;
 pub use click::Click;
 pub use common::FillStrat;
-pub use composite::{CompositeBuild, CompositeMeta, CompositeWidget};
+pub use composite::CompositeMeta;
 pub use container::Container;
 pub use controller::{Controller, ControllerHost};
 pub use either::Either;


### PR DESCRIPTION
This PR adds derive macro to implement the Widget trait. It can be helpful for a composite widget that is built from existing widgets.

**Example**

```rust
#[derive(Widget)]
pub struct TextBoxWithLabel {
    #[widget(meta)]
    meta: CompositeMeta<String>,
    label: String,
}

impl TextBoxWithLabel {
    fn new(label: impl Into<String>) -> Self {
        TextBoxWithLabel {
            meta: CompositeMeta::default(),
            label: label.into(),
        }
    }

    fn build(&self) -> impl Widget<String> + 'static {
        Flex::column()
            .cross_axis_alignment(CrossAxisAlignment::Start)
            .with_child(Label::new(self.label.clone()))
            .with_spacer(4.)
            .with_child(TextBox::new().with_placeholder(String::from("Test")))
    }
}

fn make_ui() -> impl Widget<String> {
    Align::centered(
        Flex::column()
            .with_child(TextBoxWithLabel::new("My text box"))
            .padding(10.0),
    )
}
```

this will expand to this:

```rust
mod text_box_with_label_derived_widgets {
    use super::*;
    use druid::kurbo::{Point, Rect, Size};
    use druid::{
        BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
        UpdateCtx, Widget, WidgetPod,
    };
    impl Widget<String> for TextBoxWithLabel {
        fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut String, env: &Env) {
            if let Some(widget) = &mut self.meta.widget {
                widget.event(ctx, event, data, env);
            }
        }
        fn lifecycle(
            &mut self,
            ctx: &mut LifeCycleCtx,
            event: &LifeCycle,
            data: &String,
            env: &Env,
        ) {
            if let LifeCycle::WidgetAdded = event {
                self.meta
                    .widget
                    .replace(WidgetPod::new(self.build()).boxed());
            }
            if let Some(widget) = &mut self.meta.widget {
                widget.lifecycle(ctx, event, data, env);
            }
        }
        fn update(&mut self, ctx: &mut UpdateCtx, _: &String, data: &String, env: &Env) {
            if let Some(widget) = &mut self.meta.widget {
                widget.update(ctx, data, env);
            }
        }
        fn layout(
            &mut self,
            ctx: &mut LayoutCtx,
            bc: &BoxConstraints,
            data: &String,
            env: &Env,
        ) -> Size {
            match &mut self.meta.widget {
                Some(widget) => {
                    let size = widget.layout(ctx, &bc, data, env);
                    let rect = Rect::from_origin_size(Point::ORIGIN, size);
                    widget.set_layout_rect(ctx, data, env, rect);
                    size
                }
                None => Size::ZERO,
            }
        }
        fn paint(&mut self, ctx: &mut PaintCtx, data: &String, env: &Env) {
            if let Some(widget) = &mut self.meta.widget {
                widget.paint(ctx, data, env);
            }
        }
    }
}
pub use text_box_with_label_derived_widgets::*;
```