### PR TITLE
[ci] Run GTK tests as separate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,87 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: install libgtk-3-dev libx11-dev
+      - name: install libx11-dev
         run: |
           sudo apt update
-          sudo apt install libgtk-3-dev libx11-dev
+          sudo apt install libx11-dev
         if: contains(matrix.os, 'ubuntu')
+
+      - name: install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+          profile: minimal
+          override: true
+
+      # Clippy packages in deeper-to-higher dependency order
+      - name: cargo clippy druid-shell
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path=druid-shell/Cargo.toml --all-targets --features=x11 --no-default-features -- -D warnings
+
+      - name: cargo clippy druid
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path=druid/Cargo.toml --all-targets  --no-default-features --features=svg,image,im,x11 -- -D warnings
+
+      - name: cargo clippy druid-derive
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path=druid-derive/Cargo.toml --all-targets -- -D warnings
+        # there's no platform specific code here so we only run once
+        if: contains(matrix.os, 'mac')
+
+      - name: cargo clippy book examples
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path=docs/book_examples/Cargo.toml --all-targets -- -D warnings
+        if: contains(matrix.os, 'mac')
+
+      # Test packages in deeper-to-higher dependency order
+      - name: cargo test druid-shell
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path=druid-shell/Cargo.toml --no-default-features --features=x11
+
+      - name: cargo test druid
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path=druid/Cargo.toml --no-default-features --features=svg,image,im,x11
+
+      - name: cargo test druid-derive
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path=druid-derive/Cargo.toml
+        if: contains(matrix.os, 'mac')
+
+      - name: cargo test book examples
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path=docs/book_examples/Cargo.toml
+        if: contains(matrix.os, 'mac')
+
+  # we test the gtk backend as a separate job because gtk install takes
+  # a long time.
+  test-stable-gtk:
+    runs-on: ubuntu-latest
+    name: cargo clippy+test (gtk)
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install libgtk-3-dev
+        run: |
+          sudo apt update
+          sudo apt install libgtk-3-dev
 
       - name: install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -61,19 +137,6 @@ jobs:
           command: clippy
           args: --manifest-path=druid/Cargo.toml --all-targets --features=svg,image,im -- -D warnings
 
-      - name: cargo clippy druid-derive
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path=druid-derive/Cargo.toml --all-targets -- -D warnings
-
-      - name: cargo clippy book examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path=docs/book_examples/Cargo.toml --all-targets -- -D warnings
-
-      # Test packages in deeper-to-higher dependency order
       - name: cargo test druid-shell
         uses: actions-rs/cargo@v1
         with:
@@ -85,48 +148,6 @@ jobs:
         with:
           command: test
           args: --manifest-path=druid/Cargo.toml --features=svg,image,im
-
-      - name: cargo test druid-derive
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=druid-derive/Cargo.toml
-
-      - name: cargo test book examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=docs/book_examples/Cargo.toml
-
-      # After default features are done, also perform X11 clippy+testing on Linux.
-      # This is better than a separate job because common dependencies are already built.
-      - name: cargo clippy druid-shell (X11)
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path=druid-shell/Cargo.toml --all-targets --features=x11 -- -D warnings
-        if: contains(matrix.os, 'ubuntu')
-
-      - name: cargo clippy druid (X11)
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path=druid/Cargo.toml --all-targets --features=x11 -- -D warnings
-        if: contains(matrix.os, 'ubuntu')
-
-      - name: cargo test druid-shell (X11)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=druid-shell/Cargo.toml --features=x11
-        if: contains(matrix.os, 'ubuntu')
-
-      - name: cargo test druid (X11)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=druid/Cargo.toml --features=x11
-        if: contains(matrix.os, 'ubuntu')
 
   test-stable-wasm:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,10 +260,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: install libgtk-dev libx11-dev
+      - name: install libx11-dev
         run: |
           sudo apt update
-          sudo apt install libgtk-3-dev libx11-dev
+          sudo apt install libx11-dev
         if: contains(matrix.os, 'ubuntu')
 
       - name: install nightly toolchain
@@ -278,6 +278,52 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --manifest-path=druid-shell/Cargo.toml --no-default-features --features=x11
+
+      - name: cargo test druid
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path=druid/Cargo.toml --no-default-features --features=svg,image,im,x11
+
+      - name: cargo test druid-derive
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path=druid-derive/Cargo.toml
+        if: contains(matrix.os, 'windows')
+
+      - name: cargo test book examples
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path=docs/book_examples/Cargo.toml
+        if: contains(matrix.os, 'windows')
+
+  # we test the gtk backend as a separate job because gtk install takes
+  # a long time.
+  test-nightly-gtk:
+    runs-on: ubuntu-latest
+    name: cargo test nightly (gtk)
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install libgtk-3-dev
+        run: |
+          sudo apt update
+          sudo apt install libgtk-3-dev
+
+      - name: install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+
+      - name: cargo test druid-shell
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
           args: --manifest-path=druid-shell/Cargo.toml
 
       - name: cargo test druid
@@ -286,33 +332,6 @@ jobs:
           command: test
           args: --manifest-path=druid/Cargo.toml --features=svg,image,im
 
-      - name: cargo test druid-derive
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=druid-derive/Cargo.toml
-
-      - name: cargo test book examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=docs/book_examples/Cargo.toml
-
-      # After default features are done, also perform X11 testing on Linux.
-      # This is better than a separate job because common dependencies are already built.
-      - name: cargo test druid-shell (X11)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=druid-shell/Cargo.toml --features=x11
-        if: contains(matrix.os, 'ubuntu')
-
-      - name: cargo test druid (X11)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=druid/Cargo.toml --features=x11
-        if: contains(matrix.os, 'ubuntu')
 
   check-docs:
     name: Docs

--- a/druid-shell/src/common_util.rs
+++ b/druid-shell/src/common_util.rs
@@ -21,8 +21,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// Strip the access keys from the menu string.
 ///
 /// Changes "E&xit" to "Exit". Actual ampersands are escaped as "&&".
-#[cfg(not(feature = "x11"))]
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[cfg(any(target_os = "macos", all(target_os = "linux", feature = "gtk")))]
 pub fn strip_access_key(raw_menu_text: &str) -> String {
     let mut saw_ampersand = false;
     let mut result = String::new();

--- a/druid-shell/src/dialog.rs
+++ b/druid-shell/src/dialog.rs
@@ -25,7 +25,7 @@ pub struct FileInfo {
 }
 
 /// Type of file dialog.
-#[cfg(not(feature = "x11"))]
+#[cfg(not(all(target_os = "linux", feature = "x11")))]
 pub enum FileDialogType {
     /// File open dialog.
     Open,


### PR DESCRIPTION
The linux builds are by far the slowest part of CI, and we
should see *some* modest gain by splitting them in two.