### PR TITLE
Allow container widgets to deref to their children

### DIFF
--- a/druid/src/widget/align.rs
+++ b/druid/src/widget/align.rs
@@ -23,65 +23,65 @@ use crate::{
 use crate::piet::UnitPoint;
 
 /// A widget that aligns its child.
-pub struct Align<T> {
+pub struct Align<T, W> {
     align: UnitPoint,
-    child: WidgetPod<T, Box<dyn Widget<T>>>,
+    child: WidgetPod<T, W>,
     width_factor: Option<f64>,
     height_factor: Option<f64>,
 }
 
-impl<T> Align<T> {
+impl<T, W: Widget<T> + 'static> Align<T, W> {
     /// Create widget with alignment.
     ///
     /// Note that the `align` parameter is specified as a `UnitPoint` in
     /// terms of left and right. This is inadequate for bidi-aware layout
     /// and thus the API will change when druid gains bidi capability.
-    pub fn new(align: UnitPoint, child: impl Widget<T> + 'static) -> Align<T> {
+    pub fn new(align: UnitPoint, child: W) -> Align<T, W> {
         Align {
             align,
-            child: WidgetPod::new(child).boxed(),
+            child: WidgetPod::new(child),
             width_factor: None,
             height_factor: None,
         }
     }
 
     /// Create centered widget.
-    pub fn centered(child: impl Widget<T> + 'static) -> Align<T> {
+    pub fn centered(child: W) -> Align<T, W> {
         Align::new(UnitPoint::CENTER, child)
     }
 
     /// Create right-aligned widget.
-    pub fn right(child: impl Widget<T> + 'static) -> Align<T> {
+    pub fn right(child: W) -> Align<T, W> {
         Align::new(UnitPoint::RIGHT, child)
     }
 
     /// Create left-aligned widget.
-    pub fn left(child: impl Widget<T> + 'static) -> Align<T> {
+    pub fn left(child: W) -> Align<T, W> {
         Align::new(UnitPoint::LEFT, child)
     }
 
     /// Align only in the horizontal axis, keeping the child's size in the vertical.
-    pub fn horizontal(align: UnitPoint, child: impl Widget<T> + 'static) -> Align<T> {
+    pub fn horizontal(align: UnitPoint, child: W) -> Align<T, W> {
         Align {
             align,
-            child: WidgetPod::new(child).boxed(),
+            child: WidgetPod::new(child),
             width_factor: None,
             height_factor: Some(1.0),
         }
     }
 
     /// Align only in the vertical axis, keeping the child's size in the horizontal.
-    pub fn vertical(align: UnitPoint, child: impl Widget<T> + 'static) -> Align<T> {
+    pub fn vertical(align: UnitPoint, child: W) -> Align<T, W> {
         Align {
             align,
-            child: WidgetPod::new(child).boxed(),
+            child: WidgetPod::new(child),
             width_factor: Some(1.0),
             height_factor: None,
         }
     }
 }
 
-impl<T: Data> Widget<T> for Align<T> {
+impl<T: Data, W: Widget<T>> Widget<T> for Align<T, W> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         self.child.event(ctx, event, data, env)
     }
@@ -142,5 +142,18 @@ fn log_size_warnings(size: Size) {
 
     if size.height.is_infinite() {
         log::warn!("Align widget's child has an infinite height.");
+    }
+}
+
+impl<T, W: Widget<T>> std::ops::Deref for Align<T, W> {
+    type Target = W;
+    fn deref(&self) -> &Self::Target {
+        self.child.widget()
+    }
+}
+
+impl<T, W: Widget<T>> std::ops::DerefMut for Align<T, W> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.child.widget_mut()
     }
 }

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -62,7 +62,7 @@ const LABEL_X_PADDING: f64 = 2.0;
 ///     .with_text_color(Color::rgb(1.0, 0.2, 0.2));
 /// # // our data type T isn't known; this is just a trick for the compiler
 /// # // to keep our example clean
-/// # let _ = SizedBox::<()>::new(important_label);
+/// # let _ = SizedBox::<(), Label<()>>::new(important_label);
 /// ```
 ///
 /// [`ArcStr`]: ../type.ArcStr.html

--- a/druid/src/widget/padding.rs
+++ b/druid/src/widget/padding.rs
@@ -21,16 +21,15 @@ use crate::{
 };
 
 /// A widget that just adds padding around its child.
-pub struct Padding<T> {
+pub struct Padding<T, W> {
     left: f64,
     right: f64,
     top: f64,
     bottom: f64,
-
-    child: WidgetPod<T, Box<dyn Widget<T>>>,
+    child: WidgetPod<T, W>,
 }
 
-impl<T> Padding<T> {
+impl<T: Data, W: Widget<T> + 'static> Padding<T, W> {
     /// Create a new widget with the specified padding. This can either be an instance
     /// of [`kurbo::Insets`], a f64 for uniform padding, a 2-tuple for axis-uniform padding
     /// or 4-tuple with (left, top, right, bottom) values.
@@ -40,39 +39,44 @@ impl<T> Padding<T> {
     /// Uniform padding:
     ///
     /// ```
-    /// use druid::widget::{Label, Padding};
-    /// use druid::kurbo::Insets;
+    /// # use druid::widget::*;
+    /// # use druid::*;
     ///
-    /// let _: Padding<()> = Padding::new(10.0, Label::new("uniform!"));
-    /// let _: Padding<()> = Padding::new(Insets::uniform(10.0), Label::new("uniform!"));
+    /// let uniform1 = Padding::new(10.0, Label::new("uniform!"));
+    /// let uniform2 = Padding::new(Insets::uniform(10.0), Label::new("uniform!"));
+    /// # let _: Box<dyn Widget<()>> = uniform1.boxed();
+    /// # let _: Box<dyn Widget<()>> = uniform2.boxed();
     /// ```
     ///
     /// Uniform padding across each axis:
     ///
     /// ```
-    /// use druid::widget::{Label, Padding};
-    /// use druid::kurbo::Insets;
+    /// # use druid::widget::*;
+    /// # use druid::*;
     ///
     /// let child: Label<()> = Label::new("I need my space!");
-    /// let _: Padding<()> = Padding::new((10.0, 20.0), Label::new("more y than x!"));
+    /// let xy1 = Padding::new((10.0, 20.0), Label::new("more y than x!"));
     /// // equivalent:
-    /// let _: Padding<()> = Padding::new(Insets::uniform_xy(10.0, 20.0), Label::new("ditto :)"));
+    /// let xy2 = Padding::new(Insets::uniform_xy(10.0, 20.0), Label::new("ditto :)"));
+    ///
+    /// # let _: Box<dyn Widget<()>> = xy1.boxed();
+    /// # let _: Box<dyn Widget<()>> = xy2.boxed();
     /// ```
     ///
     /// [`kurbo::Insets`]: https://docs.rs/kurbo/0.5.3/kurbo/struct.Insets.html
-    pub fn new(insets: impl Into<Insets>, child: impl Widget<T> + 'static) -> Padding<T> {
+    pub fn new(insets: impl Into<Insets>, child: W) -> Padding<T, W> {
         let insets = insets.into();
         Padding {
             left: insets.x0,
             right: insets.x1,
             top: insets.y0,
             bottom: insets.y1,
-            child: WidgetPod::new(child).boxed(),
+            child: WidgetPod::new(child),
         }
     }
 }
 
-impl<T: Data> Widget<T> for Padding<T> {
+impl<T: Data, W: Widget<T>> Widget<T> for Padding<T, W> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         self.child.event(ctx, event, data, env)
     }
@@ -105,5 +109,18 @@ impl<T: Data> Widget<T> for Padding<T> {
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         self.child.paint(ctx, data, env);
+    }
+}
+
+impl<T, W: Widget<T>> std::ops::Deref for Padding<T, W> {
+    type Target = W;
+    fn deref(&self) -> &Self::Target {
+        self.child.widget()
+    }
+}
+
+impl<T, W: Widget<T>> std::ops::DerefMut for Padding<T, W> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.child.widget_mut()
     }
 }

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -27,63 +27,63 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     ///
     /// [`Padding`]: widget/struct.Padding.html
     /// [`Insets`]: kurbo/struct.Insets.html
-    fn padding(self, insets: impl Into<Insets>) -> Padding<T> {
+    fn padding(self, insets: impl Into<Insets>) -> Padding<T, Self> {
         Padding::new(insets, self)
     }
 
     /// Wrap this widget in an [`Align`] widget, configured to center it.
     ///
     /// [`Align`]: widget/struct.Align.html
-    fn center(self) -> Align<T> {
+    fn center(self) -> Align<T, Self> {
         Align::centered(self)
     }
 
     /// Wrap this widget in an [`Align`] widget, configured to align left.
     ///
     /// [`Align`]: widget/struct.Align.html
-    fn align_left(self) -> Align<T> {
+    fn align_left(self) -> Align<T, Self> {
         Align::left(self)
     }
 
     /// Wrap this widget in an [`Align`] widget, configured to align right.
     ///
     /// [`Align`]: widget/struct.Align.html
-    fn align_right(self) -> Align<T> {
+    fn align_right(self) -> Align<T, Self> {
         Align::right(self)
     }
 
     /// Wrap this widget in an [`Align`] widget, configured to align vertically.
     ///
     /// [`Align`]: widget/struct.Align.html
-    fn align_vertical(self, align: UnitPoint) -> Align<T> {
+    fn align_vertical(self, align: UnitPoint) -> Align<T, Self> {
         Align::vertical(align, self)
     }
 
     /// Wrap this widget in an [`Align`] widget, configured to align horizontally.
     ///
     /// [`Align`]: widget/struct.Align.html
-    fn align_horizontal(self, align: UnitPoint) -> Align<T> {
+    fn align_horizontal(self, align: UnitPoint) -> Align<T, Self> {
         Align::horizontal(align, self)
     }
 
     /// Wrap this widget in a [`SizedBox`] with an explicit width.
     ///
     /// [`SizedBox`]: widget/struct.SizedBox.html
-    fn fix_width(self, width: f64) -> SizedBox<T> {
+    fn fix_width(self, width: f64) -> SizedBox<T, Self> {
         SizedBox::new(self).width(width)
     }
 
     /// Wrap this widget in a [`SizedBox`] with an explicit width.
     ///
     /// [`SizedBox`]: widget/struct.SizedBox.html
-    fn fix_height(self, height: f64) -> SizedBox<T> {
+    fn fix_height(self, height: f64) -> SizedBox<T, Self> {
         SizedBox::new(self).height(height)
     }
 
     /// Wrap this widget in an [`SizedBox`] with an explicit width and height
     ///
     /// [`SizedBox`]: widget/struct.SizedBox.html
-    fn fix_size(self, width: f64, height: f64) -> SizedBox<T> {
+    fn fix_size(self, width: f64, height: f64) -> SizedBox<T, Self> {
         SizedBox::new(self).width(width).height(height)
     }
 
@@ -96,7 +96,7 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     /// [`expand_height`]: #method.expand_height
     /// [`expand_width`]: #method.expand_width
     /// [`SizedBox`]: widget/struct.SizedBox.html
-    fn expand(self) -> SizedBox<T> {
+    fn expand(self) -> SizedBox<T, Self> {
         SizedBox::new(self).expand()
     }
 
@@ -105,7 +105,7 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     /// This will force the child to use all available space on the x-axis.
     ///
     /// [`SizedBox`]: widget/struct.SizedBox.html
-    fn expand_width(self) -> SizedBox<T> {
+    fn expand_width(self) -> SizedBox<T, Self> {
         SizedBox::new(self).expand_width()
     }
 
@@ -114,7 +114,7 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     /// This will force the child to use all available space on the y-axis.
     ///
     /// [`SizedBox`]: widget/struct.SizedBox.html
-    fn expand_height(self) -> SizedBox<T> {
+    fn expand_height(self) -> SizedBox<T, Self> {
         SizedBox::new(self).expand_height()
     }
 
@@ -253,12 +253,12 @@ impl<T: Data, W: Widget<T> + 'static> WidgetExt<T> for W {}
 // name.
 
 #[doc(hidden)]
-impl<T: Data> SizedBox<T> {
-    pub fn fix_width(self, width: f64) -> SizedBox<T> {
+impl<T: Data, W: Widget<T>> SizedBox<T, W> {
+    pub fn fix_width(self, width: f64) -> SizedBox<T, W> {
         self.width(width)
     }
 
-    pub fn fix_height(self, height: f64) -> SizedBox<T> {
+    pub fn fix_height(self, height: f64) -> SizedBox<T, W> {
         self.height(height)
     }
 }
@@ -316,5 +316,17 @@ mod tests {
         // this should be SizedBox<TextBox>
         let widget = TextBox::new().fix_height(10.0).fix_width(1.0);
         assert_eq!(widget.width_and_height(), (Some(1.0), Some(10.0)));
+    }
+
+    #[test]
+    fn deref() {
+        use crate::widget::Label;
+        let mut widget = Label::<()>::new("hello")
+            .padding(5.0)
+            .align_left()
+            .expand_width()
+            .padding(10.)
+            .fix_height(205.);
+        widget.set_text("what!?");
     }
 }


### PR DESCRIPTION
This is.... Honestly, I'm not sure what I think about this.

It's an attempt to deal with a common enough problem, which is that
we often cannot access methods on a given concrete widget once
it has been made a child of a container widget; and we certainly
can't access those methods when it is buried more than one widget
deep in the hierarchy.

This is frustrating! It means, for instance, that if you a widget
that has a child label that has padding applied, you can't change
attributes of that label.

This solves that by gratuitious abuse of deref and derefmut.

The basic idea is that all of the built-in widgets that have a single
child can deref to that child. Because of the way deref works, you
can in this way reach arbitrarily deep into the widget hierarchy.

So: this PR demonstrates that, by adding deref to SizedBox, Align,
and Padding. You can now have a widget like,
Padding<Align<SizedBox<Padding<Align<Label<T>>>>>>, and you can
call widget.set_text_size(420.0), and it "works".

What does this do to compile times and code size? No idea!
Is this a defensable design choice? Great question!
Is this likely to cause difficult to diagnose problems? Seems likely!
Does this solve an actual problem? Yes, maybe?

I think this might be interesting to @sysint64; it's another approach to some of the problems encountered in #1089, and that I think motivated #1247.