### PR TITLE
Fix update on delegate commands.

### DIFF
--- a/druid/examples/open_save.rs
+++ b/druid/examples/open_save.rs
@@ -89,7 +89,7 @@ impl AppDelegate<String> for Delegate {
             if let Err(e) = std::fs::write(file_info.path(), &data[..]) {
                 println!("Error writing file: {}", e);
             }
-            return true;
+            return false;
         }
         if let Some(file_info) = cmd.get(commands::OPEN_FILE) {
             match std::fs::read_to_string(file_info.path()) {
@@ -101,8 +101,8 @@ impl AppDelegate<String> for Delegate {
                     println!("Error opening file: {}", e);
                 }
             }
-            return true;
+            return false;
         }
-        false
+        true
     }
 }

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -322,6 +322,7 @@ impl<T: Data> Inner<T> {
     /// Returns `true` if the command was handled.
     fn dispatch_cmd(&mut self, cmd: Command) -> bool {
         if !self.delegate_cmd(&cmd) {
+            self.do_update();
             return true;
         }
 


### PR DESCRIPTION
This is a small fix for a bug I encountered while working on #1068. The first problem is that update wasn't called when a command was handled by the delegate. The second is that the `open_save` example had `true` and `false` mixed up.

On a related note, I'd like to change some `bool`s to something like `enum Handled { Handled, Unhandled }`. Is there any objection to that?