### PR TITLE
Remove minimum height from TextBox

### DIFF
--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -281,7 +281,6 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, _data: &T, env: &Env) -> Size {
         let width = env.get(theme::WIDE_WIDGET_WIDTH);
-        let min_height = env.get(theme::BORDERED_WIDGET_HEIGHT);
 
         self.placeholder.rebuild_if_needed(ctx.text(), env);
         if self.multiline {
@@ -291,8 +290,7 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
         self.editor.rebuild_if_needed(ctx.text(), env);
 
         let text_metrics = self.editor.layout().layout_metrics();
-        let text_height = text_metrics.size.height + TEXT_INSETS.y_value();
-        let height = text_height.max(min_height);
+        let height = text_metrics.size.height + TEXT_INSETS.y_value();
 
         let size = bc.constrain((width, height));
         let bottom_padding = (size.height - text_metrics.size.height) / 2.0;
@@ -305,7 +303,6 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         let size = ctx.size();
-        let text_size = self.editor.layout().size();
         let background_color = env.get(theme::BACKGROUND_LIGHT);
         let selection_color = env.get(theme::SELECTION_COLOR);
         let cursor_color = env.get(theme::CURSOR_COLOR);
@@ -333,15 +330,7 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
             // Shift everything inside the clip by the hscroll_offset
             rc.transform(Affine::translate((-self.hscroll_offset, 0.)));
 
-            // in the case that our text is smaller than the default size,
-            // we draw it vertically centered.
-            let extra_padding = if self.multiline {
-                0.
-            } else {
-                (size.height - text_size.height - TEXT_INSETS.y_value()).max(0.) / 2.
-            };
-
-            let text_pos = Point::new(TEXT_INSETS.x0, TEXT_INSETS.y0 + extra_padding);
+            let text_pos = Point::new(TEXT_INSETS.x0, TEXT_INSETS.y0);
 
             // Draw selection rect
             if !data.is_empty() {


### PR DESCRIPTION


A lot of this stuff with bounding the height of widgets was
a consequence of us not being able to calculate the height
of text, and wanting to ensure that control widgets had
similar metrics; that should now be revisited.

In this particular case, this minimum height just seems
like extra logic with no clear benefit, and was complicating
the EditableLabel stuff in runebender.

<img width="236" alt="Screen Shot 2020-10-15 at 12 35 56 PM" src="https://user-images.githubusercontent.com/3330916/96159721-ff169580-0ee2-11eb-890d-bceb658710d0.png">

<img width="220" alt="Screen Shot 2020-10-15 at 12 35 17 PM" src="https://user-images.githubusercontent.com/3330916/96159643-e312f400-0ee2-11eb-91ee-8a8a9a49ec62.png">

