### PR TITLE
Fix incorrect cursor position when hscroll > 0.0

### DIFF
--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -174,18 +174,22 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
             Event::MouseDown(mouse) => {
                 ctx.request_focus();
                 ctx.set_active(true);
+                let mut mouse = mouse.clone();
+                mouse.pos += Vec2::new(self.hscroll_offset, 0.0);
 
                 if !mouse.focus {
                     self.reset_cursor_blink(ctx.request_timer(CURSOR_BLINK_DURATION));
-                    self.editor.click(mouse, data);
+                    self.editor.click(&mouse, data);
                 }
 
                 ctx.request_paint();
             }
             Event::MouseMove(mouse) => {
+                let mut mouse = mouse.clone();
+                mouse.pos += Vec2::new(self.hscroll_offset, 0.0);
                 ctx.set_cursor(&Cursor::IBeam);
                 if ctx.is_active() {
-                    self.editor.drag(mouse, data);
+                    self.editor.drag(&mouse, data);
                     ctx.request_paint();
                 }
             }
@@ -351,7 +355,7 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
                 // (commonly when there is trailing whitespace) so we clamp it
                 // to the right edge.
                 let mut cursor = self.editor.cursor_line() + text_pos.to_vec2();
-                let dx = size.width - TEXT_INSETS.x_value() - cursor.p0.x;
+                let dx = size.width + self.hscroll_offset - TEXT_INSETS.x_value() - cursor.p0.x;
                 if dx < 0.0 {
                     cursor = cursor + Vec2::new(dx, 0.);
                 }


### PR DESCRIPTION
Had been testing the multiline case and ignoring the single when
I fixed the cursor to always clamp to the right bound of the layout
when necessary.

- fixes #1313