### PR TITLE
Implement vertical movement (for text editing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - 'Tabs' widget allowing static and dynamic tabbed layouts. ([#1160] by [@rjwittams])
 - `RichText` and `Attribute` types for creating rich text ([#1255] by [@cmyr])
 - `request_timer` can now be called from `LayoutCtx` ([#1278] by [@Majora320])
+- TextBox supports vertical movement ([#1280] by [@cmyr])
 
 ### Changed
 
@@ -490,6 +491,7 @@ Last release without a changelog :(
 [#1255]: https://github.com/linebender/druid/pull/1255
 [#1276]: https://github.com/linebender/druid/pull/1276
 [#1278]: https://github.com/linebender/druid/pull/1278
+[#1280]: https://github.com/linebender/druid/pull/1280
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master
 [0.6.0]: https://github.com/linebender/druid/compare/v0.5.0...v0.6.0

--- a/druid/src/text/editor.rs
+++ b/druid/src/text/editor.rs
@@ -173,16 +173,18 @@ impl<T: TextStorage + EditableText> Editor<T> {
             EditAction::Delete => self.delete_forward(data),
             EditAction::JumpDelete(mvmt) | EditAction::JumpBackspace(mvmt) => {
                 let to_delete = if self.selection.is_caret() {
-                    movement(mvmt, self.selection, data, true)
+                    movement(mvmt, self.selection, &self.layout, true)
                 } else {
                     self.selection
                 };
                 data.edit(to_delete.range(), "");
                 self.selection = Selection::caret(to_delete.min());
             }
-            EditAction::Move(mvmt) => self.selection = movement(mvmt, self.selection, data, false),
+            EditAction::Move(mvmt) => {
+                self.selection = movement(mvmt, self.selection, &self.layout, false)
+            }
             EditAction::ModifySelection(mvmt) => {
-                self.selection = movement(mvmt, self.selection, data, true)
+                self.selection = movement(mvmt, self.selection, &self.layout, true)
             }
             EditAction::Click(action) => {
                 if action.mods.shift() {
@@ -240,7 +242,7 @@ impl<T: TextStorage + EditableText> Editor<T> {
 
     fn delete_forward(&mut self, data: &mut T) {
         let to_delete = if self.selection.is_caret() {
-            movement(Movement::Right, self.selection, data, true)
+            movement(Movement::Right, self.selection, &self.layout, true)
         } else {
             self.selection
         };

--- a/druid/src/text/layout.rs
+++ b/druid/src/text/layout.rs
@@ -174,6 +174,13 @@ impl<T: TextStorage> TextLayout<T> {
         self.text.as_ref()
     }
 
+    /// Returns the inner Piet [`TextLayout`] type.
+    ///
+    /// [`TextLayout`]: ./piet/trait.TextLayout.html
+    pub fn layout(&self) -> Option<&PietTextLayout> {
+        self.layout.as_ref()
+    }
+
     /// The size of the laid-out text.
     ///
     /// This is not meaningful until [`rebuild_if_needed`] has been called.

--- a/druid/src/text/selection.rs
+++ b/druid/src/text/selection.rs
@@ -28,13 +28,20 @@ pub struct Selection {
 
     /// The active edge of a selection, as a byte offset.
     pub end: usize,
+
+    /// The saved horizontal position, during vertical movement.
+    pub h_pos: Option<f64>,
 }
 
 impl Selection {
     /// Create a selection that begins at start and goes to end.
     /// Like dragging a mouse from start to end.
     pub fn new(start: usize, end: usize) -> Self {
-        Selection { start, end }
+        Selection {
+            start,
+            end,
+            h_pos: None,
+        }
     }
 
     /// Create a selection that starts at the beginning and ends at text length.
@@ -49,7 +56,14 @@ impl Selection {
         Selection {
             start: pos,
             end: pos,
+            h_pos: None,
         }
+    }
+
+    /// Construct a new selection from this selection, with the provided h_pos.
+    pub fn with_h_pos(mut self, h_pos: Option<f64>) -> Self {
+        self.h_pos = h_pos;
+        self
     }
 
     /// If start == end, it's a caret

--- a/druid/src/text/text_input.rs
+++ b/druid/src/text/text_input.rs
@@ -112,6 +112,18 @@ impl TextInput for BasicTextInput {
             k_e if (HotKey::new(None, KbKey::ArrowRight)).matches(k_e) => {
                 EditAction::Move(Movement::Right)
             }
+            k_e if (HotKey::new(None, KbKey::ArrowUp)).matches(k_e) => {
+                EditAction::Move(Movement::Up)
+            }
+            k_e if (HotKey::new(None, KbKey::ArrowDown)).matches(k_e) => {
+                EditAction::Move(Movement::Down)
+            }
+            k_e if (HotKey::new(SysMods::Shift, KbKey::ArrowUp)).matches(k_e) => {
+                EditAction::ModifySelection(Movement::Up)
+            }
+            k_e if (HotKey::new(SysMods::Shift, KbKey::ArrowDown)).matches(k_e) => {
+                EditAction::ModifySelection(Movement::Down)
+            }
             // Delete left word
             k_e if (HotKey::new(SysMods::Cmd, KbKey::Backspace)).matches(k_e) => {
                 EditAction::JumpBackspace(Movement::LeftWord)


### PR DESCRIPTION
Based off of #1274 

This implements vertical motion for text editing.

I think the traits we use here may change over time, but this gets something working for now.

![2020-10-05 11 00 03](https://user-images.githubusercontent.com/3330916/95096247-075c1d00-06fa-11eb-86de-cdfb548e1bb3.gif)

(this is slightly buggy because it relies on a pending piet release)