### PR TITLE
Updated broken links to a new ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,7 @@ druid = { git = "https://github.com/linebender/druid.git" }
 
 #### Linux
 
-On Linux, Druid requires gtk+3; see [gtk-rs dependencies] for installation
-instructions.
+On Linux, Druid requires gtk+3; see [GTK installation page].
 
 Alternatively, there is an X11 backend available, although it is currently
 [missing quite a few features](https://github.com/linebender/druid/issues?q=is%3Aopen+is%3Aissue+label%3Ashell%2Fx11+label%3Amissing).
@@ -296,7 +295,7 @@ active and friendly community.
 [basic utility and layout widgets]: ./druid/src/widget
 [Flutter's box layout model]: https://api.flutter.dev/flutter/rendering/BoxConstraints-class.html
 [value types]: https://sinusoid.es/lager/model.html#id2
-[gtk-rs dependencies]: http://gtk-rs.org/docs/requirements.html
+[GTK installation page]: https://www.gtk.org/docs/installations/linux/
 [Rust-native GUI experiments]: https://areweguiyet.com
 [CONTRIBUTING.md]: ./CONTRIBUTING.md
 [Zulip chat instance]: https://xi.zulipchat.com

--- a/docs/src/setup.md
+++ b/docs/src/setup.md
@@ -22,7 +22,7 @@ On Fedora
 sudo dnf install gtk3-devel glib2-devel
 ```
 
-See [gtk-rs dependencies] for more installation instructions.
+See [GTK installation page] for more installation instructions.
 
 ## Starting a project
 Starting a project is as easy as creating an empty application with
@@ -37,4 +37,4 @@ druid = "0.6.0"
 druid = { git = "https://github.com/linebender/druid.git" }
 ```
 
-[gtk-rs dependencies]: http://gtk-rs.org/docs/requirements.html
+[GTK installation page]: https://www.gtk.org/docs/installations/linux/


### PR DESCRIPTION
Fixes #1268 

Looks like this link from upstream is the best one, despite they are suggesting to use latest versions of dependencies, not ones from your distro. I think our users will see that and we don't need to clarify.

I'm not sure whether it make sense to add this pure documentation PR to a changelog, I think this is not what users want to see when they check changes for a new version.