### PR TITLE
Expose baseline on TextLayout, add Baseline alignment to Flex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - `RichText` and `Attribute` types for creating rich text ([#1255] by [@cmyr])
 - `request_timer` can now be called from `LayoutCtx` ([#1278] by [@Majora320])
 - TextBox supports vertical movement ([#1280] by [@cmyr])
+- Widgets can specify a baseline, flex rows can align baselines ([#1295] by [@cmyr])
 
 ### Changed
 
@@ -495,6 +496,7 @@ Last release without a changelog :(
 [#1276]: https://github.com/linebender/druid/pull/1276
 [#1278]: https://github.com/linebender/druid/pull/1278
 [#1280]: https://github.com/linebender/druid/pull/1280
+[#1295]: https://github.com/linebender/druid/pull/1280
 [#1298]: https://github.com/linebender/druid/pull/1298
 [#1299]: https://github.com/linebender/druid/pull/1299
 

--- a/druid/examples/flex.rs
+++ b/druid/examples/flex.rs
@@ -146,6 +146,7 @@ fn make_control_row() -> impl Widget<AppState> {
                         ("Start", CrossAxisAlignment::Start),
                         ("Center", CrossAxisAlignment::Center),
                         ("End", CrossAxisAlignment::End),
+                        ("Baseline", CrossAxisAlignment::Baseline),
                     ])
                     .lens(Params::cross_alignment),
                 ),
@@ -261,11 +262,13 @@ fn build_widget(state: &Params) -> Box<dyn Widget<AppState>> {
 
     space_if_needed(&mut flex, state);
 
-    flex.add_child(Label::new(|data: &DemoState, _: &Env| {
-        data.input_text.clone()
-    }));
+    flex.add_child(
+        Label::new(|data: &DemoState, _: &Env| data.input_text.clone()).with_text_size(32.0),
+    );
     space_if_needed(&mut flex, state);
     flex.add_child(Checkbox::new("Demo").lens(DemoState::enabled));
+    space_if_needed(&mut flex, state);
+    flex.add_child(Switch::new().lens(DemoState::enabled));
     space_if_needed(&mut flex, state);
     flex.add_child(Slider::new().lens(DemoState::volume));
     space_if_needed(&mut flex, state);
@@ -278,8 +281,6 @@ fn build_widget(state: &Params) -> Box<dyn Widget<AppState>> {
             .with_wraparound(true)
             .lens(DemoState::volume),
     );
-    space_if_needed(&mut flex, state);
-    flex.add_child(Switch::new().lens(DemoState::enabled));
 
     let mut flex = SizedBox::new(flex);
     if state.fix_minor_axis {

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -595,6 +595,19 @@ impl LayoutCtx<'_, '_> {
     pub fn set_paint_insets(&mut self, insets: impl Into<Insets>) {
         self.widget_state.paint_insets = insets.into().nonnegative();
     }
+
+    /// Set an explicit baseline position for this widget.
+    ///
+    /// The baseline position is used to align widgets that contain text,
+    /// such as buttons, labels, and other controls. It may also be used
+    /// by other widgets that are opinionated about how they are aligned
+    /// relative to neighbouring text, such as switches or checkboxes.
+    ///
+    /// The provided value should be the distance from the *bottom* of the
+    /// widget to the baseline.
+    pub fn set_baseline_offset(&mut self, baseline: f64) {
+        self.widget_state.baseline_offset = baseline
+    }
 }
 
 impl PaintCtx<'_, '_, '_> {

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -80,6 +80,13 @@ pub(crate) struct WidgetState {
     /// drop shadows or overflowing text.
     pub(crate) paint_insets: Insets,
 
+    /// The offset of the baseline relative to the bottom of the widget.
+    ///
+    /// In general, this will be zero; the bottom of the widget will be considered
+    /// the baseline. Widgets that contain text or controls that expect to be
+    /// laid out alongside text can set this as appropriate.
+    pub(crate) baseline_offset: f64,
+
     // The region that needs to be repainted, relative to the widget's bounds.
     pub(crate) invalid: Region,
 
@@ -311,6 +318,11 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
         let parent_bounds = Rect::ZERO.with_size(parent_size);
         let union_pant_rect = self.paint_rect().union(parent_bounds);
         union_pant_rect - parent_bounds
+    }
+
+    /// The distance from the bottom of this widget to the baseline.
+    pub fn baseline_offset(&self) -> f64 {
+        self.state.baseline_offset
     }
 
     /// Determines if the provided `mouse_pos` is inside `rect`
@@ -884,6 +896,7 @@ impl WidgetState {
             paint_insets: Insets::ZERO,
             invalid: Region::EMPTY,
             viewport_offset: Vec2::ZERO,
+            baseline_offset: 0.0,
             is_hot: false,
             needs_layout: false,
             is_active: false,

--- a/druid/src/text/layout.rs
+++ b/druid/src/text/layout.rs
@@ -57,6 +57,16 @@ pub struct TextLayout<T> {
     alignment: TextAlignment,
 }
 
+/// Metrics describing the layout text.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LayoutMetrics {
+    /// The nominal size of the layout.
+    pub size: Size,
+    /// The distance from the nominal top of the layout to the first baseline.
+    pub first_baseline: f64,
+    //TODO: add inking_rect
+}
+
 impl<T> TextLayout<T> {
     /// Create a new `TextLayout` object.
     ///
@@ -192,6 +202,31 @@ impl<T: TextStorage> TextLayout<T> {
             .as_ref()
             .map(|layout| layout.size())
             .unwrap_or_default()
+    }
+
+    /// Return the text's [`LayoutMetrics`].
+    ///
+    /// This is not meaningful until [`rebuild_if_needed`] has been called.
+    ///
+    /// [`rebuild_if_needed`]: #method.rebuild_if_needed
+    /// [`LayoutMetrics`]: struct.LayoutMetrics.html
+    pub fn layout_metrics(&self) -> LayoutMetrics {
+        debug_assert!(
+            self.layout.is_some(),
+            "TextLayout::layout_metrics called without rebuilding layout object. Text was '{}'",
+            self.text().as_ref().map(|s| s.as_str()).unwrap_or_default()
+        );
+
+        if let Some(layout) = self.layout.as_ref() {
+            let first_baseline = layout.line_metric(0).unwrap().baseline;
+            let size = layout.size();
+            LayoutMetrics {
+                size,
+                first_baseline,
+            }
+        } else {
+            LayoutMetrics::default()
+        }
     }
 
     /// For a given `Point` (relative to this object's origin), returns index

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -137,20 +137,16 @@ impl<T: Data> Widget<T> for Button<T> {
         self.label.update(ctx, old_data, data, env)
     }
 
-    fn layout(
-        &mut self,
-        layout_ctx: &mut LayoutCtx,
-        bc: &BoxConstraints,
-        data: &T,
-        env: &Env,
-    ) -> Size {
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         bc.debug_check("Button");
         let padding = Size::new(LABEL_INSETS.x_value(), LABEL_INSETS.y_value());
         let label_bc = bc.shrink(padding).loosen();
-        self.label_size = self.label.layout(layout_ctx, &label_bc, data, env);
+        self.label_size = self.label.layout(ctx, &label_bc, data, env);
         // HACK: to make sure we look okay at default sizes when beside a textbox,
         // we make sure we will have at least the same height as the default textbox.
         let min_height = env.get(theme::BORDERED_WIDGET_HEIGHT);
+        let baseline = self.label.baseline_offset();
+        ctx.set_baseline_offset(baseline + LABEL_INSETS.y1);
 
         bc.constrain(Size::new(
             self.label_size.width + padding.width,

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -79,7 +79,10 @@ impl Widget<bool> for Checkbox {
             check_size + x_padding + label_size.width,
             check_size.max(label_size.height),
         );
-        bc.constrain(desired_size)
+        let our_size = bc.constrain(desired_size);
+        let baseline = self.child_label.baseline_offset() + (our_size.height - label_size.height);
+        ctx.set_baseline_offset(baseline);
+        our_size
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &bool, env: &Env) {

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -268,6 +268,12 @@ impl<T: TextStorage> RawLabel<T> {
     pub fn draw_at(&self, ctx: &mut PaintCtx, origin: impl Into<Point>) {
         self.layout.draw(ctx, origin)
     }
+
+    /// Return the offset of the first baseline relative to the bottom of the widget.
+    pub fn baseline_offset(&self) -> f64 {
+        let text_metrics = self.layout.layout_metrics();
+        text_metrics.size.height - text_metrics.first_baseline
+    }
 }
 
 impl<T: TextStorage> Label<T> {
@@ -533,9 +539,12 @@ impl<T: TextStorage> Widget<T> for RawLabel<T> {
         self.layout.set_wrap_width(width);
         self.layout.rebuild_if_needed(ctx.text(), env);
 
-        let mut text_size = self.layout.size();
-        text_size.width += 2. * LABEL_X_PADDING;
-        bc.constrain(text_size)
+        let text_metrics = self.layout.layout_metrics();
+        ctx.set_baseline_offset(text_metrics.size.height - text_metrics.first_baseline);
+        bc.constrain(Size::new(
+            text_metrics.size.width + 2. * LABEL_X_PADDING,
+            text_metrics.size.height,
+        ))
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, _data: &T, _env: &Env) {

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -18,6 +18,10 @@ use crate::kurbo::{Circle, Shape};
 use crate::widget::prelude::*;
 use crate::{theme, LinearGradient, Point, Rect, UnitPoint};
 
+const TRACK_THICKNESS: f64 = 4.0;
+const BORDER_WIDTH: f64 = 2.0;
+const KNOB_STROKE_WIDTH: f64 = 2.0;
+
 /// A slider, allowing interactive update of a numeric value.
 ///
 /// This slider implements `Widget<f64>`, and works on values clamped
@@ -117,16 +121,12 @@ impl Widget<f64> for Slider {
         ctx.request_paint();
     }
 
-    fn layout(
-        &mut self,
-        _layout_ctx: &mut LayoutCtx,
-        bc: &BoxConstraints,
-        _data: &f64,
-        env: &Env,
-    ) -> Size {
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, _data: &f64, env: &Env) -> Size {
         bc.debug_check("Slider");
         let height = env.get(theme::BASIC_WIDGET_HEIGHT);
         let width = env.get(theme::WIDE_WIDGET_WIDTH);
+        let baseline_offset = (height / 2.0) - TRACK_THICKNESS;
+        ctx.set_baseline_offset(baseline_offset);
         bc.constrain((width, height))
     }
 
@@ -134,16 +134,13 @@ impl Widget<f64> for Slider {
         let clamped = self.normalize(*data);
         let rect = ctx.size().to_rect();
         let knob_size = env.get(theme::BASIC_WIDGET_HEIGHT);
-        let track_thickness = 4.;
-        let border_width = 2.;
-        let knob_stroke_width = 2.;
 
         //Paint the background
         let background_width = rect.width() - knob_size;
-        let background_origin = Point::new(knob_size / 2., (knob_size - track_thickness) / 2.);
-        let background_size = Size::new(background_width, track_thickness);
+        let background_origin = Point::new(knob_size / 2., (knob_size - TRACK_THICKNESS) / 2.);
+        let background_size = Size::new(background_width, TRACK_THICKNESS);
         let background_rect = Rect::from_origin_size(background_origin, background_size)
-            .inset(-border_width / 2.)
+            .inset(-BORDER_WIDTH / 2.)
             .to_rounded_rect(2.);
 
         let background_gradient = LinearGradient::new(
@@ -155,7 +152,7 @@ impl Widget<f64> for Slider {
             ),
         );
 
-        ctx.stroke(background_rect, &env.get(theme::BORDER_DARK), border_width);
+        ctx.stroke(background_rect, &env.get(theme::BORDER_DARK), BORDER_WIDTH);
 
         ctx.fill(background_rect, &background_gradient);
 
@@ -165,7 +162,7 @@ impl Widget<f64> for Slider {
 
         let knob_position = (rect.width() - knob_size) * clamped + knob_size / 2.;
         self.knob_pos = Point::new(knob_position, knob_size / 2.);
-        let knob_circle = Circle::new(self.knob_pos, (knob_size - knob_stroke_width) / 2.);
+        let knob_circle = Circle::new(self.knob_pos, (knob_size - KNOB_STROKE_WIDTH) / 2.);
 
         let normal_knob_gradient = LinearGradient::new(
             UnitPoint::TOP,
@@ -197,7 +194,7 @@ impl Widget<f64> for Slider {
             env.get(theme::FOREGROUND_DARK)
         };
 
-        ctx.stroke(knob_circle, &border_color, knob_stroke_width);
+        ctx.stroke(knob_circle, &border_color, KNOB_STROKE_WIDTH);
 
         //Actually paint the knob
         ctx.fill(knob_circle, &knob_gradient);

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -169,9 +169,16 @@ impl Widget<bool> for Switch {
         }
     }
 
-    fn layout(&mut self, _ctx: &mut LayoutCtx, bc: &BoxConstraints, _: &bool, env: &Env) -> Size {
-        let width = env.get(theme::BORDERED_WIDGET_HEIGHT) * SWITCH_WIDTH_RATIO;
-        bc.constrain(Size::new(width, env.get(theme::BORDERED_WIDGET_HEIGHT)))
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, _: &bool, env: &Env) -> Size {
+        let text_metrics = self.on_text.layout_metrics();
+        let height = env.get(theme::BORDERED_WIDGET_HEIGHT);
+        let width = height * SWITCH_WIDTH_RATIO;
+
+        let label_y = (height - text_metrics.size.height).max(0.0) / 2.0;
+        let text_bottom_padding = height - (text_metrics.size.height + label_y);
+        let text_baseline_offset = text_metrics.size.height - text_metrics.first_baseline;
+        ctx.set_baseline_offset(text_bottom_padding + text_baseline_offset);
+        bc.constrain(Size::new(width, height))
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &bool, env: &Env) {

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -268,21 +268,27 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, _data: &T, env: &Env) -> Size {
+        let width = env.get(theme::WIDE_WIDGET_WIDTH);
+        let min_height = env.get(theme::BORDERED_WIDGET_HEIGHT);
+
         self.placeholder.rebuild_if_needed(ctx.text(), env);
         if self.multiline {
             self.editor
                 .set_wrap_width(bc.max().width - TEXT_INSETS.x_value());
         }
         self.editor.rebuild_if_needed(ctx.text(), env);
-        let size = self.editor.layout().size();
 
-        let width = env.get(theme::WIDE_WIDGET_WIDTH);
-        let min_height = env.get(theme::BORDERED_WIDGET_HEIGHT);
-
-        let text_height = size.height + TEXT_INSETS.y_value();
+        let text_metrics = self.editor.layout().layout_metrics();
+        let text_height = text_metrics.size.height + TEXT_INSETS.y_value();
         let height = text_height.max(min_height);
 
-        bc.constrain((width, height))
+        let size = bc.constrain((width, height));
+        let bottom_padding = (size.height - text_metrics.size.height) / 2.0;
+        let baseline_off =
+            bottom_padding + (text_metrics.size.height - text_metrics.first_baseline);
+        ctx.set_baseline_offset(baseline_off);
+
+        size
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {


### PR DESCRIPTION
This introduces the idea of baseline alignment as a component
of layout.

During their `layout` calls, widgets can specify their baseline_offset,
which is the distance from the bottom of their reported size to their
baseline.

Generally, the baseline will be derived from some text object,
although widgets that do not contain text but which appear next
to widgets that do can specify an arbitrary baseline.

This also adds CrossAxisAlignment::Baseline to Flex; this is
only meaningful in a Flex::row, in which case it aligns all of
its children based on their own reported baselines.

The best place to play around with this code is in examples/flex.rs.

![Screen Shot 2020-10-08 at 6 20 10 PM](https://user-images.githubusercontent.com/3330916/95519350-e82bec80-0992-11eb-8791-65afe04998cb.png)
![Screen Shot 2020-10-08 at 6 20 21 PM](https://user-images.githubusercontent.com/3330916/95519361-ee21cd80-0992-11eb-8e52-2e758556798d.png)
![Screen Shot 2020-10-08 at 6 20 28 PM](https://user-images.githubusercontent.com/3330916/95519372-f37f1800-0992-11eb-920d-ac8d0ed342dd.png)
![Screen Shot 2020-10-08 at 6 20 36 PM](https://user-images.githubusercontent.com/3330916/95519387-f7ab3580-0992-11eb-821d-86f063b11768.png)


This is also the last of the major outstanding text stuff??