### PR TITLE
Add back Label::text method

### DIFF
--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -330,6 +330,11 @@ impl<T: Data> Label<T> {
         Label::new(text)
     }
 
+    /// Return the current value of the label's text.
+    pub fn text(&self) -> ArcStr {
+        self.text.display_text()
+    }
+
     /// Set the label's text.
     ///
     /// # Note


### PR DESCRIPTION
This was removed as part of #1252, but I actually use it
in runebender so would prefer to keep it around for the
time being.