### PR TITLE
Centralize the WinHandler borrowing in gtk/x11 backends

### DIFF
--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -20,6 +20,7 @@ use std::convert::TryFrom;
 use std::ffi::c_void;
 use std::ffi::OsString;
 use std::os::raw::{c_int, c_uint};
+use std::panic::Location;
 use std::ptr;
 use std::slice;
 use std::sync::{Arc, Mutex, Weak};
@@ -139,12 +140,12 @@ pub(crate) struct WindowState {
     // we then copy onto `drawing_area`.
     surface: RefCell<Option<Surface>>,
     // The size of `surface` in pixels. This could be bigger than `drawing_area`.
-    surface_size: RefCell<(i32, i32)>,
+    surface_size: Cell<(i32, i32)>,
     // The invalid region, in display points.
     invalid: RefCell<Region>,
     pub(crate) handler: RefCell<Box<dyn WinHandler>>,
     idle_queue: Arc<Mutex<Vec<IdleKind>>>,
-    current_keycode: RefCell<Option<u16>>,
+    current_keycode: Cell<Option<u16>>,
 }
 
 #[derive(Clone)]
@@ -241,11 +242,11 @@ impl WindowBuilder {
             closing: Cell::new(false),
             drawing_area,
             surface: RefCell::new(None),
-            surface_size: RefCell::new((0, 0)),
+            surface_size: Cell::new((0, 0)),
             invalid: RefCell::new(Region::EMPTY),
             handler: RefCell::new(handler),
             idle_queue: Arc::new(Mutex::new(vec![])),
-            current_keycode: RefCell::new(None),
+            current_keycode: Cell::new(None),
         });
 
         self.app
@@ -321,11 +322,7 @@ impl WindowBuilder {
                         scale = reported_scale;
                         state.scale.set(scale);
                         scale_changed = true;
-                        if let Ok(mut handler_borrow) = state.handler.try_borrow_mut() {
-                            handler_borrow.scale(scale);
-                        } else {
-                            log::warn!("Failed to inform the handler of scale change because it was already borrowed");
-                        }
+                        state.with_handler(|h| h.scale(scale));
                     }
                 }
 
@@ -341,56 +338,53 @@ impl WindowBuilder {
                     if let Err(e) = state.resize_surface(extents.width, extents.height) {
                         log::error!("Failed to resize surface: {}", e);
                     }
-                    if let Ok(mut handler_borrow) = state.handler.try_borrow_mut() {
-                        handler_borrow.size(size_dp);
-                    } else {
-                        log::warn!("Failed to inform the handler of a resize because it was already borrowed");
-                    }
+                    state.with_handler(|h| h.size(size_dp));
                     state.invalidate_rect(size_dp.to_rect());
                 }
 
