### PR TITLE
Make open/save dialogs no longer synchronous (in GTK)

### DIFF
--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -72,8 +72,8 @@ pub use region::Region;
 pub use scale::{Scalable, Scale, ScaledArea};
 pub use screen::{Monitor, Screen};
 pub use window::{
-    IdleHandle, IdleToken, TimerToken, WinHandler, WindowBuilder, WindowHandle, WindowLevel,
-    WindowState,
+    FileDialogToken, IdleHandle, IdleToken, TimerToken, WinHandler, WindowBuilder, WindowHandle,
+    WindowLevel, WindowState,
 };
 
 pub use keyboard_types;

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -18,7 +18,6 @@ use std::any::Any;
 use std::cell::{Cell, RefCell};
 use std::convert::TryFrom;
 use std::ffi::c_void;
-use std::ffi::OsString;
 use std::os::raw::{c_int, c_uint};
 use std::panic::Location;
 use std::ptr;
@@ -45,7 +44,7 @@ use crate::piet::ImageFormat;
 use crate::region::Region;
 use crate::scale::{Scalable, Scale, ScaledArea};
 use crate::window;
-use crate::window::{IdleToken, TimerToken, WinHandler, WindowLevel};
+use crate::window::{DeferredOp, FileDialogToken, IdleToken, TimerToken, WinHandler, WindowLevel};
 
 use super::application::Application;
 use super::dialog;
@@ -130,6 +129,8 @@ pub(crate) struct WindowState {
     /// Used to determine whether to honor close requests from the system: we inhibit them unless
     /// this is true, and this gets set to true when our client requests a close.
     closing: Cell<bool>,
+    /// A counter for generating unique tokens.
+    next_token: Cell<usize>,
     drawing_area: DrawingArea,
     // A cairo surface for us to render to; we copy this to the drawing_area whenever necessary.
     // This extra buffer is necessitated by DrawingArea's painting model: when our paint callback
@@ -149,6 +150,7 @@ pub(crate) struct WindowState {
     pub(crate) handler: RefCell<Box<dyn WinHandler>>,
     idle_queue: Arc<Mutex<Vec<IdleKind>>>,
     current_keycode: Cell<Option<u16>>,
+    deferred_queue: RefCell<Vec<DeferredOp>>,
 }
 
 #[derive(Clone)]
@@ -243,6 +245,7 @@ impl WindowBuilder {
             scale: Cell::new(scale),
             area: Cell::new(area),
             closing: Cell::new(false),
+            next_token: Cell::new(0),
             drawing_area,
             surface: RefCell::new(None),
             surface_size: Cell::new((0, 0)),
@@ -250,6 +253,7 @@ impl WindowBuilder {
             handler: RefCell::new(handler),
             idle_queue: Arc::new(Mutex::new(vec![])),
             current_keycode: Cell::new(None),
+            deferred_queue: RefCell::new(Vec::new()),
         });
 
         self.app
@@ -623,7 +627,10 @@ impl WindowState {
             return None;
         }
 
-        self.with_handler_and_dont_check_the_other_borrows(f)
+        let ret = self.with_handler_and_dont_check_the_other_borrows(f);
+
+        self.run_deferred();
+        ret
     }
 
     #[track_caller]
@@ -638,6 +645,12 @@ impl WindowState {
                 None
             }
         }
+    }
+
+    fn next_token(&self) -> usize {
+        let next = self.next_token.get();
+        self.next_token.set(next + 1);
+        next
     }
 
     fn resize_surface(&self, width: i32, height: i32) -> Result<(), anyhow::Error> {
@@ -688,6 +701,39 @@ impl WindowState {
             self.window.queue_draw();
         } else {
             log::warn!("Not invalidating rect because region already borrowed");
+        }
+    }
+
+    /// Pushes a deferred op onto the queue.
+    fn defer(&self, op: DeferredOp) {
+        self.deferred_queue.borrow_mut().push(op);
+    }
+
+    fn run_deferred(&self) {
+        let queue = self.deferred_queue.replace(Vec::new());
+        for op in queue {
+            match op {
+                DeferredOp::Open(options, token) => {
+                    let file_info = dialog::get_file_dialog_path(
+                        self.window.upcast_ref(),
+                        FileDialogType::Open,
+                        options,
+                    )
+                    .ok()
+                    .map(|s| FileInfo { path: s.into() });
+                    self.with_handler(|h| h.open_file(token, file_info));
+                }
+                DeferredOp::SaveAs(options, token) => {
+                    let file_info = dialog::get_file_dialog_path(
+                        self.window.upcast_ref(),
+                        FileDialogType::Save,
+                        options,
+                    )
+                    .ok()
+                    .map(|s| FileInfo { path: s.into() });
+                    self.with_handler(|h| h.save_as(token, file_info));
+                }
+            }
         }
     }
 }
