### PR TITLE
[ci] Disable clippy + wasm in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,30 +179,31 @@ jobs:
           override: true
 
       # Clippy wasm32 relevant packages in deeper-to-higher dependency order
-      - name: cargo clippy druid-shell
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path=druid-shell/Cargo.toml --all-targets --target wasm32-unknown-unknown -- -D warnings
+      # FIXME: reenable clippy when rustc >= 1.47.1
+      #- name: cargo clippy druid-shell (wasm)
+        #uses: actions-rs/cargo@v1
+        #with:
+          #command: clippy
+          #args: --manifest-path=druid-shell/Cargo.toml --all-targets --target wasm32-unknown-unknown -- -D warnings
 
-      - name: cargo clippy druid
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          # TODO: Add svg feature when it's no longer broken with wasm
-          args: --manifest-path=druid/Cargo.toml --all-targets --features=image,im --target wasm32-unknown-unknown -- -D warnings
+      #- name: cargo clippy druid (wasm)
+        #uses: actions-rs/cargo@v1
+        #with:
+          #command: clippy
+          ## TODO: Add svg feature when it's no longer broken with wasm
+          #args: --manifest-path=druid/Cargo.toml --all-targets --features=image,im --target wasm32-unknown-unknown -- -D warnings
 
-      - name: cargo clippy druid-derive
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path=druid-derive/Cargo.toml --all-targets --target wasm32-unknown-unknown -- -D warnings
+      #- name: cargo clippy druid-derive (wasm)
+        #uses: actions-rs/cargo@v1
+        #with:
+          #command: clippy
+          #args: --manifest-path=druid-derive/Cargo.toml --all-targets --target wasm32-unknown-unknown -- -D warnings
 
-      - name: cargo clippy book examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path=docs/book_examples/Cargo.toml --all-targets --target wasm32-unknown-unknown -- -D warnings
+      #- name: cargo clippy book examples (wasm)
+        #uses: actions-rs/cargo@v1
+        #with:
+          #command: clippy
+          #args: --manifest-path=docs/book_examples/Cargo.toml --all-targets --target wasm32-unknown-unknown -- -D warnings
 
       # Test wasm32 relevant packages in deeper-to-higher dependency order
       # TODO: Find a way to make tests work. Until then the tests are merely compiled.
@@ -231,22 +232,22 @@ jobs:
           command: test
           args: --manifest-path=docs/book_examples/Cargo.toml --no-run --target wasm32-unknown-unknown
 
-      # Clippy and build the special druid-web-examples package.
-      - name: cargo clippy druid-web-examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path=druid/examples/web/Cargo.toml --target wasm32-unknown-unknown -- -D warnings
+      ## Clippy and build the special druid-web-examples package.
+      #- name: cargo clippy druid-web-examples
+        #uses: actions-rs/cargo@v1
+        #with:
+          #command: clippy
+          #args: --manifest-path=druid/examples/web/Cargo.toml --target wasm32-unknown-unknown -- -D warnings
 
       - name: wasm-pack build examples
         run: wasm-pack build --dev --target web druid/examples/web
 
-      # Clippy and build the hello_web example
-      - name: cargo clippy hello_web example
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path=druid/examples/hello_web/Cargo.toml --target wasm32-unknown-unknown -- -D warnings
+      ## Clippy and build the hello_web example
+      #- name: cargo clippy hello_web example
+        #uses: actions-rs/cargo@v1
+        #with:
+          #command: clippy
+          #args: --manifest-path=druid/examples/hello_web/Cargo.toml --target wasm32-unknown-unknown -- -D warnings
 
       - name: wasm-pack build hello_web example
         run: wasm-pack build --dev --target web druid/examples/hello_web


### PR DESCRIPTION
This will still the tests against wasm, but clippy is disabled
until further notice. This can be turned back on the next time
we get an update to cargo.

See https://github.com/rust-lang/rust-clippy/issues/6140