### PR TITLE
Use widget::prelude::* where appropriate

### DIFF
--- a/druid/examples/custom_widget.rs
+++ b/druid/examples/custom_widget.rs
@@ -63,7 +63,7 @@ impl Widget<String> for CustomWidget {
         // Clear the whole widget with the color of your choice
         // (ctx.size() returns the size of the layout rect we're painting in)
         let size = ctx.size();
-        let rect = Rect::from_origin_size(Point::ORIGIN, size);
+        let rect = size.to_rect();
         ctx.fill(rect, &Color::WHITE);
 
         // Note: ctx also has a `clear` method, but that clears the whole context,
@@ -105,11 +105,7 @@ impl Widget<String> for CustomWidget {
             .make_image(256, 256, &image_data, ImageFormat::RgbaSeparate)
             .unwrap();
         // The image is automatically scaled to fit the rect you pass to draw_image
-        ctx.draw_image(
-            &image,
-            Rect::from_origin_size(Point::ORIGIN, size),
-            InterpolationMode::Bilinear,
-        );
+        ctx.draw_image(&image, size.to_rect(), InterpolationMode::Bilinear);
     }
 }
 

--- a/druid/src/scroll_component.rs
+++ b/druid/src/scroll_component.rs
@@ -318,7 +318,7 @@ impl ScrollComponent {
     /// Make sure to call on every event
     pub fn event(&mut self, ctx: &mut EventCtx, event: &Event, env: &Env) {
         let size = ctx.size();
-        let viewport = Rect::from_origin_size(Point::ORIGIN, size);
+        let viewport = size.to_rect();
 
         let scrollbar_is_hovered = match event {
             Event::MouseMove(e) | Event::MouseUp(e) | Event::MouseDown(e) => {

--- a/druid/src/widget/align.rs
+++ b/druid/src/widget/align.rs
@@ -14,13 +14,8 @@
 
 //! A widget that aligns its child (for example, centering it).
 
-use crate::kurbo::{Rect, Size};
-use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
-    UpdateCtx, Widget, WidgetPod,
-};
-
-use crate::piet::UnitPoint;
+use crate::widget::prelude::*;
+use crate::{Data, Rect, Size, UnitPoint, WidgetPod};
 
 /// A widget that aligns its child.
 pub struct Align<T> {

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -13,11 +13,10 @@
 // limitations under the License.
 
 //! A button widget.
-use crate::theme;
+
 use crate::widget::prelude::*;
 use crate::widget::{Click, ControllerHost, Label, LabelText};
-
-use crate::{Affine, Data, Insets, LinearGradient, Point, Rect, RenderContext, UnitPoint, Widget};
+use crate::{theme, Affine, Data, Insets, LinearGradient, UnitPoint};
 
 // the minimum padding added to a button.
 // NOTE: these values are chosen to match the existing look of TextBox; these
@@ -165,7 +164,8 @@ impl<T: Data> Widget<T> for Button<T> {
         let size = ctx.size();
         let stroke_width = env.get(theme::BUTTON_BORDER_WIDTH);
 
-        let rounded_rect = Rect::from_origin_size(Point::ORIGIN, size)
+        let rounded_rect = size
+            .to_rect()
             .inset(-stroke_width / 2.0)
             .to_rounded_rect(env.get(theme::BUTTON_BORDER_RADIUS));
 

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -17,11 +17,7 @@
 use crate::kurbo::{BezPath, Size};
 use crate::piet::{LineCap, LineJoin, LinearGradient, RenderContext, StrokeStyle, UnitPoint};
 use crate::theme;
-use crate::widget::{Label, LabelText};
-use crate::{
-    BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, UpdateCtx,
-    Widget,
-};
+use crate::widget::{prelude::*, Label, LabelText};
 
 /// A checkbox that toggles a `bool`.
 pub struct Checkbox {

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -15,11 +15,9 @@
 //! A widget that provides simple visual styling options to a child.
 
 use super::BackgroundBrush;
-use crate::shell::kurbo::{Point, Rect, Size};
-use crate::{
-    BoxConstraints, Color, Data, Env, Event, EventCtx, KeyOrValue, LayoutCtx, LifeCycle,
-    LifeCycleCtx, PaintCtx, RenderContext, UpdateCtx, Widget, WidgetPod,
-};
+use crate::kurbo::Point;
+use crate::widget::prelude::*;
+use crate::{Color, Data, KeyOrValue, Rect, WidgetPod};
 
 struct BorderStyle {
     width: KeyOrValue<f64>,

--- a/druid/src/widget/controller.rs
+++ b/druid/src/widget/controller.rs
@@ -14,10 +14,7 @@
 
 //! A widget-controlling widget.
 
-use crate::{
-    BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Size,
-    UpdateCtx, Widget, WidgetId,
-};
+use crate::widget::prelude::*;
 
 /// A trait for types that modify behaviour of a child widget.
 ///

--- a/druid/src/widget/either.rs
+++ b/druid/src/widget/either.rs
@@ -14,11 +14,8 @@
 
 //! A widget that switches dynamically between two child views.
 
-use crate::kurbo::{Point, Rect, Size};
-use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
-    UpdateCtx, Widget, WidgetPod,
-};
+use crate::widget::prelude::*;
+use crate::{Data, WidgetPod};
 
 /// A widget that switches between two possible child views.
 pub struct Either<T> {
@@ -80,22 +77,14 @@ impl<T: Data> Widget<T> for Either<T> {
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         if self.current {
             let size = self.true_branch.layout(ctx, bc, data, env);
-            self.true_branch.set_layout_rect(
-                ctx,
-                data,
-                env,
-                Rect::from_origin_size(Point::ORIGIN, size),
-            );
+            self.true_branch
+                .set_layout_rect(ctx, data, env, size.to_rect());
             ctx.set_paint_insets(self.true_branch.paint_insets());
             size
         } else {
             let size = self.false_branch.layout(ctx, bc, data, env);
-            self.false_branch.set_layout_rect(
-                ctx,
-                data,
-                env,
-                Rect::from_origin_size(Point::ORIGIN, size),
-            );
+            self.false_branch
+                .set_layout_rect(ctx, data, env, size.to_rect());
             ctx.set_paint_insets(self.true_branch.paint_insets());
             size
         }

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -14,11 +14,8 @@
 
 //! A widget that accepts a closure to update the environment for its child.
 
-use crate::kurbo::Size;
-use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
-    UpdateCtx, Widget, WidgetPod,
-};
+use crate::widget::prelude::*;
+use crate::{Data, WidgetPod};
 
 /// A widget that accepts a closure to update the environment for its child.
 pub struct EnvScope<T, W> {

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -15,13 +15,9 @@
 //! A widget that arranges its children in a one-dimensional array.
 
 use crate::kurbo::common::FloatExt;
-use crate::kurbo::{Point, Rect, Size};
-
+use crate::widget::prelude::*;
 use crate::widget::SizedBox;
-use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, KeyOrValue, LayoutCtx, LifeCycle, LifeCycleCtx,
-    PaintCtx, UpdateCtx, Widget, WidgetPod,
-};
+use crate::{Data, KeyOrValue, Point, Rect, WidgetPod};
 
 /// A container with either horizontal or vertical layout.
 ///
@@ -632,7 +628,7 @@ impl<T: Data> Widget<T> for Flex<T> {
                 major_non_flex += self.direction.major(child_size).expand();
                 minor = minor.max(self.direction.minor(child_size).expand());
                 // Stash size.
-                let rect = Rect::from_origin_size(Point::ORIGIN, child_size);
+                let rect = child_size.to_rect();
                 child.widget.set_layout_rect(ctx, data, env, rect);
             }
         }
@@ -659,7 +655,7 @@ impl<T: Data> Widget<T> for Flex<T> {
                 major_flex += self.direction.major(child_size).expand();
                 minor = minor.max(self.direction.minor(child_size).expand());
                 // Stash size.
-                let rect = Rect::from_origin_size(Point::ORIGIN, child_size);
+                let rect = child_size.to_rect();
                 child.widget.set_layout_rect(ctx, data, env, rect);
             }
         }

--- a/druid/src/widget/identity_wrapper.rs
+++ b/druid/src/widget/identity_wrapper.rs
@@ -14,11 +14,8 @@
 
 //! A widget that provides an explicit identity to a child.
 
-use crate::kurbo::Size;
-use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
-    UpdateCtx, Widget, WidgetId,
-};
+use crate::widget::prelude::*;
+use crate::Data;
 
 /// A wrapper that adds an identity to an otherwise anonymous widget.
 pub struct IdentityWrapper<W> {

--- a/druid/src/widget/image.rs
+++ b/druid/src/widget/image.rs
@@ -20,8 +20,8 @@ use druid_shell::ImageBuf;
 use crate::{
     piet::{Image as PietImage, InterpolationMode},
     widget::common::FillStrat,
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Rect,
-    RenderContext, Size, UpdateCtx, Widget,
+    widget::prelude::*,
+    Data,
 };
 
 /// A widget that renders a bitmap Image.
@@ -167,7 +167,7 @@ impl<T: Data> Widget<T> for Image {
         // The ImageData's to_piet function does not clip to the image's size
         // CairoRenderContext is very like druids but with some extra goodies like clip
         if self.fill != FillStrat::Contain {
-            let clip_rect = Rect::ZERO.with_size(ctx.size());
+            let clip_rect = ctx.size().to_rect();
             ctx.clip(clip_rect);
         }
 

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -19,8 +19,8 @@ use std::ops::{Deref, DerefMut};
 use crate::text::TextStorage;
 use crate::widget::prelude::*;
 use crate::{
-    ArcStr, BoxConstraints, Color, Data, FontDescriptor, KeyOrValue, LocalizedString, Point, Size,
-    TextAlignment, TextLayout,
+    ArcStr, Color, Data, FontDescriptor, KeyOrValue, LocalizedString, Point, TextAlignment,
+    TextLayout,
 };
 
 // added padding between the edges of the widget and the text.

--- a/druid/src/widget/padding.rs
+++ b/druid/src/widget/padding.rs
@@ -14,11 +14,8 @@
 
 //! A widget that just adds padding during layout.
 
-use crate::kurbo::{Insets, Point, Rect, Size};
-use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
-    UpdateCtx, Widget, WidgetPod,
-};
+use crate::widget::prelude::*;
+use crate::{Data, Insets, Point, Rect, WidgetPod};
 
 /// A widget that just adds padding around its child.
 pub struct Padding<T> {

--- a/druid/src/widget/painter.rs
+++ b/druid/src/widget/painter.rs
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 use crate::piet::{FixedGradient, LinearGradient, PaintBrush, RadialGradient};
-use crate::{
-    BoxConstraints, Color, Data, Env, Event, EventCtx, Key, LayoutCtx, LifeCycle, LifeCycleCtx,
-    PaintCtx, RenderContext, Size, UpdateCtx, Widget,
-};
+use crate::widget::prelude::*;
+use crate::{Color, Data, Key};
 
 /// A widget that only handles painting.
 ///

--- a/druid/src/widget/parse.rs
+++ b/druid/src/widget/parse.rs
@@ -16,11 +16,8 @@ use std::fmt::Display;
 use std::mem;
 use std::str::FromStr;
 
-use crate::kurbo::Size;
-use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
-    UpdateCtx, Widget, WidgetId,
-};
+use crate::widget::prelude::*;
+use crate::Data;
 
 /// Converts a `Widget<String>` to a `Widget<Option<T>>`, mapping parse errors to None
 pub struct Parse<T> {

--- a/druid/src/widget/progress_bar.rs
+++ b/druid/src/widget/progress_bar.rs
@@ -14,12 +14,8 @@
 
 //! A progress bar widget.
 
-use crate::kurbo::{Point, Rect, Size};
-use crate::theme;
-use crate::{
-    BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, LinearGradient,
-    PaintCtx, RenderContext, UnitPoint, UpdateCtx, Widget,
-};
+use crate::widget::prelude::*;
+use crate::{theme, LinearGradient, Point, Rect, UnitPoint};
 
 /// A progress bar, displaying a numeric progress value.
 ///

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -14,13 +14,10 @@
 
 //! A radio button widget.
 
-use crate::kurbo::{Circle, Size};
-use crate::theme;
+use crate::kurbo::Circle;
+use crate::widget::prelude::*;
 use crate::widget::{CrossAxisAlignment, Flex, Label, LabelText};
-use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, LinearGradient,
-    PaintCtx, RenderContext, UnitPoint, UpdateCtx, Widget,
-};
+use crate::{theme, Data, LinearGradient, UnitPoint};
 
 const DEFAULT_RADIO_RADIUS: f64 = 7.0;
 const INNER_CIRCLE_RADIUS: f64 = 2.0;

--- a/druid/src/widget/scope.rs
+++ b/druid/src/widget/scope.rs
@@ -1,9 +1,7 @@
-use crate::kurbo::{Point, Rect};
-use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, Lens, LifeCycle, LifeCycleCtx, PaintCtx,
-    Size, UpdateCtx, Widget, WidgetPod,
-};
 use std::marker::PhantomData;
+
+use crate::widget::prelude::*;
+use crate::{Data, Lens, WidgetPod};
 
 /// A policy that controls how a [`Scope`] will interact with its surrounding
 /// application data. Specifically, how to create an initial State from the
@@ -294,7 +292,7 @@ impl<SP: ScopePolicy, W: Widget<SP::State>> Widget<SP::In> for Scope<SP, W> {
     ) -> Size {
         self.with_state(data, |state, inner| {
             let size = inner.layout(ctx, bc, state, env);
-            inner.set_layout_rect(ctx, state, env, Rect::from_origin_size(Point::ORIGIN, size));
+            inner.set_layout_rect(ctx, state, env, size.to_rect());
             size
         })
     }

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -16,11 +16,8 @@
 
 use std::f64::INFINITY;
 
-use crate::kurbo::{Point, Rect, Size, Vec2};
-use crate::{
-    scroll_component::*, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle,
-    LifeCycleCtx, PaintCtx, UpdateCtx, Widget, WidgetPod,
-};
+use crate::widget::prelude::*;
+use crate::{scroll_component::*, Data, Vec2, WidgetPod};
 
 #[derive(Debug, Clone)]
 enum ScrollDirection {
@@ -107,7 +104,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         self.scroll_component.event(ctx, event, env);
         if !ctx.is_handled() {
-            let viewport = Rect::from_origin_size(Point::ORIGIN, ctx.size());
+            let viewport = ctx.size().to_rect();
 
             let force_event = self.child.is_hot() || self.child.is_active();
             let child_event =

--- a/druid/src/widget/sized_box.rs
+++ b/druid/src/widget/sized_box.rs
@@ -16,11 +16,8 @@
 
 use std::f64::INFINITY;
 
-use crate::shell::kurbo::Size;
-use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
-    UpdateCtx, Widget, WidgetId,
-};
+use crate::widget::prelude::*;
+use crate::Data;
 
 /// A widget with predefined size.
 ///

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -14,12 +14,9 @@
 
 //! A slider widget.
 
-use crate::kurbo::{Circle, Point, Rect, Shape, Size};
-use crate::theme;
-use crate::{
-    BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, LinearGradient,
-    PaintCtx, RenderContext, UnitPoint, UpdateCtx, Widget,
-};
+use crate::kurbo::{Circle, Shape};
+use crate::widget::prelude::*;
+use crate::{theme, LinearGradient, Point, Rect, UnitPoint};
 
 /// A slider, allowing interactive update of a numeric value.
 ///
@@ -135,7 +132,7 @@ impl Widget<f64> for Slider {
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &f64, env: &Env) {
         let clamped = self.normalize(*data);
-        let rect = Rect::from_origin_size(Point::ORIGIN, ctx.size());
+        let rect = ctx.size().to_rect();
         let knob_size = env.get(theme::BASIC_WIDGET_HEIGHT);
         let track_thickness = 4.;
         let border_width = 2.;

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -14,12 +14,10 @@
 
 //! A widget which splits an area in two, with a settable ratio, and optional draggable resizing.
 
-use crate::kurbo::{Line, Point, Rect, Size};
+use crate::kurbo::Line;
 use crate::widget::flex::Axis;
-use crate::{
-    theme, BoxConstraints, Color, Cursor, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle,
-    LifeCycleCtx, PaintCtx, RenderContext, UpdateCtx, Widget, WidgetPod,
-};
+use crate::widget::prelude::*;
+use crate::{theme, Color, Cursor, Data, Point, Rect, WidgetPod};
 
 /// A container containing two other widgets, splitting the area either horizontally or vertically.
 pub struct Split<T> {

--- a/druid/src/widget/stepper.rs
+++ b/druid/src/widget/stepper.rs
@@ -17,15 +17,10 @@
 use std::f64::EPSILON;
 use std::time::Duration;
 
-use crate::kurbo::{BezPath, Rect};
+use crate::kurbo::BezPath;
 use crate::piet::{LinearGradient, RenderContext, UnitPoint};
-use crate::{
-    BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Size,
-    TimerToken, UpdateCtx, Widget,
-};
-
-use crate::theme;
-use crate::Point;
+use crate::widget::prelude::*;
+use crate::{theme, Point, Rect, TimerToken};
 
 // Delay until stepper starts automatically changing valued when one of the button is held down.
 const STEPPER_REPEAT_DELAY: Duration = Duration::from_millis(500);
@@ -137,8 +132,7 @@ impl Widget<f64> for Stepper {
 
         // draw buttons for increase/decrease
         let increase_button_origin = Point::ORIGIN;
-        let mut decrease_button_origin = Point::ORIGIN;
-        decrease_button_origin.y += height / 2.;
+        let decrease_button_origin = Point::new(0., height / 2.0);
 
         let increase_button_rect = Rect::from_origin_size(increase_button_origin, button_size);
         let decrease_button_rect = Rect::from_origin_size(decrease_button_origin, button_size);

--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -21,9 +21,7 @@ use std::sync::Arc;
 use log::error;
 
 use crate::{
-    kurbo::BezPath, widget::common::FillStrat, Affine, BoxConstraints, Color, Data, Env, Event,
-    EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Rect, RenderContext, Size, UpdateCtx,
-    Widget,
+    kurbo::BezPath, widget::common::FillStrat, widget::prelude::*, Affine, Color, Data, Rect,
 };
 
 /// A widget that renders a SVG

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -16,13 +16,10 @@
 
 use std::time::Duration;
 
-use crate::kurbo::{Circle, Point, Shape, Size};
+use crate::kurbo::{Circle, Shape};
 use crate::piet::{LinearGradient, RenderContext, UnitPoint};
-use crate::theme;
-use crate::{
-    ArcStr, BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
-    TextLayout, UpdateCtx, Widget,
-};
+use crate::widget::prelude::*;
+use crate::{theme, ArcStr, Point, TextLayout};
 
 const SWITCH_CHANGE_TIME: f64 = 0.2;
 const SWITCH_PADDING: f64 = 3.;

--- a/druid/src/widget/tabs.rs
+++ b/druid/src/widget/tabs.rs
@@ -22,9 +22,7 @@ use std::marker::PhantomData;
 use std::rc::Rc;
 
 use crate::kurbo::Line;
-use crate::piet::RenderContext;
 use crate::widget::prelude::*;
-
 use crate::widget::{Axis, Flex, Label, LabelText, LensScopeTransfer, Scope, ScopePolicy};
 use crate::{theme, Affine, Data, Insets, Lens, Point, Rect, SingleUse, WidgetExt, WidgetPod};
 
@@ -675,7 +673,7 @@ impl<TP: TabsPolicy> Widget<TabsState<TP>> for TabsBody<TP> {
         // Laying out all children so events can be delivered to them.
         for child in self.child_pods() {
             let size = child.layout(ctx, bc, inner, env);
-            child.set_layout_rect(ctx, inner, env, Rect::from_origin_size(Point::ORIGIN, size));
+            child.set_layout_rect(ctx, inner, env, size.to_rect());
         }
 
         bc.max()
@@ -686,7 +684,7 @@ impl<TP: TabsPolicy> Widget<TabsState<TP>> for TabsBody<TP> {
             let axis = self.axis;
             let size = ctx.size();
             let major = axis.major(size);
-            ctx.clip(Rect::from_origin_size(Point::ZERO, size));
+            ctx.clip(size.to_rect());
 
             let children = &mut self.children;
             if let Some(ref mut prev) = Self::child(children, trans.previous_idx) {

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -16,15 +16,14 @@
 
 use std::time::Duration;
 
-use crate::kurbo::{Affine, Insets, Point, Size, Vec2};
+use crate::kurbo::Vec2;
 use crate::text::{
     BasicTextInput, EditAction, EditableText, Editor, TextInput, TextLayout, TextStorage,
 };
-use crate::theme;
 use crate::widget::prelude::*;
 use crate::{
-    BoxConstraints, Cursor, Env, FontDescriptor, HotKey, KbKey, KeyOrValue, Selector, SysMods,
-    TimerToken,
+    theme, Affine, Cursor, FontDescriptor, HotKey, Insets, KbKey, KeyOrValue, Point, Selector,
+    SysMods, TimerToken,
 };
 
 const BORDER_WIDTH: f64 = 1.;

--- a/druid/src/widget/view_switcher.rs
+++ b/druid/src/widget/view_switcher.rs
@@ -14,10 +14,8 @@
 
 //! A widget that can dynamically switch between one of many views.
 
-use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
-    Point, Rect, Size, UpdateCtx, Widget, WidgetPod,
-};
+use crate::widget::prelude::*;
+use crate::{Data, WidgetPod};
 
 /// A widget that can switch dynamically between one of many views depending
 /// on application state.
@@ -91,7 +89,7 @@ impl<T: Data, U: Data> Widget<T> for ViewSwitcher<T, U> {
         match self.active_child {
             Some(ref mut child) => {
                 let size = child.layout(ctx, bc, data, env);
-                child.set_layout_rect(ctx, data, env, Rect::from_origin_size(Point::ORIGIN, size));
+                child.set_layout_rect(ctx, data, env, size.to_rect());
                 size
             }
             None => bc.max(),

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -20,7 +20,6 @@ use std::mem;
 // Automatically defaults to std::time::Instant on non Wasm platforms
 use instant::Instant;
 
-use crate::kurbo::{Point, Rect, Size};
 use crate::piet::{Piet, RenderContext};
 use crate::shell::{Counter, Cursor, Region, WindowHandle};
 
@@ -32,8 +31,8 @@ use crate::widget::LabelText;
 use crate::win_handler::RUN_COMMANDS_TOKEN;
 use crate::{
     BoxConstraints, Command, Data, Env, Event, EventCtx, ExtEventSink, InternalEvent,
-    InternalLifeCycle, LayoutCtx, LifeCycle, LifeCycleCtx, MenuDesc, PaintCtx, TimerToken,
-    UpdateCtx, Widget, WidgetId, WidgetPod,
+    InternalLifeCycle, LayoutCtx, LifeCycle, LifeCycleCtx, MenuDesc, PaintCtx, Point, Size,
+    TimerToken, UpdateCtx, Widget, WidgetId, WidgetPod,
 };
 
 /// A unique identifier for a window.
@@ -366,12 +365,8 @@ impl<T: Data> Window<T> {
         };
         let bc = BoxConstraints::tight(self.size);
         let size = self.root.layout(&mut layout_ctx, &bc, data, env);
-        self.root.set_layout_rect(
-            &mut layout_ctx,
-            data,
-            env,
-            Rect::from_origin_size(Point::ORIGIN, size),
-        );
+        self.root
+            .set_layout_rect(&mut layout_ctx, data, env, size.to_rect());
         self.post_event_processing(&mut widget_state, queue, data, env, true);
     }
 


### PR DESCRIPTION
This will encourage other people to use the prelude, which in
turn makes it slightly less annoying when (and if) we change the
signatures of widget methods.

This includes a few small cleanups that came about while
updating imports; most of these involve replacing things like

`let rect = Rect::from_origin_size(Point::ZERO, my_size);`

with,

`let rect = my_size.to_rect();`.