-                if let Ok(mut handler_borrow) = state.handler.try_borrow_mut() {
-                    // Note that we aren't holding any RefCell borrows here (except for the
-                    // WinHandler itself), because prepare_paint can call back into our WindowHandle
-                    // (most likely for invalidation).
-                    handler_borrow.prepare_paint();
+                state.with_handler(|h| h.prepare_paint());
 
-                    let surface = state.surface.try_borrow();
-                    if let Ok(Some(surface)) = surface.as_ref().map(|s| s.as_ref()) {
-                        if let Ok(mut invalid) = state.invalid.try_borrow_mut() {
-                            let surface_context = cairo::Context::new(surface);
-
-                            // Clip to the invalid region, in order that our surface doesn't get
-                            // messed up if there's any painting outside them.
-                            for rect in invalid.rects() {
-                                surface_context.rectangle(rect.x0, rect.y0, rect.width(), rect.height());
-                            }
-                            surface_context.clip();
-
-                            surface_context.scale(scale.x(), scale.y());
-                            let mut piet_context = Piet::new(&surface_context);
-                            handler_borrow.paint(&mut piet_context, &invalid);
-                            if let Err(e) = piet_context.finish() {
-                                log::error!("piet error on render: {:?}", e);
-                            }
-
-                            // Copy the entire surface to the drawing area (not just the invalid
-                            // region, because there might be parts of the drawing area that were
-                            // invalidated by external forces).
-                            let alloc = widget.get_allocation();
-                            context.set_source_surface(&surface, 0.0, 0.0);
-                            context.rectangle(0.0, 0.0, alloc.width as f64, alloc.height as f64);
-                            context.fill();
-
-                            invalid.clear();
-                        } else {
-                            log::warn!("Drawing was skipped because the invalid region was borrowed");
-                        }
-                    } else {
-                        log::warn!("Drawing was skipped because there was no surface");
+                let invalid = match state.invalid.try_borrow_mut() {
+                    Ok(mut invalid) => std::mem::replace(&mut *invalid, Region::EMPTY),
+                    Err(_) => {
+                        log::error!("invalid region borrowed while drawing");
+                        Region::EMPTY
                     }
+                };
+
+                if let Ok(Some(surface)) = state.surface.try_borrow().as_ref().map(|s| s.as_ref()) {
+                    // Note that we're borrowing the surface while calling the handler. This is ok,
+                    // because we don't return control to the system or re-borrow the surface from
+                    // any code that the client can call.
+                    // (TODO: the above comment isn't true yet because of save_as_sync and
+                    // open_sync, but it will be true soon)
+                    state.with_handler_and_dont_check_the_other_borrows(|handler| {
+                        let surface_context = cairo::Context::new(surface);
+
+                        // Clip to the invalid region, in order that our surface doesn't get
+                        // messed up if there's any painting outside them.
+                        for rect in invalid.rects() {
+                            surface_context.rectangle(rect.x0, rect.y0, rect.width(), rect.height());
+                        }
+                        surface_context.clip();
+
+                        surface_context.scale(scale.x(), scale.y());
+                        let mut piet_context = Piet::new(&surface_context);
+                        handler.paint(&mut piet_context, &invalid);
+                        if let Err(e) = piet_context.finish() {
+                            log::error!("piet error on render: {:?}", e);
+                        }
+
+                        // Copy the entire surface to the drawing area (not just the invalid
+                        // region, because there might be parts of the drawing area that were
+                        // invalidated by external forces).
+                        let alloc = widget.get_allocation();
+                        context.set_source_surface(&surface, 0.0, 0.0);
+                        context.rectangle(0.0, 0.0, alloc.width as f64, alloc.height as f64);
+                        context.fill();
+                    });
                 } else {
-                    log::warn!("Drawing was skipped because the handler was already borrowed");
+                    log::warn!("Drawing was skipped because there was no surface");
                 }
             }
 
@@ -399,7 +393,7 @@ impl WindowBuilder {
 
         win_state.drawing_area.connect_button_press_event(clone!(handle => move |_widget, event| {
             if let Some(state) = handle.state.upgrade() {
-                if let Ok(mut handler) = state.handler.try_borrow_mut() {
+                state.with_handler(|handler| {
                     if let Some(button) = get_mouse_button(event.get_button()) {
                         let scale = state.scale.get();
                         let button_state = event.get_state();
@@ -415,9 +409,7 @@ impl WindowBuilder {
                             },
                         );
                     }
-                } else {
-                    log::warn!("GTK event was dropped because the handler was already borrowed");
-                }
+                });
             }
 
             Inhibit(true)
@@ -425,7 +417,7 @@ impl WindowBuilder {
 
         win_state.drawing_area.connect_button_release_event(clone!(handle => move |_widget, event| {
             if let Some(state) = handle.state.upgrade() {
-                if let Ok(mut handler) = state.handler.try_borrow_mut() {
+                state.with_handler(|handler| {
                     if let Some(button) = get_mouse_button(event.get_button()) {
                         let scale = state.scale.get();
                         let button_state = event.get_state();
@@ -441,161 +433,152 @@ impl WindowBuilder {
                             },
                         );
                     }
-                } else {
-                    log::warn!("GTK event was dropped because the handler was already borrowed");
-                }
+                });
             }
 
             Inhibit(true)
         }));
 
-        win_state.drawing_area.connect_motion_notify_event(clone!(handle => move |_widget, motion| {
-            if let Some(state) = handle.state.upgrade() {
-                let scale = state.scale.get();
-                let motion_state = motion.get_state();
-                let mouse_event = MouseEvent {
-                    pos: Point::from(motion.get_position()).to_dp(scale),
-                    buttons: get_mouse_buttons_from_modifiers(motion_state),
-                    mods: get_modifiers(motion_state),
-                    count: 0,
-                    focus: false,
-                    button: MouseButton::None,
-                    wheel_delta: Vec2::ZERO
-                };
-
-                if let Ok(mut handler) = state.handler.try_borrow_mut() {
-                    handler.mouse_move(&mouse_event);
-                } else {
-                    log::warn!("GTK event was dropped because the handler was already borrowed");
-                }
-            }
-
-            Inhibit(true)
-        }));
-
-        win_state.drawing_area.connect_leave_notify_event(clone!(handle => move |_widget, crossing| {
-            if let Some(state) = handle.state.upgrade() {
-                let scale = state.scale.get();
-                let crossing_state = crossing.get_state();
-                let mouse_event = MouseEvent {
-                    pos: Point::from(crossing.get_position()).to_dp(scale),
-                    buttons: get_mouse_buttons_from_modifiers(crossing_state),
-                    mods: get_modifiers(crossing_state),
-                    count: 0,
-                    focus: false,
-                    button: MouseButton::None,
-                    wheel_delta: Vec2::ZERO
-                };
-
-                if let Ok(mut handler) = state.handler.try_borrow_mut() {
-                    handler.mouse_move(&mouse_event);
-                } else {
-                    log::warn!("GTK event was dropped because the handler was already borrowed");
-                }
-            }
-
-            Inhibit(true)
-        }));
-
-        win_state.drawing_area.connect_scroll_event(clone!(handle => move |_widget, scroll| {
-            if let Some(state) = handle.state.upgrade() {
-                let scale = state.scale.get();
-                let mods = get_modifiers(scroll.get_state());
-
-                // The magic "120"s are from Microsoft's documentation for WM_MOUSEWHEEL.
-                // They claim that one "tick" on a scroll wheel should be 120 units.
-                let shift = mods.shift();
-                let wheel_delta = match scroll.get_direction() {
-                    ScrollDirection::Up if shift => Some(Vec2::new(-120.0, 0.0)),
-                    ScrollDirection::Up => Some(Vec2::new(0.0, -120.0)),
-                    ScrollDirection::Down if shift => Some(Vec2::new(120.0, 0.0)),
-                    ScrollDirection::Down => Some(Vec2::new(0.0, 120.0)),
-                    ScrollDirection::Left => Some(Vec2::new(-120.0, 0.0)),
-                    ScrollDirection::Right => Some(Vec2::new(120.0, 0.0)),
-                    ScrollDirection::Smooth => {
-                        //TODO: Look at how gtk's scroll containers implements it
-                        let (mut delta_x, mut delta_y) = scroll.get_delta();
-                        delta_x *= 120.;
-                        delta_y *= 120.;
-                        if shift {
-                            delta_x += delta_y;
-                            delta_y = 0.;
-                        }
-                        Some(Vec2::new(delta_x, delta_y))
-                    }
-                    e => {
-                        eprintln!(
-                            "Warning: the Druid widget got some whacky scroll direction {:?}",
-                            e
-                        );
-                        None
-                    }
-                };
-
-                if let Some(wheel_delta) = wheel_delta {
+        win_state.drawing_area.connect_motion_notify_event(
+            clone!(handle => move |_widget, motion| {
+                if let Some(state) = handle.state.upgrade() {
+                    let scale = state.scale.get();
+                    let motion_state = motion.get_state();
                     let mouse_event = MouseEvent {
-                        pos: Point::from(scroll.get_position()).to_dp(scale),
-                        buttons: get_mouse_buttons_from_modifiers(scroll.get_state()),
-                        mods,
+                        pos: Point::from(motion.get_position()).to_dp(scale),
+                        buttons: get_mouse_buttons_from_modifiers(motion_state),
+                        mods: get_modifiers(motion_state),
                         count: 0,
                         focus: false,
                         button: MouseButton::None,
-                        wheel_delta
+                        wheel_delta: Vec2::ZERO
                     };
 
-                    if let Ok(mut handler) = state.handler.try_borrow_mut() {
-                        handler.wheel(&mouse_event);
-                    } else {
-                        log::info!("GTK event was dropped because the handler was already borrowed");
+                    state.with_handler(|h| h.mouse_move(&mouse_event));
+                }
+
+                Inhibit(true)
+            }),
+        );
+
+        win_state.drawing_area.connect_leave_notify_event(
+            clone!(handle => move |_widget, crossing| {
+                if let Some(state) = handle.state.upgrade() {
+                    let scale = state.scale.get();
+                    let crossing_state = crossing.get_state();
+                    let mouse_event = MouseEvent {
+                        pos: Point::from(crossing.get_position()).to_dp(scale),
+                        buttons: get_mouse_buttons_from_modifiers(crossing_state),
+                        mods: get_modifiers(crossing_state),
+                        count: 0,
+                        focus: false,
+                        button: MouseButton::None,
+                        wheel_delta: Vec2::ZERO
+                    };
+
+                    state.with_handler(|h| h.mouse_move(&mouse_event));
+                }
+
+                Inhibit(true)
+            }),
+        );
+
+        win_state
+            .drawing_area
+            .connect_scroll_event(clone!(handle => move |_widget, scroll| {
+                if let Some(state) = handle.state.upgrade() {
+                    let scale = state.scale.get();
+                    let mods = get_modifiers(scroll.get_state());
+
+                    // The magic "120"s are from Microsoft's documentation for WM_MOUSEWHEEL.
+                    // They claim that one "tick" on a scroll wheel should be 120 units.
+                    let shift = mods.shift();
+                    let wheel_delta = match scroll.get_direction() {
+                        ScrollDirection::Up if shift => Some(Vec2::new(-120.0, 0.0)),
+                        ScrollDirection::Up => Some(Vec2::new(0.0, -120.0)),
+                        ScrollDirection::Down if shift => Some(Vec2::new(120.0, 0.0)),
+                        ScrollDirection::Down => Some(Vec2::new(0.0, 120.0)),
+                        ScrollDirection::Left => Some(Vec2::new(-120.0, 0.0)),
+                        ScrollDirection::Right => Some(Vec2::new(120.0, 0.0)),
+                        ScrollDirection::Smooth => {
+                            //TODO: Look at how gtk's scroll containers implements it
+                            let (mut delta_x, mut delta_y) = scroll.get_delta();
+                            delta_x *= 120.;
+                            delta_y *= 120.;
+                            if shift {
+                                delta_x += delta_y;
+                                delta_y = 0.;
+                            }
+                            Some(Vec2::new(delta_x, delta_y))
+                        }
+                        e => {
+                            eprintln!(
+                                "Warning: the Druid widget got some whacky scroll direction {:?}",
+                                e
+                            );
+                            None
+                        }
+                    };
+
+                    if let Some(wheel_delta) = wheel_delta {
+                        let mouse_event = MouseEvent {
+                            pos: Point::from(scroll.get_position()).to_dp(scale),
+                            buttons: get_mouse_buttons_from_modifiers(scroll.get_state()),
+                            mods,
+                            count: 0,
+                            focus: false,
+                            button: MouseButton::None,
+                            wheel_delta
+                        };
+
+                        state.with_handler(|h| h.wheel(&mouse_event));
                     }
                 }
-            }
 
-            Inhibit(true)
-        }));
+                Inhibit(true)
+            }));
 
-        win_state.drawing_area.connect_key_press_event(clone!(handle => move |_widget, key| {
-            if let Some(state) = handle.state.upgrade() {
+        win_state
+            .drawing_area
+            .connect_key_press_event(clone!(handle => move |_widget, key| {
+                if let Some(state) = handle.state.upgrade() {
 
-                let mut current_keycode = state.current_keycode.borrow_mut();
-                let hw_keycode = key.get_hardware_keycode();
-                let repeat = *current_keycode == Some(hw_keycode);
+                    let hw_keycode = key.get_hardware_keycode();
+                    let repeat = state.current_keycode.get() == Some(hw_keycode);
 
-                *current_keycode = Some(hw_keycode);
+                    state.current_keycode.set(Some(hw_keycode));
 
-                if let Ok(mut handler) = state.handler.try_borrow_mut() {
-                    handler.key_down(make_key_event(key, repeat, KeyState::Down));
-                } else {
-                    log::info!("GTK event was dropped because the handler was already borrowed");
-                }
-            }
-
-            Inhibit(true)
-        }));
-
-        win_state.drawing_area.connect_key_release_event(clone!(handle => move |_widget, key| {
-            if let Some(state) = handle.state.upgrade() {
-
-                let mut current_keycode = state.current_keycode.borrow_mut();
-                if *current_keycode == Some(key.get_hardware_keycode()) {
-                    *current_keycode = None;
+                    state.with_handler(|h|
+                        h.key_down(make_key_event(key, repeat, KeyState::Down))
+                    );
                 }
 
-                if let Ok(mut handler) = state.handler.try_borrow_mut() {
-                    handler.key_up(make_key_event(key, false, KeyState::Up));
-                } else {
-                    log::info!("GTK event was dropped because the handler was already borrowed");
-                }
-            }
+                Inhibit(true)
+            }));
 
-            Inhibit(true)
-        }));
+        win_state
+            .drawing_area
+            .connect_key_release_event(clone!(handle => move |_widget, key| {
+                if let Some(state) = handle.state.upgrade() {
+
+                    if state.current_keycode.get() == Some(key.get_hardware_keycode()) {
+                        state.current_keycode.set(None);
+                    }
+
+
+                    state.with_handler(|h|
+                        h.key_up(make_key_event(key, false, KeyState::Up))
+                    );
+                }
+
+                Inhibit(true)
+            }));
 
         win_state
             .window
             .connect_delete_event(clone!(handle => move |_widget, _ev| {
                 if let Some(state) = handle.state.upgrade() {
-                    state.handler.borrow_mut().request_close();
+                    state.with_handler(|h| h.request_close());
                     Inhibit(!state.closing.get())
                 } else {
                     Inhibit(false)
@@ -606,7 +589,7 @@ impl WindowBuilder {
             .drawing_area
             .connect_destroy(clone!(handle => move |_widget| {
                 if let Some(state) = handle.state.upgrade() {
-                    state.handler.borrow_mut().destroy();
+                    state.with_handler(|h| h.destroy());
                 }
             }));
 
@@ -618,16 +601,42 @@ impl WindowBuilder {
             .expect("realize didn't create window")
             .set_event_compression(false);
 
-        let mut handler = win_state.handler.borrow_mut();
-        handler.connect(&handle.clone().into());
-        handler.scale(scale);
-        handler.size(self.size);
+        let size = self.size;
+        win_state.with_handler(|h| {
+            h.connect(&handle.clone().into());
+            h.scale(scale);
+            h.size(size);
+        });
 
         Ok(handle)
     }
 }
 
 impl WindowState {
+    #[track_caller]
+    fn with_handler<T, F: FnOnce(&mut dyn WinHandler) -> T>(&self, f: F) -> Option<T> {
+        if self.invalid.try_borrow_mut().is_err() || self.surface.try_borrow_mut().is_err() {
+            log::error!("other RefCells were borrowed when calling into the handler");
+            return None;
+        }
+
+        self.with_handler_and_dont_check_the_other_borrows(f)
+    }
+
+    #[track_caller]
+    fn with_handler_and_dont_check_the_other_borrows<T, F: FnOnce(&mut dyn WinHandler) -> T>(
+        &self,
+        f: F,
+    ) -> Option<T> {
+        match self.handler.try_borrow_mut() {
+            Ok(mut h) => Some(f(&mut **h)),
+            Err(_) => {
+                log::error!("failed to borrow WinHandler at {}", Location::caller());
+                None
+            }
+        }
+    }
+
     fn resize_surface(&self, width: i32, height: i32) -> Result<(), anyhow::Error> {
         fn next_size(x: i32) -> i32 {
             // We round up to the nearest multiple of `accuracy`, which is between x/2 and x/4.
@@ -638,10 +647,11 @@ impl WindowState {
         }
 
         let mut surface = self.surface.borrow_mut();
-        let mut cur_size = self.surface_size.borrow_mut();
+        let mut cur_size = self.surface_size.get();
         let (width, height) = (next_size(width), next_size(height));
-        if surface.is_none() || *cur_size != (width, height) {
-            *cur_size = (width, height);
+        if surface.is_none() || cur_size != (width, height) {
+            cur_size = (width, height);
+            self.surface_size.set(cur_size);
             if let Some(s) = surface.as_ref() {
                 s.finish();
             }
@@ -839,8 +849,7 @@ impl WindowHandle {
 
         glib::timeout_add(interval, move || {
             if let Some(state) = handle.state.upgrade() {
-                if let Ok(mut handler_borrow) = state.handler.try_borrow_mut() {
-                    handler_borrow.timer(token);
+                if state.with_handler(|h| h.timer(token)).is_some() {
                     return glib::Continue(false);
                 }
             }
@@ -1015,7 +1024,7 @@ impl IdleHandle {
 
 fn run_idle(state: &Arc<WindowState>) -> glib::source::Continue {
     util::assert_main_thread();
-    if let Ok(mut handler) = state.handler.try_borrow_mut() {
+    let result = state.with_handler(|handler| {
         let queue: Vec<_> = std::mem::replace(&mut state.idle_queue.lock().unwrap(), Vec::new());
 
         for item in queue {
@@ -1024,7 +1033,9 @@ fn run_idle(state: &Arc<WindowState>) -> glib::source::Continue {
                 IdleKind::Token(it) => handler.idle(it),
             }
         }
-    } else {
+    });
+
+    if result.is_none() {
         log::warn!("Delaying idle callbacks because the handler is borrowed.");
         // Keep trying to reschedule this idle callback, because we haven't had a chance
         // to empty the idle queue. Returning glib::source::Continue(true) achieves this but

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -120,6 +120,9 @@ enum IdleKind {
     Token(IdleToken),
 }
 
+// We use RefCells for interior mutability, but we try to structure things so that double-borrows
+// are impossible. See the documentation on crate::platform::x11::window::Window for more details,
+// since the idea there is basically the same.
 pub(crate) struct WindowState {
     window: ApplicationWindow,
     scale: Cell<Scale>,

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -269,8 +269,7 @@ impl Application {
                 let w = self
                     .window(ev.event)
                     .context("KEY_PRESS - failed to get window")?;
-                w.handle_key_press(ev)
-                    .context("KEY_PRESS - failed to handle")?;
+                w.handle_key_press(ev);
             }
             Event::ButtonPress(ev) => {
                 let w = self
@@ -283,8 +282,7 @@ impl Application {
                     w.handle_wheel(ev)
                         .context("BUTTON_PRESS - failed to handle wheel")?;
                 } else {
-                    w.handle_button_press(ev)
-                        .context("BUTTON_PRESS - failed to handle")?;
+                    w.handle_button_press(ev);
                 }
             }
             Event::ButtonRelease(ev) => {
@@ -295,23 +293,20 @@ impl Application {
                     // This is the release event corresponding to a mouse wheel.
                     // Ignore it: we already handled the press event.
                 } else {
-                    w.handle_button_release(ev)
-                        .context("BUTTON_RELEASE - failed to handle")?;
+                    w.handle_button_release(ev);
                 }
             }
             Event::MotionNotify(ev) => {
                 let w = self
                     .window(ev.event)
                     .context("MOTION_NOTIFY - failed to get window")?;
-                w.handle_motion_notify(ev)
-                    .context("MOTION_NOTIFY - failed to handle")?;
+                w.handle_motion_notify(ev);
             }
             Event::ClientMessage(ev) => {
                 let w = self
                     .window(ev.window)
                     .context("CLIENT_MESSAGE - failed to get window")?;
-                w.handle_client_message(ev)
-                    .context("CLIENT_MESSAGE - failed to handle")?;
+                w.handle_client_message(ev);
             }
             Event::DestroyNotify(ev) => {
                 if ev.window == self.window_id {
@@ -323,8 +318,7 @@ impl Application {
                 let w = self
                     .window(ev.window)
                     .context("DESTROY_NOTIFY - failed to get window")?;
-                w.handle_destroy_notify(ev)
-                    .context("DESTROY_NOTIFY - failed to handle")?;
+                w.handle_destroy_notify(ev);
 
                 // Remove our reference to the Window and allow it to be dropped
                 let windows_left = self

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -374,7 +374,9 @@ impl WindowBuilder {
 // a) We never call into the system as a result of 2. As a consequence, we never get 1
 //    re-entrantly.
 // b) We *almost* never call into the `WinHandler` while holding any of the other RefCells. There's
-//    an exception for `paint`.
+//    an exception for `paint`. This is enforced by the `with_handler` method.
+//    (TODO: we could try to encode this exception statically, by making the data accessible in
+//    case 2 smaller than the data accessible in case 1).
 pub(crate) struct Window {
     id: u32,
     gc: Gcontext,

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -19,6 +19,7 @@ use std::cell::RefCell;
 use std::collections::BinaryHeap;
 use std::convert::{TryFrom, TryInto};
 use std::os::unix::io::RawFd;
+use std::panic::Location;
 use std::rc::{Rc, Weak};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -360,6 +361,20 @@ impl WindowBuilder {
 }
 
 /// An X11 window.
+//
+// We use lots of RefCells here, so to avoid panics we need some rules. The basic observation is
+// that there are two ways we can end up calling the code in this file:
+//
+// 1) it either comes from the system (e.g. through some X11 event), or
+// 2) from the client (e.g. druid, calling a method on its `WindowHandle`).
+//
+// Note that 2 only ever happens as a result of 1 (i.e., the system calls us, we call the client
+// using the `WinHandler`, and it calls us back). The rules are:
+//
+// a) We never call into the system as a result of 2. As a consequence, we never get 1
+//    re-entrantly.
+// b) We *almost* never call into the `WinHandler` while holding any of the other RefCells. There's
+//    an exception for `paint`.
 pub(crate) struct Window {
     id: u32,
     gc: Gcontext,
@@ -519,12 +534,41 @@ struct PresentData {
 pub struct CustomCursor(xproto::Cursor);
 
 impl Window {
+    #[track_caller]
+    fn with_handler<T, F: FnOnce(&mut dyn WinHandler) -> T>(&self, f: F) -> Option<T> {
+        if self.cairo_surface.try_borrow_mut().is_err()
+            || self.state.try_borrow_mut().is_err()
+            || self.present_data.try_borrow_mut().is_err()
+            || self.buffers.try_borrow_mut().is_err()
+        {
+            log::error!("other RefCells were borrowed when calling into the handler");
+            return None;
+        }
+
+        self.with_handler_and_dont_check_the_other_borrows(f)
+    }
+
+    #[track_caller]
+    fn with_handler_and_dont_check_the_other_borrows<T, F: FnOnce(&mut dyn WinHandler) -> T>(
+        &self,
+        f: F,
+    ) -> Option<T> {
+        match self.handler.try_borrow_mut() {
+            Ok(mut h) => Some(f(&mut **h)),
+            Err(_) => {
+                log::error!("failed to borrow WinHandler at {}", Location::caller());
+                None
+            }
+        }
+    }
+
     fn connect(&self, handle: WindowHandle) -> Result<(), Error> {
-        let mut handler = borrow_mut!(self.handler)?;
         let size = self.size()?;
-        handler.connect(&handle.into());
-        handler.scale(Scale::default());
-        handler.size(size);
+        self.with_handler(|h| {
+            h.connect(&handle.into());
+            h.scale(Scale::default());
+            h.size(size);
+        });
         Ok(())
     }
 
@@ -575,7 +619,7 @@ impl Window {
                     )
                 })?;
             self.add_invalid_rect(size.to_rect())?;
-            borrow_mut!(self.handler)?.size(size);
+            self.with_handler(|h| h.size(size));
         }
         Ok(())
     }
@@ -598,19 +642,19 @@ impl Window {
     }
 
     fn render(&self) -> Result<(), Error> {
-        borrow_mut!(self.handler)?.prepare_paint();
+        self.with_handler(|h| h.prepare_paint());
 
         if self.destroyed() {
             return Ok(());
         }
 
         self.update_cairo_surface()?;
+        let invalid = std::mem::replace(&mut borrow_mut!(self.state)?.invalid, Region::EMPTY);
         {
-            let state = borrow!(self.state)?;
             let surface = borrow!(self.cairo_surface)?;
             let cairo_ctx = cairo::Context::new(&surface);
 
-            for rect in state.invalid.rects() {
+            for rect in invalid.rects() {
                 cairo_ctx.rectangle(rect.x0, rect.y0, rect.width(), rect.height());
             }
             cairo_ctx.clip();
@@ -620,20 +664,26 @@ impl Window {
             // We need to be careful with earlier returns here, because piet_ctx
             // can panic if it isn't finish()ed. Also, we want to reset cairo's clip
             // even on error.
-            let err;
-            match borrow_mut!(self.handler) {
-                Ok(mut handler) => {
-                    handler.paint(&mut piet_ctx, &state.invalid);
-                    err = piet_ctx
+            //
+            // Note that we're borrowing the surface while calling the handler. This is ok, because
+            // we don't return control to the system or re-borrow the surface from any code that
+            // the client can call.
+            let result = self.with_handler_and_dont_check_the_other_borrows(|handler| {
+                handler.paint(&mut piet_ctx, &invalid);
+                piet_ctx
+                    .finish()
+                    .map_err(|e| anyhow!("Window::render - piet finish failed: {}", e))
+            });
+            let err = match result {
+                None => {
+                    // The handler borrow failed, so finish didn't get called.
+                    piet_ctx
                         .finish()
-                        .map_err(|e| anyhow!("Window::render - piet finish failed: {}", e));
+                        .map_err(|e| anyhow!("Window::render - piet finish failed: {}", e))
                 }
-                Err(e) => {
-                    err = Err(e);
-                    if let Err(e) = piet_ctx.finish() {
-                        // We can't return both errors, so just log this one.
-                        log::error!("Window::render - piet finish failed in error branch: {}", e);
-                    }
+                Some(e) => {
+                    // Finish might have errored, in which case we want to propagate it.
+                    e
                 }
             };
             cairo_ctx.reset_clip();
@@ -644,16 +694,15 @@ impl Window {
         self.set_needs_present(false)?;
 
         let mut buffers = borrow_mut!(self.buffers)?;
-        let mut state = borrow_mut!(self.state)?;
         let pixmap = *buffers
             .idle_pixmaps
             .last()
             .ok_or_else(|| anyhow!("after rendering, no pixmap to present"))?;
         if let Some(present) = borrow_mut!(self.present_data)?.as_mut() {
-            present.present(self.app.connection(), pixmap, self.id, &state.invalid)?;
+            present.present(self.app.connection(), pixmap, self.id, &invalid)?;
             buffers.idle_pixmaps.pop();
         } else {
-            for r in state.invalid.rects() {
+            for r in invalid.rects() {
                 let (x, y) = (r.x0 as i16, r.y0 as i16);
                 let (w, h) = (r.width() as u16, r.height() as u16);
                 self.app
@@ -661,7 +710,6 @@ impl Window {
                     .copy_area(pixmap, self.id, self.gc, x, y, x, y, w, h)?;
             }
         }
-        state.invalid.clear();
         Ok(())
     }
 
@@ -806,7 +854,7 @@ impl Window {
         Ok(())
     }
 
-    pub fn handle_key_press(&self, key_press: &xproto::KeyPressEvent) -> Result<(), Error> {
+    pub fn handle_key_press(&self, key_press: &xproto::KeyPressEvent) {
         let hw_keycode = key_press.detail;
         let code = keycodes::hardware_keycode_to_code(hw_keycode);
         let mods = key_mods(key_press.state);
@@ -822,14 +870,10 @@ impl Window {
             repeat: false,
             is_composing: false,
         };
-        borrow_mut!(self.handler)?.key_down(key_event);
-        Ok(())
+        self.with_handler(|h| h.key_down(key_event));
     }
 
-    pub fn handle_button_press(
-        &self,
-        button_press: &xproto::ButtonPressEvent,
-    ) -> Result<(), Error> {
+    pub fn handle_button_press(&self, button_press: &xproto::ButtonPressEvent) {
         let button = mouse_button(button_press.detail);
         let mouse_event = MouseEvent {
             pos: Point::new(button_press.event_x as f64, button_press.event_y as f64),
@@ -843,14 +887,10 @@ impl Window {
             button,
             wheel_delta: Vec2::ZERO,
         };
-        borrow_mut!(self.handler)?.mouse_down(&mouse_event);
-        Ok(())
+        self.with_handler(|h| h.mouse_down(&mouse_event));
     }
 
-    pub fn handle_button_release(
-        &self,
-        button_release: &xproto::ButtonReleaseEvent,
-    ) -> Result<(), Error> {
+    pub fn handle_button_release(&self, button_release: &xproto::ButtonReleaseEvent) {
         let button = mouse_button(button_release.detail);
         let mouse_event = MouseEvent {
             pos: Point::new(button_release.event_x as f64, button_release.event_y as f64),
@@ -863,8 +903,7 @@ impl Window {
             button,
             wheel_delta: Vec2::ZERO,
         };
-        borrow_mut!(self.handler)?.mouse_up(&mouse_event);
-        Ok(())
+        self.with_handler(|h| h.mouse_up(&mouse_event));
     }
 
     pub fn handle_wheel(&self, event: &xproto::ButtonPressEvent) -> Result<(), Error> {
@@ -892,14 +931,11 @@ impl Window {
             wheel_delta: delta.into(),
         };
 
-        borrow_mut!(self.handler)?.wheel(&mouse_event);
+        self.with_handler(|h| h.wheel(&mouse_event));
         Ok(())
     }
 
-    pub fn handle_motion_notify(
-        &self,
-        motion_notify: &xproto::MotionNotifyEvent,
-    ) -> Result<(), Error> {
+    pub fn handle_motion_notify(&self, motion_notify: &xproto::MotionNotifyEvent) {
         let mouse_event = MouseEvent {
             pos: Point::new(motion_notify.event_x as f64, motion_notify.event_y as f64),
             buttons: mouse_buttons(motion_notify.state),
@@ -909,32 +945,23 @@ impl Window {
             button: MouseButton::None,
             wheel_delta: Vec2::ZERO,
         };
-        borrow_mut!(self.handler)?.mouse_move(&mouse_event);
-        Ok(())
+        self.with_handler(|h| h.mouse_move(&mouse_event));
     }
 
-    pub fn handle_client_message(
-        &self,
-        client_message: &xproto::ClientMessageEvent,
-    ) -> Result<(), Error> {
+    pub fn handle_client_message(&self, client_message: &xproto::ClientMessageEvent) {
         // https://www.x.org/releases/X11R7.7/doc/libX11/libX11/libX11.html#id2745388
         // https://www.x.org/releases/X11R7.6/doc/xorg-docs/specs/ICCCM/icccm.html#window_deletion
         if client_message.type_ == self.atoms.WM_PROTOCOLS && client_message.format == 32 {
             let protocol = client_message.data.as_data32()[0];
             if protocol == self.atoms.WM_DELETE_WINDOW {
-                self.handler.borrow_mut().request_close();
+                self.with_handler(|h| h.request_close());
             }
         }
-        Ok(())
     }
 
     #[allow(clippy::trivially_copy_pass_by_ref)]
-    pub fn handle_destroy_notify(
-        &self,
-        _destroy_notify: &xproto::DestroyNotifyEvent,
-    ) -> Result<(), Error> {
-        borrow_mut!(self.handler)?.destroy();
-        Ok(())
+    pub fn handle_destroy_notify(&self, _destroy_notify: &xproto::DestroyNotifyEvent) {
+        self.with_handler(|h| h.destroy());
     }
 
     pub fn handle_configure_notify(&self, event: &ConfigureNotifyEvent) -> Result<(), Error> {
@@ -1027,7 +1054,7 @@ impl Window {
         std::mem::swap(&mut *self.idle_queue.lock().unwrap(), &mut queue);
 
         let mut needs_redraw = false;
-        if let Ok(mut handler) = self.handler.try_borrow_mut() {
+        self.with_handler(|handler| {
             for callback in queue {
                 match callback {
                     IdleKind::Callback(f) => {
@@ -1041,9 +1068,7 @@ impl Window {
                     }
                 }
             }
-        } else {
-            log::error!("Not running idle callbacks because the handler is borrowed");
-        }
+        });
 
         if needs_redraw {
             if let Err(e) = self.redraw_now() {
@@ -1067,9 +1092,7 @@ impl Window {
             }
             // Remove the timer and get the token
             let token = self.timer_queue.lock().unwrap().pop().unwrap().token();
-            if let Ok(mut handler_borrow) = self.handler.try_borrow_mut() {
-                handler_borrow.timer(token);
-            }
+            self.with_handler(|h| h.timer(token));
         }
     }
 }


### PR DESCRIPTION
This is in preparation for dealing with #1068.

The idea is to make the RefCell borrowing of the WinHandler centralized (and also more principled, and better documented). Then we'll be able to slot in the various not-quite-synchronous operations at the place where the WinHandler borrow is dropped.