### PR TITLE
Reduce flashing on window creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ You can find its changes [documented below](#060---2020-06-01).
 
 ### Changed
 
+- Windows: Reduced flashing when windows are created on high-dpi displays ([#1272] by [@rhzk])
 - Windows: Improved DPI handling. Druid should now redraw correctly when dpi changes. ([#1037] by [@rhzk])
 - windows: Window created with OS default size if not set. ([#1037] by [@rhzk])
 - `Scale::from_scale` to `Scale::new`, and `Scale` methods `scale_x` / `scale_y` to `x` / `y`. ([#1042] by [@xStrom])
@@ -492,6 +493,7 @@ Last release without a changelog :(
 [#1251]: https://github.com/linebender/druid/pull/1251
 [#1252]: https://github.com/linebender/druid/pull/1252
 [#1255]: https://github.com/linebender/druid/pull/1255
+[#1272]: https://github.com/linebender/druid/pull/1272
 [#1276]: https://github.com/linebender/druid/pull/1276
 [#1278]: https://github.com/linebender/druid/pull/1278
 [#1280]: https://github.com/linebender/druid/pull/1280

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -178,8 +178,8 @@ impl WindowHandle {
     /// [`position`] The position in pixels.
     ///
     /// [`position`]: struct.Point.html
-    pub fn set_position(&self, position: Point) {
-        self.0.set_position(position)
+    pub fn set_position(&self, position: impl Into<Point>) {
+        self.0.set_position(position.into())
     }
 
     /// Returns the position in virtual screen coordinates.
@@ -200,8 +200,8 @@ impl WindowHandle {
     ///
     /// [`WinHandler::size`]: trait.WinHandler.html#method.size
     /// [display points]: struct.Scale.html
-    pub fn set_size(&self, size: Size) {
-        self.0.set_size(size)
+    pub fn set_size(&self, size: impl Into<Size>) {
+        self.0.set_size(size.into())
     }
 
     /// Gets the window size.

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -422,8 +422,8 @@ impl<T: Data> WindowDesc<T> {
     /// [`position`] Position in pixels.
     ///
     /// [`position`]: struct.Point.html
-    pub fn set_position(mut self, position: Point) -> Self {
-        self.config = self.config.set_position(position);
+    pub fn set_position(mut self, position: impl Into<Point>) -> Self {
+        self.config = self.config.set_position(position.into());
         self
     }
 


### PR DESCRIPTION
Sets the correct window size directly after the window is built instead of adding it to the deferred queue.
Since this is done before ShowWindow is called it should not be any visible "flashing" occuring.
Updated Show() to handle maximized and minimized window, as this was also deferred and might have caused flashing.