### PR TITLE
Allow access to Editor from TextBox

### DIFF
--- a/druid/src/text/editor.rs
+++ b/druid/src/text/editor.rs
@@ -66,10 +66,17 @@ impl<T> Editor<T> {
         self.layout.set_wrap_width(width);
     }
 
-    /// Return the inner [`TextLayout`] objects.
+    /// Return a reference to the inner [`TextLayout`] object.
     ///
-    /// [`TextLayout`]: struct.TextLayout.html
-    pub fn layout(&mut self) -> &mut TextLayout<T> {
+    /// [`TextLayout`]: TextLayout
+    pub fn layout(&self) -> &TextLayout<T> {
+        &self.layout
+    }
+
+    /// Return a mutable reference to the inner [`TextLayout`] object.
+    ///
+    /// [`TextLayout`]: TextLayout
+    pub fn layout_mut(&mut self) -> &mut TextLayout<T> {
         &mut self.layout
     }
 }

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -113,7 +113,7 @@ impl<T> TextBox<T> {
     /// [`Key<f64>`]: ../struct.Key.html
     pub fn set_text_size(&mut self, size: impl Into<KeyOrValue<f64>>) {
         let size = size.into();
-        self.editor.layout().set_text_size(size.clone());
+        self.editor.layout_mut().set_text_size(size.clone());
         self.placeholder.set_text_size(size);
     }
 
@@ -127,8 +127,16 @@ impl<T> TextBox<T> {
     /// [`Key<FontDescriptor>`]: ../struct.Key.html
     pub fn set_font(&mut self, font: impl Into<KeyOrValue<FontDescriptor>>) {
         let font = font.into();
-        self.editor.layout().set_font(font.clone());
+        self.editor.layout_mut().set_font(font.clone());
         self.placeholder.set_font(font);
+    }
+
+    /// Return the [`Editor`] used by this `TextBox`.
+    ///
+    /// This is only needed in advanced cases, such as if you want to customize
+    /// the drawing of the text.
+    pub fn editor(&self) -> &Editor<T> {
+        &self.editor
     }
 }
 


### PR DESCRIPTION
This is directly motivated by the EditableLabel in runebender;
I need access to the layout in my new implementation.

This also tweaks the api for getting access to the TextLayout from
within the Editor to better conform with rust API conventions.