### PR TITLE
Display hotkeys for menu items in Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - Able to select text in multiple TextBoxes at once. ([#1276] by [@sysint64])
 - The scroll bar now shows when the contents of a scrollable area change size. ([#1278] by [@Majora320])
 - Fix `widget::Either` using the wrong paint insets ([#1299] by [@andrewhickman])
+- Various fixes to cross-platform menus ([#1306] by [@raphlinus])
 
 ### Visual
 
@@ -499,6 +500,7 @@ Last release without a changelog :(
 [#1295]: https://github.com/linebender/druid/pull/1280
 [#1298]: https://github.com/linebender/druid/pull/1298
 [#1299]: https://github.com/linebender/druid/pull/1299
+[#1306]: https://github.com/linebender/druid/pull/1306
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master
 [0.6.0]: https://github.com/linebender/druid/compare/v0.5.0...v0.6.0

--- a/druid/src/menu.rs
+++ b/druid/src/menu.rs
@@ -107,7 +107,6 @@
 
 use std::num::NonZeroU32;
 
-use crate::keyboard_types::Key;
 use crate::kurbo::Point;
 use crate::shell::{HotKey, IntoKey, Menu as PlatformMenu, RawMods, SysMods};
 use crate::{commands, Command, Data, Env, LocalizedString, Selector};
@@ -617,7 +616,6 @@ pub mod sys {
                     LocalizedString::new("win-menu-file-exit"),
                     commands::QUIT_APP,
                 )
-                .hotkey(RawMods::Alt, Key::F4)
             }
         }
     }


### PR DESCRIPTION
This patch adds a string to describe hotkeys for menu items in the
Windows back-end.

Part of work tracked in #1306