### PR TITLE
Fix small bug in TextBox hscroll calculation

### DIFF
--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -148,7 +148,7 @@ impl<T: TextStorage + EditableText> TextBox<T> {
 
         //// when advancing the cursor, we want some additional padding
         let padding = TEXT_INSETS.x0 * 2.;
-        if overall_text_width < self_width {
+        if overall_text_width < self_width - padding {
             // There's no offset if text is smaller than text box
             //
             // [***I*  ]


### PR DESCRIPTION
This was not correctly accounting for padding, which would
cause us to not add hscroll as needed if the width of
the text was less than our width, but more than our width
exclusive of padding.

before:
![2020-10-15 13 00 15](https://user-images.githubusercontent.com/3330916/96162368-74379a00-0ee6-11eb-8c80-a4efcd935795.gif)
after:
![2020-10-15 12 59 34](https://user-images.githubusercontent.com/3330916/96162373-7568c700-0ee6-11eb-969a-f5328259be40.gif)