@@ -900,16 +946,34 @@ impl WindowHandle {
         }
     }
 
-    pub fn open_file_sync(&mut self, options: FileDialogOptions) -> Option<FileInfo> {
-        self.file_dialog(FileDialogType::Open, options)
-            .ok()
-            .map(|s| FileInfo { path: s.into() })
+    pub fn open_file(&mut self, options: FileDialogOptions) -> Option<FileDialogToken> {
+        if let Some(state) = self.state.upgrade() {
+            let tok = FileDialogToken::new(state.next_token());
+            state.defer(DeferredOp::Open(options, tok));
+            Some(tok)
+        } else {
+            None
+        }
     }
 
-    pub fn save_as_sync(&mut self, options: FileDialogOptions) -> Option<FileInfo> {
-        self.file_dialog(FileDialogType::Save, options)
-            .ok()
-            .map(|s| FileInfo { path: s.into() })
+    pub fn save_as(&mut self, options: FileDialogOptions) -> Option<FileDialogToken> {
+        if let Some(state) = self.state.upgrade() {
+            let tok = FileDialogToken::new(state.next_token());
+            state.defer(DeferredOp::SaveAs(options, tok));
+            Some(tok)
+        } else {
+            None
+        }
+    }
+
+    pub fn save_as_sync(&mut self, _options: FileDialogOptions) -> Option<FileInfo> {
+        log::error!("save as sync no longer supported on GTK");
+        None
+    }
+
+    pub fn open_file_sync(&mut self, _options: FileDialogOptions) -> Option<FileInfo> {
+        log::error!("open file sync no longer supported on GTK");
+        None
     }
 
     /// Get a handle that can be used to schedule an idle task.
@@ -969,18 +1033,6 @@ impl WindowHandle {
     pub fn set_title(&self, title: impl Into<String>) {
         if let Some(state) = self.state.upgrade() {
             state.window.set_title(&(title.into()));
-        }
-    }
-
-    fn file_dialog(
-        &self,
-        ty: FileDialogType,
-        options: FileDialogOptions,
-    ) -> Result<OsString, ShellError> {
-        if let Some(state) = self.state.upgrade() {
-            dialog::get_file_dialog_path(state.window.upcast_ref(), ty, options)
-        } else {
-            Err(anyhow!("Cannot upgrade state from weak pointer to arc").into())
         }
     }
 }

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -56,7 +56,7 @@ use crate::keyboard_types::KeyState;
 use crate::mouse::{Cursor, CursorDesc, MouseButton, MouseButtons, MouseEvent};
 use crate::region::Region;
 use crate::scale::Scale;
-use crate::window::{IdleToken, TimerToken, WinHandler, WindowLevel, WindowState};
+use crate::window::{FileDialogToken, IdleToken, TimerToken, WinHandler, WindowLevel, WindowState};
 use crate::Error;
 
 #[allow(non_upper_case_globals)]
@@ -938,9 +938,19 @@ impl WindowHandle {
             .map(|s| FileInfo { path: s.into() })
     }
 
+    pub fn open_file(&mut self, _options: FileDialogOptions) -> Option<FileDialogToken> {
+        // TODO: implement this and get rid of open_file_sync
+        None
+    }
+
     pub fn save_as_sync(&mut self, options: FileDialogOptions) -> Option<FileInfo> {
         dialog::get_file_dialog_path(FileDialogType::Save, options)
             .map(|s| FileInfo { path: s.into() })
+    }
+
+    pub fn save_as(&mut self, _options: FileDialogOptions) -> Option<FileDialogToken> {
+        // TODO: implement this and get rid of save_as_sync
+        None
     }
 
     /// Set the title for this menu.

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -42,7 +42,7 @@ use crate::keyboard::{KbKey, KeyState, Modifiers};
 use crate::mouse::{Cursor, CursorDesc, MouseButton, MouseButtons, MouseEvent};
 use crate::region::Region;
 use crate::window;
-use crate::window::{IdleToken, TimerToken, WinHandler, WindowLevel};
+use crate::window::{FileDialogToken, IdleToken, TimerToken, WinHandler, WindowLevel};
 
 // This is a macro instead of a function since KeyboardEvent and MouseEvent has identical functions
 // to query modifier key states.
@@ -571,11 +571,19 @@ impl WindowHandle {
             .map(|s| FileInfo { path: s.into() })
     }
 
+    pub fn open_file(&mut self, _options: FileDialogOptions) -> Option<FileDialogToken> {
+        None
+    }
+
     pub fn save_as_sync(&mut self, options: FileDialogOptions) -> Option<FileInfo> {
         log::warn!("save_as_sync is currently unimplemented for web.");
         self.file_dialog(FileDialogType::Save, options)
             .ok()
             .map(|s| FileInfo { path: s.into() })
+    }
+
+    pub fn save_as(&mut self, _options: FileDialogOptions) -> Option<FileDialogToken> {
+        None
     }
 
     fn render_soon(&self) {

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -66,7 +66,7 @@ use crate::mouse::{Cursor, CursorDesc, MouseButton, MouseButtons, MouseEvent};
 use crate::region::Region;
 use crate::scale::{Scalable, Scale, ScaledArea};
 use crate::window;
-use crate::window::{IdleToken, TimerToken, WinHandler, WindowLevel};
+use crate::window::{FileDialogToken, IdleToken, TimerToken, WinHandler, WindowLevel};
 
 /// The platform target DPI.
 ///
@@ -1856,6 +1856,11 @@ impl WindowHandle {
         }
     }
 
+    pub fn open_file(&mut self, _options: FileDialogOptions) -> Option<FileDialogToken> {
+        // TODO: implement this and remove open_file_sync
+        None
+    }
+
     /// Prompt the user to chose a file to open.
     ///
     /// Blocks while the user picks the file.
@@ -1868,6 +1873,11 @@ impl WindowHandle {
                     path: os_str.into(),
                 })
         }
