### PR TITLE
Use Handled instead of bools.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - Window construction: WindowDesc decomposed to PendingWindow and WindowConfig to allow for sub-windows and reconfiguration. ([#1235] by [@rjwittams])
 - `LocalizedString` and `LabelText` use `ArcStr` instead of String ([#1245] by [@cmyr])
 - `LensWrap` widget moved into widget module ([#1251] by [@cmyr])
+- `Delegate::command` now returns `Handled`, not `bool` ([#1298] by [@jneem])
 
 ### Deprecated
 
@@ -492,6 +493,7 @@ Last release without a changelog :(
 [#1276]: https://github.com/linebender/druid/pull/1276
 [#1278]: https://github.com/linebender/druid/pull/1278
 [#1280]: https://github.com/linebender/druid/pull/1280
+[#1298]: https://github.com/linebender/druid/pull/1298
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master
 [0.6.0]: https://github.com/linebender/druid/compare/v0.5.0...v0.6.0

--- a/druid/examples/blocking_function.rs
+++ b/druid/examples/blocking_function.rs
@@ -23,7 +23,7 @@ use druid::{
 
 use druid::{
     widget::{Button, Either, Flex, Label, Spinner},
-    Target,
+    Handled, Target,
 };
 
 const FINISH_SLOW_FUNCTION: Selector<u32> = Selector::new("finish_slow_function");
@@ -59,12 +59,14 @@ impl AppDelegate<AppState> for Delegate {
         cmd: &Command,
         data: &mut AppState,
         _env: &Env,
-    ) -> bool {
+    ) -> Handled {
         if let Some(number) = cmd.get(FINISH_SLOW_FUNCTION) {
             data.processing = false;
             data.value = *number;
+            Handled::Yes
+        } else {
+            Handled::No
         }
-        true
     }
 }
 

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -21,7 +21,8 @@ use druid::widget::{
 use druid::Target::Global;
 use druid::{
     commands as sys_cmds, AppDelegate, AppLauncher, Application, Color, Command, ContextMenu, Data,
-    DelegateCtx, LocalizedString, MenuDesc, MenuItem, Selector, Target, WindowDesc, WindowId,
+    DelegateCtx, Handled, LocalizedString, MenuDesc, MenuItem, Selector, Target, WindowDesc,
+    WindowId,
 };
 use log::info;
 
@@ -153,14 +154,14 @@ impl AppDelegate<State> for Delegate {
         cmd: &Command,
         data: &mut State,
         _env: &Env,
-    ) -> bool {
+    ) -> Handled {
         match cmd {
             _ if cmd.is(sys_cmds::NEW_FILE) => {
                 let new_win = WindowDesc::new(ui_builder)
                     .menu(make_menu(data))
                     .window_size((data.selected as f64 * 100.0 + 300.0, 500.0));
                 ctx.new_window(new_win);
-                false
+                Handled::Yes
             }
             _ if cmd.is(MENU_COUNT_ACTION) => {
                 data.selected = *cmd.get_unchecked(MENU_COUNT_ACTION);
@@ -168,7 +169,7 @@ impl AppDelegate<State> for Delegate {
                 for id in &self.windows {
                     ctx.set_menu(menu.clone(), *id);
                 }
-                false
+                Handled::Yes
             }
             // wouldn't it be nice if a menu (like a button) could just mutate state
             // directly if desired?
@@ -178,7 +179,7 @@ impl AppDelegate<State> for Delegate {
                 for id in &self.windows {
                     ctx.set_menu(menu.clone(), *id);
                 }
-                false
+                Handled::Yes
             }
             _ if cmd.is(MENU_DECREMENT_ACTION) => {
                 data.menu_count = data.menu_count.saturating_sub(1);
@@ -186,13 +187,13 @@ impl AppDelegate<State> for Delegate {
                 for id in &self.windows {
                     ctx.set_menu(menu.clone(), *id);
                 }
-                false
+                Handled::Yes
             }
             _ if cmd.is(MENU_SWITCH_GLOW_ACTION) => {
                 data.glow_hot = !data.glow_hot;
-                false
+                Handled::Yes
             }
-            _ => true,
+            _ => Handled::No,
         }
     }
 

--- a/druid/examples/open_save.rs
+++ b/druid/examples/open_save.rs
@@ -15,7 +15,7 @@
 use druid::widget::{Align, Button, Flex, TextBox};
 use druid::{
     commands, AppDelegate, AppLauncher, Command, DelegateCtx, Env, FileDialogOptions, FileSpec,
-    LocalizedString, Target, Widget, WindowDesc,
+    Handled, LocalizedString, Target, Widget, WindowDesc,
 };
 
 struct Delegate;
@@ -84,12 +84,12 @@ impl AppDelegate<String> for Delegate {
         cmd: &Command,
         data: &mut String,
         _env: &Env,
-    ) -> bool {
+    ) -> Handled {
         if let Some(Some(file_info)) = cmd.get(commands::SAVE_FILE) {
             if let Err(e) = std::fs::write(file_info.path(), &data[..]) {
                 println!("Error writing file: {}", e);
             }
-            return false;
+            return Handled::Yes;
         }
         if let Some(file_info) = cmd.get(commands::OPEN_FILE) {
             match std::fs::read_to_string(file_info.path()) {
@@ -101,8 +101,8 @@ impl AppDelegate<String> for Delegate {
                     println!("Error opening file: {}", e);
                 }
             }
-            return false;
+            return Handled::Yes;
         }
-        true
+        Handled::No
     }
 }

--- a/druid/src/app_delegate.rs
+++ b/druid/src/app_delegate.rs
@@ -122,7 +122,7 @@ pub trait AppDelegate<T: Data> {
     /// This function is called with each ([`Target`], [`Command`]) pair before
     /// they are sent down the tree.
     ///
-    /// If your implementation returns `Handled::Unhandled`, the command will be sent down
+    /// If your implementation returns `Handled::No`, the command will be sent down
     /// the widget tree. Otherwise it will not.
     ///
     /// To do anything fancier than this, you can submit arbitary commands

--- a/druid/src/app_delegate.rs
+++ b/druid/src/app_delegate.rs
@@ -17,7 +17,7 @@
 use std::any::{Any, TypeId};
 
 use crate::{
-    commands, core::CommandQueue, Command, Data, Env, Event, MenuDesc, SingleUse, Target,
+    commands, core::CommandQueue, Command, Data, Env, Event, Handled, MenuDesc, SingleUse, Target,
     WindowDesc, WindowId,
 };
 
@@ -122,7 +122,7 @@ pub trait AppDelegate<T: Data> {
     /// This function is called with each ([`Target`], [`Command`]) pair before
     /// they are sent down the tree.
     ///
-    /// If your implementation returns `true`, the command will be sent down
+    /// If your implementation returns `Handled::Unhandled`, the command will be sent down
     /// the widget tree. Otherwise it will not.
     ///
     /// To do anything fancier than this, you can submit arbitary commands
@@ -138,8 +138,8 @@ pub trait AppDelegate<T: Data> {
         cmd: &Command,
         data: &mut T,
         env: &Env,
-    ) -> bool {
-        true
+    ) -> Handled {
+        Handled::No
     }
 
     /// The handler for window creation events.

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -200,6 +200,7 @@ pub use localization::LocalizedString;
 pub use menu::{sys as platform_menus, ContextMenu, MenuDesc, MenuItem};
 pub use mouse::MouseEvent;
 pub use text::{ArcStr, FontDescriptor, TextLayout};
+pub use util::Handled;
 pub use widget::{Widget, WidgetExt, WidgetId};
 pub use win_handler::DruidHandler;
 pub use window::{Window, WindowId};

--- a/druid/src/util.rs
+++ b/druid/src/util.rs
@@ -65,9 +65,11 @@ impl Handled {
     pub fn is_handled(self) -> bool {
         self == Handled::Yes
     }
+}
 
-    /// Returns `Handled` if `handled` is true, and `Unhandled` otherwise.
-    pub fn from_handled(handled: bool) -> Handled {
+impl From<bool> for Handled {
+    /// Returns `Handled::Yes` if `handled` is true, and `Handled::No` otherwise.
+    fn from(handled: bool) -> Handled {
         if handled {
             Handled::Yes
         } else {

--- a/druid/src/util.rs
+++ b/druid/src/util.rs
@@ -63,7 +63,7 @@ pub enum Handled {
 impl Handled {
     /// Has the event been handled yet?
     pub fn is_handled(self) -> bool {
-        matches!(self, Handled::Yes)
+        self == Handled::Yes
     }
 
     /// Returns `Handled` if `handled` is true, and `Unhandled` otherwise.

--- a/druid/src/util.rs
+++ b/druid/src/util.rs
@@ -50,3 +50,28 @@ where
         }
     }
 }
+
+/// An enum for specifying whether an event was handled.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Handled {
+    /// An event was already handled, and shouldn't be propagated to other event handlers.
+    Yes,
+    /// An event has not yet been handled.
+    No,
+}
+
+impl Handled {
+    /// Has the event been handled yet?
+    pub fn is_handled(self) -> bool {
+        matches!(self, Handled::Yes)
+    }
+
+    /// Returns `Handled` if `handled` is true, and `Unhandled` otherwise.
+    pub fn from_handled(handled: bool) -> Handled {
+        if handled {
+            Handled::Yes
+        } else {
+            Handled::No
+        }
+    }
+}

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -321,8 +321,6 @@ impl<T: Data> Inner<T> {
 
     fn dispatch_cmd(&mut self, cmd: Command) -> Handled {
         let handled = self.delegate_cmd(&cmd);
-        // We do the update whether or not the command was handled, because the delegate has
-        // arbitrary user code in it: it could change the data but return Handled::No.
         self.do_update();
         if handled.is_handled() {
             return handled;

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -30,7 +30,7 @@ use crate::util::ExtendDrain;
 use crate::widget::LabelText;
 use crate::win_handler::RUN_COMMANDS_TOKEN;
 use crate::{
-    BoxConstraints, Command, Data, Env, Event, EventCtx, ExtEventSink, InternalEvent,
+    BoxConstraints, Command, Data, Env, Event, EventCtx, ExtEventSink, Handled, InternalEvent,
     InternalLifeCycle, LayoutCtx, LifeCycle, LifeCycleCtx, MenuDesc, PaintCtx, Point, Size,
     TimerToken, UpdateCtx, Widget, WidgetId, WidgetPod,
 };
@@ -173,7 +173,7 @@ impl<T: Data> Window<T> {
         event: Event,
         data: &mut T,
         env: &Env,
-    ) -> bool {
+    ) -> Handled {
         match &event {
             Event::WindowSize(size) => self.size = *size,
             Event::MouseDown(e) | Event::MouseUp(e) | Event::MouseMove(e) | Event::Wheel(e) => {
@@ -194,7 +194,7 @@ impl<T: Data> Window<T> {
                     Event::Internal(InternalEvent::RouteTimer(token, *widget_id))
                 } else {
                     log::error!("No widget found for timer {:?}", token);
-                    return false;
+                    return Handled::No;
                 }
             }
             other => other,
@@ -223,7 +223,7 @@ impl<T: Data> Window<T> {
             };
 
             self.root.event(&mut ctx, &event, data, env);
-            ctx.is_handled
+            Handled::from_handled(ctx.is_handled)
         };
 
         // Clean up the timer token and do it immediately after the event handling

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -223,7 +223,7 @@ impl<T: Data> Window<T> {
             };
 
             self.root.event(&mut ctx, &event, data, env);
-            Handled::from_handled(ctx.is_handled)
+            Handled::from(ctx.is_handled)
         };
 
         // Clean up the timer token and do it immediately after the event handling


### PR DESCRIPTION
This makes some "is this event handled"-style return types more typey, and it also includes a better fix for #1279. I originally went with `Handled::Handled` and `Handled::Unhandled`, but it seemed a bit redundant.