### PR TITLE
Guarantee that WidgetAdded is the first thing a widget sees.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - `Checkbox::set_text` to update the label. ([#1346] by [@finnerale])
 - `Event::should_propagate_to_hidden` and `Lifecycle::should_propagate_to_hidden` to determine whether an event should be sent to hidden widgets (e.g. in `Tabs` or `Either`). ([#1351] by [@andrewhickman])
 - `set_cursor` can be called in the `update` method. ([#1361] by [@jneem])
+- `WidgetPod::is_initialized` to check if a widget has received `WidgetAdded`. ([#1259] by [@finnerale])
 
 ### Changed
 
@@ -118,6 +119,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - Improve Windows 7 DXGI compatibility ([#1311] by [@raphlinus])
 - Fixed `Either` not passing events to its hidden child correctly. ([#1351] by [@andrewhickman])
 - Don't drop events while showing file dialogs ([#1302], [#1328] by [@jneem])
+- Ensure that `LifeCycle::WidgetAdded` is the first thing a widget sees. ([#1259] by [@finnerale])
 
 ### Visual
 
@@ -138,6 +140,7 @@ You can find its changes [documented below](#060---2020-06-01).
 
 - Standardized web targeting terminology. ([#1013] by [@xStrom])
 - X11: Ported the X11 backend to [`x11rb`](https://github.com/psychon/x11rb). ([#1025] by [@jneem])
+- Add `debug_panic` macro for when a backtrace is useful but a panic unnecessary. ([#1259] by [@finnerale])
 
 ### Outside News
 
@@ -524,6 +527,7 @@ Last release without a changelog :(
 [#1328]: https://github.com/linebender/druid/pull/1328
 [#1346]: https://github.com/linebender/druid/pull/1346
 [#1351]: https://github.com/linebender/druid/pull/1351
+[#1259]: https://github.com/linebender/druid/pull/1259
 [#1361]: https://github.com/linebender/druid/pull/1361
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master

--- a/druid/src/app_delegate.rs
+++ b/druid/src/app_delegate.rs
@@ -57,12 +57,7 @@ impl<'a> DelegateCtx<'a> {
                     .to(Target::Global),
             );
         } else {
-            const MSG: &str = "WindowDesc<T> - T must match the application data type.";
-            if cfg!(debug_assertions) {
-                panic!(MSG);
-            } else {
-                log::error!("DelegateCtx::new_window: {}", MSG)
-            }
+            debug_panic!("DelegateCtx::new_window<T> - T must match the application data type.");
         }
     }
 
@@ -78,12 +73,7 @@ impl<'a> DelegateCtx<'a> {
                     .to(Target::Window(window)),
             );
         } else {
-            const MSG: &str = "MenuDesc<T> - T must match the application data type.";
-            if cfg!(debug_assertions) {
-                panic!(MSG);
-            } else {
-                log::error!("DelegateCtx::set_menu: {}", MSG)
-            }
+            debug_panic!("DelegateCtx::set_menu<T> - T must match the application data type.");
         }
     }
 }

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -388,7 +388,7 @@ impl Command {
                 panic!(
                     "The selector \"{}\" exists twice with different types. See druid::Command::get for more information",
                     selector.symbol()
-                )
+                );
             }))
         } else {
             None

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -391,12 +391,7 @@ impl EventCtx<'_, '_> {
                     .to(Target::Global),
             );
         } else {
-            const MSG: &str = "WindowDesc<T> - T must match the application data type.";
-            if cfg!(debug_assertions) {
-                panic!(MSG);
-            } else {
-                log::error!("EventCtx::new_window: {}", MSG)
-            }
+            debug_panic!("EventCtx::new_window<T> - T must match the application data type.");
         }
     }
 
@@ -412,12 +407,9 @@ impl EventCtx<'_, '_> {
                     .to(Target::Window(self.state.window_id)),
             );
         } else {
-            const MSG: &str = "ContextMenu<T> - T must match the application data type.";
-            if cfg!(debug_assertions) {
-                panic!(MSG);
-            } else {
-                log::error!("EventCtx::show_context_menu: {}", MSG)
-            }
+            debug_panic!(
+                "EventCtx::show_context_menu<T> - T must match the application data type."
+            );
         }
     }
 
@@ -736,12 +728,7 @@ impl<'a> ContextState<'a> {
                     .to(Target::Window(self.window_id)),
             );
         } else {
-            const MSG: &str = "MenuDesc<T> - T must match the application data type.";
-            if cfg!(debug_assertions) {
-                panic!(MSG);
-            } else {
-                log::error!("EventCtx::set_menu: {}", MSG)
-            }
+            debug_panic!("EventCtx::set_menu<T> - T must match the application data type.");
         }
     }
 

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -145,6 +145,9 @@ pub use im;
 #[macro_use]
 pub mod lens;
 
+#[macro_use]
+mod util;
+
 mod app;
 mod app_delegate;
 mod bloom;
@@ -165,7 +168,6 @@ pub mod scroll_component;
 mod tests;
 pub mod text;
 pub mod theme;
-mod util;
 pub mod widget;
 mod win_handler;
 mod window;

--- a/druid/src/util.rs
+++ b/druid/src/util.rs
@@ -18,6 +18,31 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::mem;
 
+/// Panic in debug and log::error in release mode.
+///
+/// This macro is in some way a combination of `panic` and `debug_assert`,
+/// but it will log the provided message instead of ignoring it in release builds.
+///
+/// It's useful when a backtrace would aid debugging but a crash can be avoided in release.
+macro_rules! debug_panic {
+    () => { ... };
+    ($msg:expr) => {
+        if cfg!(debug_assertions) {
+            panic!($msg);
+        } else {
+            log::error!($msg);
+        }
+    };
+    ($msg:expr,) => { debug_panic!($msg) };
+    ($fmt:expr, $($arg:tt)+) => {
+        if cfg!(debug_assertions) {
+            panic!($fmt, $($arg)*);
+        } else {
+            log::error!($fmt, $($arg)*);
+        }
+    };
+}
+
 /// Fast path for equal type extend + drain.
 pub trait ExtendDrain {
     /// Extend the collection by draining the entries from `source`.


### PR DESCRIPTION
Closes #1127 and hopefully closes #1258 as well.

With this, `WidgetPod` will panic whenever a widget receives anything but `LifeCycle::WidgetAdded` as its first event.

The advantage of a panic is that the backtrace makes it in my experience very easy to track down where things went wrong.