### PR TITLE
Improve selection behaviour on focus change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - `LocalizedString` and `LabelText` use `ArcStr` instead of String ([#1245] by [@cmyr])
 - `LensWrap` widget moved into widget module ([#1251] by [@cmyr])
 - `Delegate::command` now returns `Handled`, not `bool` ([#1298] by [@jneem])
+- `TextBox` selects all contents when tabbed to on macOS ([#1283] by [@cmyr])
 
 ### Deprecated
 
@@ -498,6 +499,7 @@ Last release without a changelog :(
 [#1276]: https://github.com/linebender/druid/pull/1276
 [#1278]: https://github.com/linebender/druid/pull/1278
 [#1280]: https://github.com/linebender/druid/pull/1280
+[#1283]: https://github.com/linebender/druid/pull/1283
 [#1295]: https://github.com/linebender/druid/pull/1280
 [#1298]: https://github.com/linebender/druid/pull/1298
 [#1299]: https://github.com/linebender/druid/pull/1299

--- a/druid/src/text/editor.rs
+++ b/druid/src/text/editor.rs
@@ -137,6 +137,11 @@ impl<T: TextStorage + EditableText> Editor<T> {
         self.do_edit(EditAction::Paste(t), data)
     }
 
+    /// Set the selection to the entire buffer.
+    pub fn select_all(&mut self, data: &T) {
+        self.selection = Selection::new(0, data.len());
+    }
+
     fn mouse_action_for_event(&self, event: &MouseEvent) -> MouseAction {
         let pos = self.layout.text_position_for_point(event.pos);
         MouseAction {

--- a/druid/src/text/selection.rs
+++ b/druid/src/text/selection.rs
@@ -53,13 +53,6 @@ impl Selection {
         self
     }
 
-    /// Create a selection that starts at the beginning and ends at text length.
-    /// TODO: can text length be at a non-codepoint or a non-grapheme?
-    pub fn all(&mut self, text: &impl EditableText) {
-        self.start = 0;
-        self.end = text.len();
-    }
-
     /// Create a caret, which is just a selection with the same and start and end.
     pub fn caret(pos: usize) -> Self {
         Selection {


### PR DESCRIPTION
On windows, we persist the existing selection when focus
changes. On mac, the behaviour depends on whether or not there
was a click. If there was a click, we use the click to determine
the selection; otherwise we select the whole buffer.

In addition, on mac, we no longer draw the cursor if the selection
is not a caret.

- fixes #1225 (again)