### PR TITLE
Add AnyWidget trait for dynamically fetching children

### DIFF
--- a/druid/examples/anim.rs
+++ b/druid/examples/anim.rs
@@ -25,6 +25,9 @@ struct AnimWidget {
 }
 
 impl Widget<u32> for AnimWidget {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, _data: &mut u32, _env: &Env) {
         match event {
             Event::MouseDown(_) => {

--- a/druid/examples/custom_widget.rs
+++ b/druid/examples/custom_widget.rs
@@ -25,6 +25,9 @@ use druid::{
 struct CustomWidget;
 
 impl Widget<String> for CustomWidget {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut String, _env: &Env) {}
 
     fn lifecycle(

--- a/druid/examples/ext_event.rs
+++ b/druid/examples/ext_event.rs
@@ -53,6 +53,9 @@ impl ColorWell {
 }
 
 impl Widget<MyColor> for ColorWell {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut MyColor, _env: &Env) {
         match event {
             Event::Command(cmd) if cmd.is(SET_COLOR) => {

--- a/druid/examples/flex.rs
+++ b/druid/examples/flex.rs
@@ -83,6 +83,9 @@ impl Rebuilder {
 }
 
 impl Widget<AppState> for Rebuilder {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut AppState, env: &Env) {
         self.inner.event(ctx, event, data, env)
     }

--- a/druid/examples/game_of_life.rs
+++ b/druid/examples/game_of_life.rs
@@ -232,6 +232,9 @@ impl GameOfLifeWidget {
 }
 
 impl Widget<AppData> for GameOfLifeWidget {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut AppData, _env: &Env) {
         match event {
             Event::WindowConnected => {

--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -93,6 +93,9 @@ impl ColorWell {
 }
 
 impl Widget<OurData> for ColorWell {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut OurData, _env: &Env) {
         match event {
             Event::Timer(t) if t == &self.token => {

--- a/druid/examples/invalidation.rs
+++ b/druid/examples/invalidation.rs
@@ -144,4 +144,8 @@ impl Widget<Vector<Circle>> for CircleView {
             }
         });
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -92,6 +92,9 @@ impl<W> Glow<W> {
 }
 
 impl<W: Widget<State>> Widget<State> for Glow<W> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut State, env: &Env) {
         self.inner.event(ctx, event, data, env);
     }

--- a/druid/examples/scroll.rs
+++ b/druid/examples/scroll.rs
@@ -44,6 +44,9 @@ struct OverPainter(u64);
 const INSETS: Insets = Insets::uniform(50.);
 
 impl<T: Data> Widget<T> for OverPainter {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, _: &mut EventCtx, _: &Event, _: &mut T, _: &Env) {}
 
     fn lifecycle(&mut self, _: &mut LifeCycleCtx, _: &LifeCycle, _: &T, _: &Env) {}

--- a/druid/examples/timer.rs
+++ b/druid/examples/timer.rs
@@ -45,6 +45,9 @@ impl TimerWidget {
 }
 
 impl Widget<u32> for TimerWidget {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut u32, env: &Env) {
         match event {
             Event::WindowConnected => {
@@ -86,6 +89,9 @@ impl Widget<u32> for TimerWidget {
 struct SimpleBox;
 
 impl Widget<u32> for SimpleBox {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut u32, _env: &Env) {}
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &u32, _env: &Env) {

--- a/druid/examples/widget_gallery.rs
+++ b/druid/examples/widget_gallery.rs
@@ -267,7 +267,7 @@ pub struct SquaresGrid<T> {
     spacing: f64,
 }
 
-impl<T> SquaresGrid<T> {
+impl<T: 'static> SquaresGrid<T> {
     pub fn new() -> Self {
         SquaresGrid {
             widgets: vec![],
@@ -293,7 +293,7 @@ impl<T> SquaresGrid<T> {
     }
 }
 
-impl<T> Default for SquaresGrid<T> {
+impl<T: 'static> Default for SquaresGrid<T> {
     fn default() -> Self {
         Self::new()
     }
@@ -384,5 +384,9 @@ impl<T: Data> Widget<T> for SquaresGrid<T> {
         for widget in self.widgets.iter_mut().take(self.drawable_widgets) {
             widget.paint(ctx, data, env);
         }
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -866,7 +866,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
     }
 }
 
-impl<T, W: Widget<T> + 'static> WidgetPod<T, W> {
+impl<T: 'static, W: Widget<T>> WidgetPod<T, W> {
     /// Box the contained widget.
     ///
     /// Convert a `WidgetPod` containing a widget of a specific concrete type

--- a/druid/src/tests/helpers.rs
+++ b/druid/src/tests/helpers.rs
@@ -151,7 +151,10 @@ impl<S, T> ModularWidget<S, T> {
     }
 }
 
-impl<S, T: Data> Widget<T> for ModularWidget<S, T> {
+impl<S: 'static, T: Data> Widget<T> for ModularWidget<S, T> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if let Some(f) = self.event.as_mut() {
             f(&mut self.state, ctx, event, data, env)
@@ -201,6 +204,9 @@ impl<T: Data> ReplaceChild<T> {
 }
 
 impl<T: Data> Widget<T> for ReplaceChild<T> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if let Event::Command(cmd) = event {
             if cmd.is(REPLACE_CHILD) {
@@ -266,6 +272,9 @@ impl Recording {
 }
 
 impl<T: Data, W: Widget<T>> Widget<T> for Recorder<W> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         self.recording.push(Record::E(event.clone()));
         self.inner.event(ctx, event, data, env)

--- a/druid/src/tests/invalidation_tests.rs
+++ b/druid/src/tests/invalidation_tests.rs
@@ -65,6 +65,9 @@ fn invalidate_scroll() {
     }
 
     impl<T: Data> Widget<T> for Invalidator {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
         fn event(&mut self, ctx: &mut EventCtx, _: &Event, _: &mut T, _: &Env) {
             ctx.request_paint_rect(RECT);
         }

--- a/druid/src/widget/align.rs
+++ b/druid/src/widget/align.rs
@@ -30,13 +30,13 @@ pub struct Align<T> {
     height_factor: Option<f64>,
 }
 
-impl<T> Align<T> {
+impl<T: Data> Align<T> {
     /// Create widget with alignment.
     ///
     /// Note that the `align` parameter is specified as a `UnitPoint` in
     /// terms of left and right. This is inadequate for bidi-aware layout
     /// and thus the API will change when druid gains bidi capability.
-    pub fn new(align: UnitPoint, child: impl Widget<T> + 'static) -> Align<T> {
+    pub fn new(align: UnitPoint, child: impl Widget<T>) -> Align<T> {
         Align {
             align,
             child: WidgetPod::new(child).boxed(),
@@ -46,22 +46,22 @@ impl<T> Align<T> {
     }
 
     /// Create centered widget.
-    pub fn centered(child: impl Widget<T> + 'static) -> Align<T> {
+    pub fn centered(child: impl Widget<T>) -> Align<T> {
         Align::new(UnitPoint::CENTER, child)
     }
 
     /// Create right-aligned widget.
-    pub fn right(child: impl Widget<T> + 'static) -> Align<T> {
+    pub fn right(child: impl Widget<T>) -> Align<T> {
         Align::new(UnitPoint::RIGHT, child)
     }
 
     /// Create left-aligned widget.
-    pub fn left(child: impl Widget<T> + 'static) -> Align<T> {
+    pub fn left(child: impl Widget<T>) -> Align<T> {
         Align::new(UnitPoint::LEFT, child)
     }
 
     /// Align only in the horizontal axis, keeping the child's size in the vertical.
-    pub fn horizontal(align: UnitPoint, child: impl Widget<T> + 'static) -> Align<T> {
+    pub fn horizontal(align: UnitPoint, child: impl Widget<T>) -> Align<T> {
         Align {
             align,
             child: WidgetPod::new(child).boxed(),
@@ -71,7 +71,7 @@ impl<T> Align<T> {
     }
 
     /// Align only in the vertical axis, keeping the child's size in the horizontal.
-    pub fn vertical(align: UnitPoint, child: impl Widget<T> + 'static) -> Align<T> {
+    pub fn vertical(align: UnitPoint, child: impl Widget<T>) -> Align<T> {
         Align {
             align,
             child: WidgetPod::new(child).boxed(),
@@ -82,6 +82,14 @@ impl<T> Align<T> {
 }
 
 impl<T: Data> Widget<T> for Align<T> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn child(&self) -> Option<&dyn Widget<T>> {
+        Some(self.child.widget())
+    }
+
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         self.child.event(ctx, event, data, env)
     }

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -111,6 +111,9 @@ impl<T: Data> Button<T> {
 }
 
 impl<T: Data> Widget<T> for Button<T> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, _data: &mut T, _env: &Env) {
         match event {
             Event::MouseDown(_) => {

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -38,6 +38,9 @@ impl Checkbox {
 }
 
 impl Widget<bool> for Checkbox {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut bool, _env: &Env) {
         match event {
             Event::MouseDown(_) => {

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -132,6 +132,12 @@ impl<T: Data> Container<T> {
 }
 
 impl<T: Data> Widget<T> for Container<T> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    fn child(&self) -> Option<&dyn Widget<T>> {
+        Some(self.inner.widget())
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         self.inner.event(ctx, event, data, env);
     }

--- a/druid/src/widget/controller.rs
+++ b/druid/src/widget/controller.rs
@@ -62,7 +62,7 @@ use crate::{
 /// [`TextBox`]: struct.TextBox.html
 /// [`ControllerHost`]: struct.ControllerHost.html
 /// [`WidgetExt::controller`]: ../trait.WidgetExt.html#tymethod.controller
-pub trait Controller<T, W: Widget<T>> {
+pub trait Controller<T, W: Widget<T>>: 'static {
     /// Analogous to [`Widget::event`].
     ///
     /// [`Widget::event`]: ../trait.Widget.html#tymethod.event
@@ -109,6 +109,9 @@ impl<W, C> ControllerHost<W, C> {
 }
 
 impl<T, W: Widget<T>, C: Controller<T, W>> Widget<T> for ControllerHost<W, C> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         self.controller
             .event(&mut self.widget, ctx, event, data, env)

--- a/druid/src/widget/either.rs
+++ b/druid/src/widget/either.rs
@@ -28,7 +28,7 @@ pub struct Either<T> {
     current: bool,
 }
 
-impl<T> Either<T> {
+impl<T: Data> Either<T> {
     /// Create a new widget that switches between two views.
     ///
     /// The given closure is evaluated on data change. If its value is `true`, then
@@ -48,6 +48,9 @@ impl<T> Either<T> {
 }
 
 impl<T: Data> Widget<T> for Either<T> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if self.current {
             self.true_branch.event(ctx, event, data, env)

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -59,6 +59,9 @@ impl<T, W: Widget<T>> EnvScope<T, W> {
 }
 
 impl<T: Data, W: Widget<T>> Widget<T> for EnvScope<T, W> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         let mut new_env = env.clone();
         (self.f)(&mut new_env, &data);

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -348,8 +348,8 @@ impl FlexParams {
     }
 }
 
-impl<T> ChildWidget<T> {
-    fn new(child: impl Widget<T> + 'static, params: FlexParams) -> Self {
+impl<T: Data> ChildWidget<T> {
+    fn new(child: impl Widget<T>, params: FlexParams) -> Self {
         ChildWidget {
             widget: WidgetPod::new(Box::new(child)),
             params,
@@ -588,6 +588,9 @@ impl<T: Data> Flex<T> {
 }
 
 impl<T: Data> Widget<T> for Flex<T> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         for child in &mut self.children {
             child.widget.event(ctx, event, data, env);
@@ -834,6 +837,9 @@ impl Iterator for Spacing {
 }
 
 impl<T: Data> Widget<T> for Spacer {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, _: &mut EventCtx, _: &Event, _: &mut T, _: &Env) {}
     fn lifecycle(&mut self, _: &mut LifeCycleCtx, _: &LifeCycle, _: &T, _: &Env) {}
     fn update(&mut self, _: &mut UpdateCtx, _: &T, _: &T, _: &Env) {}

--- a/druid/src/widget/identity_wrapper.rs
+++ b/druid/src/widget/identity_wrapper.rs
@@ -34,6 +34,9 @@ impl<W> IdentityWrapper<W> {
 }
 
 impl<T: Data, W: Widget<T>> Widget<T> for IdentityWrapper<W> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         self.inner.event(ctx, event, data, env);
     }

--- a/druid/src/widget/image.rs
+++ b/druid/src/widget/image.rs
@@ -130,6 +130,9 @@ impl Image {
 }
 
 impl<T: Data> Widget<T> for Image {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut T, _env: &Env) {}
 
     fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &T, _env: &Env) {}

--- a/druid/src/widget/invalidation.rs
+++ b/druid/src/widget/invalidation.rs
@@ -35,6 +35,9 @@ impl<T: Data, W: Widget<T>> DebugInvalidation<T, W> {
 }
 
 impl<T: Data, W: Widget<T>> Widget<T> for DebugInvalidation<T, W> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         self.inner.event(ctx, event, data, env);
     }

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -468,6 +468,9 @@ impl<T: Data> LabelText<T> {
 }
 
 impl<T: Data> Widget<T> for Label<T> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut T, _env: &Env) {}
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
@@ -505,6 +508,9 @@ impl<T: Data> Widget<T> for Label<T> {
 }
 
 impl<T: TextStorage> Widget<T> for RawLabel<T> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut T, _env: &Env) {}
     fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, _env: &Env) {
         if matches!(event, LifeCycle::WidgetAdded) {

--- a/druid/src/widget/lens_wrap.rs
+++ b/druid/src/widget/lens_wrap.rs
@@ -68,9 +68,12 @@ impl<T, U, L, W> Widget<T> for LensWrap<U, L, W>
 where
     T: Data,
     U: Data,
-    L: Lens<T, U>,
+    L: Lens<T, U> + 'static,
     W: Widget<U>,
 {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         let inner = &mut self.inner;
         self.lens

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -194,6 +194,9 @@ impl<S: Data, T: Data> ListIter<(S, T)> for (S, Arc<Vec<T>>) {
 }
 
 impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         let mut children = self.children.iter_mut();
         data.for_each_mut(|child_data, _| {

--- a/druid/src/widget/padding.rs
+++ b/druid/src/widget/padding.rs
@@ -30,7 +30,7 @@ pub struct Padding<T> {
     child: WidgetPod<T, Box<dyn Widget<T>>>,
 }
 
-impl<T> Padding<T> {
+impl<T: Data> Padding<T> {
     /// Create a new widget with the specified padding. This can either be an instance
     /// of [`kurbo::Insets`], a f64 for uniform padding, a 2-tuple for axis-uniform padding
     /// or 4-tuple with (left, top, right, bottom) values.
@@ -60,7 +60,7 @@ impl<T> Padding<T> {
     /// ```
     ///
     /// [`kurbo::Insets`]: https://docs.rs/kurbo/0.5.3/kurbo/struct.Insets.html
-    pub fn new(insets: impl Into<Insets>, child: impl Widget<T> + 'static) -> Padding<T> {
+    pub fn new(insets: impl Into<Insets>, child: impl Widget<T>) -> Padding<T> {
         let insets = insets.into();
         Padding {
             left: insets.x0,
@@ -73,6 +73,12 @@ impl<T> Padding<T> {
 }
 
 impl<T: Data> Widget<T> for Padding<T> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    fn child(&self) -> Option<&dyn Widget<T>> {
+        Some(self.child.widget())
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         self.child.event(ctx, event, data, env)
     }

--- a/druid/src/widget/painter.rs
+++ b/druid/src/widget/painter.rs
@@ -125,6 +125,9 @@ impl<T: Data> BackgroundBrush<T> {
 }
 
 impl<T: Data> Widget<T> for Painter<T> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, _: &mut EventCtx, _: &Event, _: &mut T, _: &Env) {}
     fn lifecycle(&mut self, _: &mut LifeCycleCtx, _: &LifeCycle, _: &T, _: &Env) {}
     fn update(&mut self, ctx: &mut UpdateCtx, old: &T, new: &T, _: &Env) {

--- a/druid/src/widget/parse.rs
+++ b/druid/src/widget/parse.rs
@@ -39,6 +39,9 @@ impl<T> Parse<T> {
 }
 
 impl<T: FromStr + Display + Data, W: Widget<String>> Widget<Option<T>> for Parse<W> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut Option<T>, env: &Env) {
         self.widget.event(ctx, event, &mut self.state, env);
         *data = self.state.parse().ok();

--- a/druid/src/widget/progress_bar.rs
+++ b/druid/src/widget/progress_bar.rs
@@ -35,6 +35,9 @@ impl ProgressBar {
 }
 
 impl Widget<f64> for ProgressBar {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut f64, _env: &Env) {}
 
     fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &f64, _env: &Env) {}

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -64,6 +64,9 @@ impl<T: Data> Radio<T> {
 }
 
 impl<T: Data + PartialEq> Widget<T> for Radio<T> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, _env: &Env) {
         match event {
             Event::MouseDown(_) => {

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -104,6 +104,9 @@ impl<T, W: Widget<T>> Scroll<T, W> {
 }
 
 impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         self.scroll_component.event(ctx, event, env);
         if !ctx.is_handled() {

--- a/druid/src/widget/sized_box.rs
+++ b/druid/src/widget/sized_box.rs
@@ -130,6 +130,16 @@ impl<T> SizedBox<T> {
 }
 
 impl<T: Data> Widget<T> for SizedBox<T> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    fn child(&self) -> Option<&dyn Widget<T>> {
+        match self.inner.as_ref() {
+            Some(inner) => Some(inner),
+            None => None,
+        }
+    }
+
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if let Some(ref mut inner) = self.inner {
             inner.event(ctx, event, data, env);

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -75,6 +75,9 @@ impl Slider {
 }
 
 impl Widget<f64> for Slider {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut f64, env: &Env) {
         let knob_size = env.get(theme::BASIC_WIDGET_HEIGHT);
         let slider_width = ctx.size().width;

--- a/druid/src/widget/spinner.rs
+++ b/druid/src/widget/spinner.rs
@@ -67,6 +67,9 @@ impl Default for Spinner {
 }
 
 impl<T: Data> Widget<T> for Spinner {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, _data: &mut T, _env: &Env) {
         if let Event::AnimFrame(interval) = event {
             self.t += (*interval as f64) * 1e-9;

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -35,7 +35,7 @@ pub struct Split<T> {
     child2: WidgetPod<T, Box<dyn Widget<T>>>,
 }
 
-impl<T> Split<T> {
+impl<T: Data> Split<T> {
     /// Create a new split panel, with the specified axis being split in two.
     ///
     /// Horizontal split axis means that the children are left and right.
@@ -266,6 +266,9 @@ impl<T> Split<T> {
 }
 
 impl<T: Data> Widget<T> for Split<T> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if self.child1.is_active() {
             self.child1.event(ctx, event, data, env);

--- a/druid/src/widget/stepper.rs
+++ b/druid/src/widget/stepper.rs
@@ -120,6 +120,9 @@ impl Default for Stepper {
 }
 
 impl Widget<f64> for Stepper {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn paint(&mut self, ctx: &mut PaintCtx, _data: &f64, env: &Env) {
         let stroke_width = 2.0;
         let rounded_rect = ctx

--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -104,6 +104,10 @@ impl<T: Data> Widget<T> for Svg {
         ctx.clip(clip_rect);
         self.svg_data.to_piet(offset_matrix, ctx);
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 /// Stored SVG data.

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -90,6 +90,9 @@ impl Switch {
 }
 
 impl Widget<bool> for Switch {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut bool, env: &Env) {
         let switch_height = env.get(theme::BORDERED_WIDGET_HEIGHT);
         let switch_width = switch_height * SWITCH_WIDTH_RATIO;

--- a/druid/src/widget/tabs.rs
+++ b/druid/src/widget/tabs.rs
@@ -308,6 +308,9 @@ impl<TP: TabsPolicy> TabBar<TP> {
 }
 
 impl<TP: TabsPolicy> Widget<TabsState<TP>> for TabBar<TP> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut TabsState<TP>, env: &Env) {
         match event {
             Event::MouseDown(e) => {
@@ -581,6 +584,9 @@ fn hidden_should_receive_lifecycle(lc: &LifeCycle) -> bool {
 }
 
 impl<TP: TabsPolicy> Widget<TabsState<TP>> for TabsBody<TP> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut TabsState<TP>, env: &Env) {
         if hidden_should_receive_event(event) {
             for child in self.child_pods() {
@@ -950,6 +956,9 @@ impl<TP: TabsPolicy> Tabs<TP> {
 }
 
 impl<TP: TabsPolicy> Widget<TP::Input> for Tabs<TP> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut TP::Input, env: &Env) {
         if let TabsContent::Running { scope } = &mut self.content {
             scope.event(ctx, event, data, env);

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -264,6 +264,9 @@ impl TextBox {
 }
 
 impl Widget<String> for TextBox {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut String, _env: &Env) {
         // Guard against external changes in data?
         self.selection = self.selection.constrain_to(data);

--- a/druid/src/widget/view_switcher.rs
+++ b/druid/src/widget/view_switcher.rs
@@ -57,6 +57,9 @@ impl<T: Data, U: Data> ViewSwitcher<T, U> {
 }
 
 impl<T: Data, U: Data> Widget<T> for ViewSwitcher<T, U> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if let Some(child) = self.active_child.as_mut() {
             child.event(ctx, event, data, env);

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -90,7 +90,7 @@ struct Windows<T> {
     windows: HashMap<WindowId, Window<T>>,
 }
 
-impl<T> Windows<T> {
+impl<T: Data> Windows<T> {
     fn connect(&mut self, id: WindowId, handle: WindowHandle, ext_handle: ExtEventSink) {
         if let Some(pending) = self.pending.remove(&id) {
             let win = Window::new(id, handle, pending, ext_handle);

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -58,7 +58,7 @@ pub struct Window<T> {
     // delegate?
 }
 
-impl<T> Window<T> {
+impl<T: Data> Window<T> {
     pub(crate) fn new(
         id: WindowId,
         handle: WindowHandle,
@@ -81,9 +81,7 @@ impl<T> Window<T> {
             ext_handle,
         }
     }
-}
 
-impl<T: Data> Window<T> {
     /// `true` iff any child requested an animation frame since the last `AnimFrame` event.
     pub(crate) fn wants_animation_frame(&self) -> bool {
         self.root.state().request_anim


### PR DESCRIPTION
*If you're looking at the code, just look at widget.rs.*

tldr: this provides a method of dynamically reaching down
into the view hierarchy and retrieving a child of a given
type, through arbitrary levels of nesting. As an example, the
following test passes:

```rust
#[test]
fn dynamism() {
    let widget = Slider::new()
        .padding(5.0)
        .align_left()
        .expand()
        .background(Color::BLACK);

    assert!(widget.downcast_child::<Slider>().is_some());
    let widget = widget.padding(10.0);
    assert!(widget.downcast_child::<Slider>().is_some());
    // get an intermediate widget:
    assert!(widget.downcast_child::<Padding<f64>>().is_some());
    assert!(widget.downcast_child::<Align<f64>>().is_some());
}
```
------

This is a proof-of-concept for another approach to fetching
child widgets through an arbitrary number of parents.

This approach has a number of moving parts.

- The Widget trait has a + 'static bound, which means that
anything implementing Widget also implements std::any::Any.

- child(&self) -> Option<&dyn Widget<T>> is a method that
by default returns None. Single-child container widgets
must implement this method and return a reference to their
child.

- as_any(&self) -> &dyn Any is a method on the Widget trait
that widgets are required to implement. This is pure
boilerplate; we cannot provide an auto-impl without adding
a Sized bound to Widget, which breaks object safety.

- AnyWidget is a new trait, that is auto-implemented for
any implementor of Widget, and which provides a method,
downcast_child<C: Widget<T>>(&self) -> Option<&C>.

Downsides to this approach:

- boilerplate: in addition to the stuff described, we are
also going to need any_mut and child_mut on Widget.
We may want to consider adding a derive to implement these?

- verbosity: getting a child requires specifying its type
correctly, and then dealing with an optional.

Upsides to this approach:

If we wish, this approach would allow us to use
Box<dyn Widget> in more places, which would simplify
type signatures and reduce code size.