### PR TITLE
Fix panic in TextBox when data changes externally

### DIFF
--- a/druid/src/text/editor.rs
+++ b/druid/src/text/editor.rs
@@ -148,7 +148,7 @@ impl<T: TextStorage + EditableText> Editor<T> {
     pub fn update(&mut self, ctx: &mut UpdateCtx, new_data: &T, env: &Env) {
         if self.data_is_stale(new_data) {
             self.layout.set_text(new_data.clone());
-            self.selection.constrain_to(new_data);
+            self.selection = self.selection.constrained(new_data);
             ctx.request_paint();
         } else if self.layout.needs_rebuild_after_update(ctx) {
             ctx.request_paint();

--- a/druid/src/text/selection.rs
+++ b/druid/src/text/selection.rs
@@ -44,6 +44,15 @@ impl Selection {
         }
     }
 
+    /// Create a new selection constrained to the length of the provided text.
+    #[must_use = "constrained constructs a new Selection"]
+    pub fn constrained(mut self, s: &impl EditableText) -> Self {
+        let s_len = s.len();
+        self.start = min(self.start, s_len);
+        self.end = min(self.end, s_len);
+        self
+    }
+
     /// Create a selection that starts at the beginning and ends at text length.
     /// TODO: can text length be at a non-codepoint or a non-grapheme?
     pub fn all(&mut self, text: &impl EditableText) {
@@ -84,13 +93,5 @@ impl Selection {
     /// Return a range from smallest to largest index
     pub fn range(self) -> Range<usize> {
         self.min()..self.max()
-    }
-
-    /// Constrain selection to be not greater than input string
-    pub fn constrain_to(mut self, s: &impl EditableText) -> Self {
-        let s_len = s.len();
-        self.start = min(self.start, s_len);
-        self.end = min(self.end, s_len);
-        self
     }
 }


### PR DESCRIPTION
We were not correctly updating the selection as required.

This will fail CI until #1291 is merged.

cc @totsteps, this is your bug from yesterday, thanks again for the testing!