### PR TITLE
Start updating TextBox for piet text changes

### DIFF
--- a/docs/book_examples/src/custom_widgets_md.rs
+++ b/docs/book_examples/src/custom_widgets_md.rs
@@ -49,10 +49,10 @@ impl TextBoxActionController {
     }
 }
 
-impl Controller<String, TextBox> for TextBoxActionController {
+impl Controller<String, TextBox<String>> for TextBoxActionController {
     fn event(
         &mut self,
-        child: &mut TextBox,
+        child: &mut TextBox<String>,
         ctx: &mut EventCtx,
         event: &Event,
         data: &mut String,

--- a/druid/examples/styled_text.rs
+++ b/druid/examples/styled_text.rs
@@ -15,7 +15,8 @@
 //! Example of dynamic text styling
 
 use druid::widget::{
-    Checkbox, Flex, Label, LensWrap, MainAxisAlignment, Painter, Parse, Stepper, TextBox,
+    Checkbox, CrossAxisAlignment, Flex, Label, LensWrap, MainAxisAlignment, Painter, Parse, Scroll,
+    Stepper, TextBox,
 };
 use druid::{
     theme, AppLauncher, Color, Data, FontDescriptor, FontFamily, Key, Lens, LensExt,
@@ -25,6 +26,8 @@ use std::fmt::Display;
 
 // This is a custom key we'll use with Env to set and get our font.
 const MY_CUSTOM_FONT: Key<FontDescriptor> = Key::new("org.linebender.example.my-custom-font");
+
+const COLUMN_WIDTH: f64 = 360.0;
 
 #[derive(Clone, Lens, Data)]
 struct AppData {
@@ -104,6 +107,16 @@ fn ui_builder() -> impl Widget<AppData> {
             env.set(MY_CUSTOM_FONT, new_font);
         });
 
+    let labels = Scroll::new(
+        Flex::column()
+            .cross_axis_alignment(CrossAxisAlignment::Start)
+            .with_child(label)
+            .with_default_spacer()
+            .with_child(styled_label),
+    )
+    .expand_height()
+    .fix_width(COLUMN_WIDTH);
+
     let stepper = Stepper::new()
         .with_range(0.0, 100.0)
         .with_step(1.0)
@@ -115,24 +128,26 @@ fn ui_builder() -> impl Widget<AppData> {
         AppData::size.map(|x| Some(*x), |x, y| *x = y.unwrap_or(24.0)),
     );
 
-    let stepper_row = Flex::row().with_child(stepper_textbox).with_child(stepper);
-
     let mono_checkbox = Checkbox::new("Monospace").lens(AppData::mono);
+    let stepper_row = Flex::row()
+        .with_child(stepper_textbox)
+        .with_child(stepper)
+        .with_default_spacer()
+        .with_child(mono_checkbox);
 
-    let input = TextBox::new()
+    let input = TextBox::multiline()
         .with_placeholder("Your sample text here :)")
-        .fix_width(200.0)
+        .fix_width(COLUMN_WIDTH)
+        .fix_height(140.0)
         .lens(AppData::text);
 
     Flex::column()
         .main_axis_alignment(MainAxisAlignment::Center)
-        .with_child(label)
         .with_default_spacer()
-        .with_child(styled_label)
-        .with_spacer(32.0)
+        .with_flex_child(labels, 1.0)
+        .with_default_spacer()
+        .with_child(input)
+        .with_default_spacer()
         .with_child(stepper_row)
         .with_default_spacer()
-        .with_child(mono_checkbox)
-        .with_default_spacer()
-        .with_child(input.padding(5.0))
 }

--- a/druid/src/text/editor.rs
+++ b/druid/src/text/editor.rs
@@ -1,0 +1,311 @@
+// Copyright 2020 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A component for building text editing widgets
+
+use super::{
+    movement, offset_for_delete_backwards, EditAction, EditableText, MouseAction, Movement,
+    Selection, TextLayout, TextStorage,
+};
+use crate::kurbo::Line;
+use crate::piet::PietText;
+use crate::{Application, Env, MouseEvent, PaintCtx, Point, Rect, UpdateCtx};
+
+/// A component for widgets that offer text editing.
+///
+/// `Editor` manages an [`EditableText`] type, applying edits and maintaining
+/// selection state.
+///
+/// [`EditableText`]: trait.EditableText.html
+#[derive(Debug, Clone)]
+pub struct Editor<T> {
+    layout: TextLayout<T>,
+    selection: Selection,
+    multiline: bool,
+    fixed_width: f64,
+}
+
+impl<T> Editor<T> {
+    /// Create a new `Editor`.
+    pub fn new() -> Self {
+        Editor {
+            layout: TextLayout::new(),
+            selection: Selection::caret(0),
+            multiline: false,
+            fixed_width: f64::INFINITY,
+        }
+    }
+
+    /// Set whether the editor supports multi-line text. Default to false.
+    ///
+    /// If this is false, inserted text will only insert up to the first
+    /// included newline.
+    pub fn set_multiline(&mut self, multiline: bool) {
+        self.multiline = multiline;
+    }
+
+    /// Set an explicit wrap width for this editor.
+    ///
+    /// By default the editor will not wrap lines; this is suitable for
+    /// cases such as a a single-line text field, where the containing
+    /// widget will scroll the editor as required.
+    pub fn set_wrap_width(&mut self, width: f64) {
+        self.layout.set_wrap_width(width);
+    }
+
+    //TODO discussion: should this deref/deref_mut?
+    /// Return the inner [`TextLayout`] objects.
+    ///
+    /// [`TextLayout`]: struct.TextLayout.html
+    pub fn layout(&mut self) -> &mut TextLayout<T> {
+        &mut self.layout
+    }
+}
+
+impl<T: TextStorage + EditableText> Editor<T> {
+    /// Set the text for this editor.
+    ///
+    /// This must be set before the editor is used, such as in [`WidgetAdded`].
+    ///
+    /// [`WidgetAdded`]: ../enum.LifeCycle.html#variant.WidgetAdded
+    pub fn set_text(&mut self, text: T) {
+        self.layout.set_text(text)
+    }
+
+    /// Return the current selection.
+    pub fn selection(&self) -> &Selection {
+        &self.selection
+    }
+
+    /// Returns the `Rect`s representing the  current selection.
+    pub fn selection_rects(&self) -> Vec<Rect> {
+        self.layout.rects_for_range(self.selection.range())
+    }
+
+    /// Returns the `Line` to draw for the current cursor position.
+    pub fn cursor_line(&self) -> Line {
+        self.layout
+            .cursor_line_for_text_position(self.selection.end)
+    }
+
+    /// Handle a mouse click
+    pub fn click(&mut self, mouse: &MouseEvent, data: &mut T) {
+        self.do_edit(EditAction::Click(self.mouse_action_for_event(mouse)), data);
+    }
+
+    /// Handle a mouse drag
+    pub fn drag(&mut self, mouse: &MouseEvent, data: &mut T) {
+        self.do_edit(EditAction::Drag(self.mouse_action_for_event(mouse)), data);
+    }
+
+    /// Handle a copy command
+    pub fn copy(&self, data: &mut T) {
+        if !self.data_is_stale(data) {
+            self.set_clipboard()
+        }
+    }
+
+    /// Handle a cut command
+    pub fn cut(&mut self, data: &mut T) {
+        if !self.data_is_stale(data) {
+            self.set_clipboard();
+            self.delete_backward(data);
+        }
+    }
+
+    /// Handle a paste command
+    pub fn paste(&mut self, t: String, data: &mut T) {
+        self.do_edit(EditAction::Paste(t), data)
+    }
+
+    fn mouse_action_for_event(&self, event: &MouseEvent) -> MouseAction {
+        let pos = self.layout.text_position_for_point(event.pos);
+        MouseAction {
+            row: 0,
+            column: pos,
+            mods: event.mods,
+        }
+    }
+
+    /// Update the editor if the data or env has changed.
+    ///
+    /// The widget owning this `Editor` must call this method during its own
+    /// [`update`] call.
+    ///
+    /// [`update`]: ../trait.Widget.html#tymethod.update
+    pub fn update(&mut self, ctx: &mut UpdateCtx, new_data: &T, env: &Env) {
+        if self.data_is_stale(new_data) {
+            self.layout.set_text(new_data.clone());
+            self.selection.constrain_to(new_data);
+            ctx.request_paint();
+        } else if self.layout.needs_rebuild_after_update(ctx) {
+            ctx.request_paint();
+        }
+        self.rebuild_if_needed(ctx.text(), env);
+    }
+
+    /// Must be called in WidgetAdded
+    pub fn rebuild_if_needed(&mut self, factory: &mut PietText, env: &Env) {
+        self.layout.rebuild_if_needed(factory, env);
+    }
+
+    /// Perform an [`EditAction`](enum.EditAction.html).
+    pub fn do_edit(&mut self, edit: EditAction, data: &mut T) {
+        if self.data_is_stale(data) {
+            log::warn!("editor data changed externally, skipping event {:?}", &edit);
+            return;
+        }
+        match edit {
+            EditAction::Insert(chars) | EditAction::Paste(chars) => self.insert(data, &chars),
+            EditAction::Backspace => self.delete_backward(data),
+            EditAction::Delete => self.delete_forward(data),
+            EditAction::JumpDelete(mvmt) | EditAction::JumpBackspace(mvmt) => {
+                let to_delete = if self.selection.is_caret() {
+                    movement(mvmt, self.selection, data, true)
+                } else {
+                    self.selection
+                };
+                data.edit(to_delete.range(), "");
+                self.selection = Selection::caret(to_delete.min());
+            }
+            EditAction::Move(mvmt) => self.selection = movement(mvmt, self.selection, data, false),
+            EditAction::ModifySelection(mvmt) => {
+                self.selection = movement(mvmt, self.selection, data, true)
+            }
+            EditAction::Click(action) => {
+                if action.mods.shift() {
+                    self.selection.end = action.column;
+                } else {
+                    self.selection = Selection::caret(action.column);
+                }
+            }
+            EditAction::Drag(action) => self.selection.end = action.column,
+            _ => (),
+        }
+    }
+
+    /// Draw this editor at the provided point.
+    pub fn draw(&self, ctx: &mut PaintCtx, point: impl Into<Point>) {
+        self.layout.draw(ctx, point)
+    }
+
+    /// Returns `true` if the data passed here has been changed externally,
+    /// which means things like our selection state may be out of sync.
+    ///
+    /// This would only happen in the unlikely case that somebody else has mutated
+    /// the data before us while handling an event; if this is the case we ignore
+    /// the event, and our data will be updated in `update`.
+    fn data_is_stale(&self, data: &T) -> bool {
+        self.layout.text().map(|t| !t.same(data)).unwrap_or(true)
+    }
+
+    fn insert(&mut self, data: &mut T, text: &str) {
+        // if we aren't multiline, we insert only up to the first newline
+        let text = if self.multiline {
+            text
+        } else {
+            text.split('\n').next().unwrap_or("")
+        };
+        let sel = self.selection.range();
+        data.edit(sel, text);
+        self.selection = Selection::caret(self.selection.min() + text.len());
+    }
+
+    /// Delete to previous grapheme if in caret mode.
+    /// Otherwise just delete everything inside the selection.
+    fn delete_backward(&mut self, data: &mut T) {
+        let cursor_pos = if self.selection.is_caret() {
+            let del_end = self.selection.end;
+            let del_start = offset_for_delete_backwards(&self.selection, data);
+            data.edit(del_start..del_end, "");
+            del_start
+        } else {
+            data.edit(self.selection.range(), "");
+            self.selection.min()
+        };
+
+        self.selection = Selection::caret(cursor_pos);
+    }
+
+    fn delete_forward(&mut self, data: &mut T) {
+        let to_delete = if self.selection.is_caret() {
+            movement(Movement::Right, self.selection, data, false)
+        } else {
+            self.selection
+        };
+
+        data.edit(to_delete.range(), "");
+        self.selection = Selection::caret(self.selection.min());
+    }
+
+    fn set_clipboard(&self) {
+        if let Some(text) = self
+            .layout
+            .text()
+            .and_then(|txt| txt.slice(self.selection.range()))
+        {
+            if !text.is_empty() {
+                Application::global().clipboard().put_string(text);
+            }
+        }
+    }
+}
+
+impl<T> Default for Editor<T> {
+    fn default() -> Self {
+        Editor::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Devanagari codepoints are 3 utf-8 code units each.
+    #[test]
+    fn backspace_devanagari() {
+        let mut editor = Editor::new();
+        let mut data = "".to_string();
+        editor.set_text(data.clone());
+
+        editor.insert(&mut data, "हिन्दी");
+        editor.delete_backward(&mut data);
+        assert_eq!(data, String::from("हिन्द"));
+        editor.delete_backward(&mut data);
+        assert_eq!(data, String::from("हिन्"));
+        editor.delete_backward(&mut data);
+        assert_eq!(data, String::from("हिन"));
+        editor.delete_backward(&mut data);
+        assert_eq!(data, String::from("हि"));
+        editor.delete_backward(&mut data);
+        assert_eq!(data, String::from("ह"));
+        editor.delete_backward(&mut data);
+        assert_eq!(data, String::from(""));
+    }
+
+    /// Test backspace on the combo character o̷
+    #[test]
+    fn backspace_combining() {
+        let mut editor = Editor::new();
+        let mut data = "".to_string();
+        editor.set_text(data.clone());
+
+        editor.insert(&mut data, "\u{0073}\u{006F}\u{0337}\u{0073}");
+
+        editor.delete_backward(&mut data);
+        editor.delete_backward(&mut data);
+
+        assert_eq!(data, String::from("\u{0073}\u{006F}"))
+    }
+}

--- a/druid/src/text/layout.rs
+++ b/druid/src/text/layout.rs
@@ -167,6 +167,13 @@ impl<T: TextStorage> TextLayout<T> {
         }
     }
 
+    /// Returns the [`TextStorage`] backing this layout, if it exists.
+    ///
+    /// [`TextStorage`]: trait.TextStorage.html
+    pub fn text(&self) -> Option<&T> {
+        self.text.as_ref()
+    }
+
     /// The size of the laid-out text.
     ///
     /// This is not meaningful until [`rebuild_if_needed`] has been called.

--- a/druid/src/text/mod.rs
+++ b/druid/src/text/mod.rs
@@ -17,6 +17,7 @@
 mod attribute;
 pub mod backspace;
 mod editable_text;
+mod editor;
 mod font_descriptor;
 mod layout;
 pub mod movement;
@@ -32,4 +33,5 @@ pub use self::layout::TextLayout;
 pub use self::movement::{movement, Movement};
 pub use self::selection::Selection;
 pub use self::text_input::{BasicTextInput, EditAction, MouseAction, TextInput};
+pub use editor::Editor;
 pub use storage::{ArcStr, RichText, TextStorage};

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -286,21 +286,21 @@ impl<T: Data, W> EnvScope<T, W> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::widget::TextBox;
+    use crate::widget::Slider;
     use crate::Color;
 
     #[test]
     fn container_reuse() {
-        // this should be Container<Align<Container<TextBox>>>
-        let widget = TextBox::new()
+        // this should be Container<Align<Container<Slider>>>
+        let widget = Slider::new()
             .background(Color::BLACK)
             .align_left()
             .border(Color::BLACK, 1.0);
         assert!(widget.border_is_some());
         assert!(!widget.background_is_some());
 
-        // this should be Container<TextBox>
-        let widget = TextBox::new()
+        // this should be Container<Slider>
+        let widget = Slider::new()
             .background(Color::BLACK)
             .border(Color::BLACK, 1.0);
         assert!(widget.background_is_some());
@@ -309,12 +309,12 @@ mod tests {
 
     #[test]
     fn sized_box_reuse() {
-        // this should be SizedBox<Align<SizedBox<TextBox>>>
-        let widget = TextBox::new().fix_height(10.0).align_left().fix_width(1.0);
+        // this should be SizedBox<Align<SizedBox<Slider>>>
+        let widget = Slider::new().fix_height(10.0).align_left().fix_width(1.0);
         assert_eq!(widget.width_and_height(), (Some(1.0), None));
 
-        // this should be SizedBox<TextBox>
-        let widget = TextBox::new().fix_height(10.0).fix_width(1.0);
+        // this should be SizedBox<Slider>
+        let widget = Slider::new().fix_height(10.0).fix_width(1.0);
         assert_eq!(widget.width_and_height(), (Some(1.0), Some(10.0)));
     }
 }


### PR DESCRIPTION
This is an attempt to integrate a bit of the new text stuff in to the `TextBox` widget.

Most of this code is a refactor that splits the actual manipulation of the buffer and selections into a new `Editor` struct that can be used to implement other text-editing widgets.

Apart from that, there are two other commits; one of them changes `TextBox` from being `Widget<String>` to be `Widget<TextStorage + EditableText>`, and the second adds a `TextBox::multiline` constructor, as a demo of multiline editing.

The multiline stuff is half-baked; the textbox does not support vertical scrolling. Ultimately it should be rewritten (maybe using @jneem's #1248 work?) so that it uses more standard scroll machinery; but this will be a bit fiddly, and I don't want to sink into it right now. I'll write up an issue detailing how I think this should work, though, and maybe someone can take it up?


This also includes a tweak to `examples/styled_text.rs` to show a multiline texbox; I'm going to replace this with a simple markdown preview app, but that work is mostly done but it's on another computer, and will have to wait til I get to the studio (perhaps later today?)