+    }
+
+    pub fn save_as(&mut self, _options: FileDialogOptions) -> Option<FileDialogToken> {
+        // TODO: implement this and remove save_as_sync
+        None
     }
 
     /// Get the raw HWND handle, for uses that are not wrapped in

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -47,7 +47,7 @@ use crate::piet::{Piet, PietText, RenderContext};
 use crate::region::Region;
 use crate::scale::Scale;
 use crate::window;
-use crate::window::{IdleToken, TimerToken, WinHandler, WindowLevel};
+use crate::window::{FileDialogToken, IdleToken, TimerToken, WinHandler, WindowLevel};
 
 use super::application::Application;
 use super::keycodes;
@@ -1498,14 +1498,24 @@ impl WindowHandle {
     }
 
     pub fn open_file_sync(&mut self, _options: FileDialogOptions) -> Option<FileInfo> {
-        // TODO(x11/file_dialogs): implement WindowHandle::open_file_sync
         log::warn!("WindowHandle::open_file_sync is currently unimplemented for X11 platforms.");
         None
     }
 
+    pub fn open_file(&mut self, _options: FileDialogOptions) -> Option<FileDialogToken> {
+        // TODO(x11/file_dialogs): implement WindowHandle::open_file
+        log::warn!("WindowHandle::open_file is currently unimplemented for X11 platforms.");
+        None
+    }
+
     pub fn save_as_sync(&mut self, _options: FileDialogOptions) -> Option<FileInfo> {
-        // TODO(x11/file_dialogs): implement WindowHandle::save_as_sync
         log::warn!("WindowHandle::save_as_sync is currently unimplemented for X11 platforms.");
+        None
+    }
+
+    pub fn save_as(&mut self, _options: FileDialogOptions) -> Option<FileDialogToken> {
+        // TODO(x11/file_dialogs): implement WindowHandle::save_as
+        log::warn!("WindowHandle::save_as is currently unimplemented for X11 platforms.");
         None
     }
 

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -92,13 +92,28 @@ impl IdleToken {
     }
 }
 
+/// A token that uniquely identifies a file dialog request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
-pub struct FileDialogToken(usize);
+pub struct FileDialogToken(u64);
 
 impl FileDialogToken {
-    /// Create a new `FileDialogToken` with the given raw `usize` id.
-    pub const fn new(raw: usize) -> FileDialogToken {
-        FileDialogToken(raw)
+    /// A token that does not correspond to any file dialog.
+    pub const INVALID: FileDialogToken = FileDialogToken(0);
+
+    /// Create a new token.
+    pub fn next() -> FileDialogToken {
+        static COUNTER: Counter = Counter::new();
+        FileDialogToken(COUNTER.next())
+    }
+
+    /// Create a new token from a raw value.
+    pub const fn from_raw(id: u64) -> FileDialogToken {
+        FileDialogToken(id)
+    }
+
+    /// Get the raw value for a token.
+    pub const fn into_raw(self) -> u64 {
+        self.0
     }
 }
 


### PR DESCRIPTION
This is a first step towards #1068: it introduces a new non-sync API to druid-shell and implements it in GTK.

One aspect that I'm not thrilled with (but don't have a better idea for) is that I need to keep around the old API for now. Druid tries the new one first, and then falls back to the old one if the new one doesn't work. The reason for this is that I can't do the mac implementation on my own -- it's non-trivial enough that I don't feel comfortable about the fact that I can't test it. (Also, I don't understand how re-entrancy is handled in the mac backend because there aren't any refcells, just unsafe casts to `&mut ViewState` -- does this mean that re-entrant calls result in UB?)