### PR TITLE
Fix #1129 and add request_timer to LayoutCtx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - `RawLabel` widget displays text `Data`. ([#1252] by [@cmyr])
 - 'Tabs' widget allowing static and dynamic tabbed layouts. ([#1160] by [@rjwittams])
 - `RichText` and `Attribute` types for creating rich text ([#1255] by [@cmyr])
+- `request_timer` can now be called from `LayoutCtx` ([#1278] by [@Majora320])
 
 ### Changed
 
@@ -98,6 +99,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - Windows: fix crash on resize from incompatible resources ([#1191 by [@raphlinus]])
 - GTK: Related dependencies are now optional, facilitating a pure X11 build. ([#1241] by [@finnerale])
 - `widget::Image` now computes the layout correctly when unbound in one direction. ([#1189] by [@JAicewizard])
+- The scroll bar now shows when the contents of a scrollable area change size. ([#1278] by [@Majora320])
 
 ### Visual
 
@@ -484,6 +486,7 @@ Last release without a changelog :(
 [#1251]: https://github.com/linebender/druid/pull/1251
 [#1252]: https://github.com/linebender/druid/pull/1252
 [#1255]: https://github.com/linebender/druid/pull/1255
+[#1278]: https://github.com/linebender/druid/pull/1278
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master
 [0.6.0]: https://github.com/linebender/druid/compare/v0.5.0...v0.6.0

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -292,14 +292,6 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
         self.widget_state.request_anim = true;
     }
 
-    /// Request a timer event.
-    ///
-    /// The return value is a token, which can be used to associate the
-    /// request with the event.
-    pub fn request_timer(&mut self, deadline: Duration) -> TimerToken {
-        self.state.request_timer(&mut self.widget_state, deadline)
-    }
-
     /// Indicate that your children have changed.
     ///
     /// Widgets must call this method after adding a new child.
@@ -317,7 +309,7 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
     }
 });
 
-// methods on event, update, and lifecycle
+// methods on everyone but paintctx
 impl_context_method!(
     EventCtx<'_, '_>,
     UpdateCtx<'_, '_>,
@@ -345,6 +337,14 @@ impl_context_method!(
         /// [`ExtEventSink`]: struct.ExtEventSink.html
         pub fn get_external_handle(&self) -> ExtEventSink {
             self.state.ext_handle.clone()
+        }
+
+        /// Request a timer event.
+        ///
+        /// The return value is a token, which can be used to associate the
+        /// request with the event.
+        pub fn request_timer(&mut self, deadline: Duration) -> TimerToken {
+            self.state.request_timer(&mut self.widget_state, deadline)
         }
     }
 );

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -144,6 +144,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
         let child_bc = BoxConstraints::new(Size::ZERO, max_bc);
         let child_size = self.child.layout(ctx, &child_bc, data, env);
         log_size_warnings(child_size);
+        let old_size = self.scroll_component.content_size;
         self.scroll_component.content_size = child_size;
         self.child
             .set_layout_rect(ctx, data, env, child_size.to_rect());
@@ -151,6 +152,11 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
         let self_size = bc.constrain(child_size);
         let _ = self.scroll_component.scroll(Vec2::new(0.0, 0.0), self_size);
         self.child.set_viewport_offset(self.offset());
+
+        if old_size != self.scroll_component.content_size {
+            self.scroll_component.reset_scrollbar_fade(|d| ctx.request_timer(d), env);
+        }
+
         self_size
     }
 

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -154,7 +154,8 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
         self.child.set_viewport_offset(self.offset());
 
         if old_size != self.scroll_component.content_size {
-            self.scroll_component.reset_scrollbar_fade(|d| ctx.request_timer(d), env);
+            self.scroll_component
+                .reset_scrollbar_fade(|d| ctx.request_timer(d), env);
         }
 
         self_size


### PR DESCRIPTION
This resolves #1129 and also adds request_timer to LayoutCtx. Please let me know if this would have any negative implications of this, although it seems like something that would be useful to have in the public api for similar use cases to this one.