### PR TITLE
[mac] Adopt new save/open API

### DIFF
--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -46,6 +46,7 @@ features = ["d2d1_1", "dwrite", "winbase", "libloaderapi", "errhandlingapi", "wi
             "d3d11", "dwmapi", "wincon", "fileapi", "processenv", "winbase", "handleapi"]
 
 [target.'cfg(target_os="macos")'.dependencies]
+block = "0.1.6"
 cocoa = "0.23.0"
 objc = "0.2.7"
 core-graphics = "0.22.0"

--- a/druid-shell/src/dialog.rs
+++ b/druid-shell/src/dialog.rs
@@ -26,6 +26,7 @@ pub struct FileInfo {
 
 /// Type of file dialog.
 #[cfg(not(all(target_os = "linux", feature = "x11")))]
+#[derive(Clone, Copy, PartialEq)]
 pub enum FileDialogType {
     /// File open dialog.
     Open,

--- a/druid-shell/src/platform/mac/dialog.rs
+++ b/druid-shell/src/platform/mac/dialog.rs
@@ -25,122 +25,120 @@ use objc::{class, msg_send, sel, sel_impl};
 use super::util::{from_nsstring, make_nsstring};
 use crate::dialog::{FileDialogOptions, FileDialogType};
 
+pub(crate) type NSModalResponse = NSInteger;
 const NSModalResponseOK: NSInteger = 1;
 const NSModalResponseCancel: NSInteger = 0;
 
+pub(crate) unsafe fn get_path(panel: id, result: NSModalResponse) -> Option<OsString> {
+    match result {
+        NSModalResponseOK => {
+            let url: id = msg_send![panel, URL];
+            let path: id = msg_send![url, path];
+            let path: OsString = from_nsstring(path).into();
+            Some(path)
+        }
+        NSModalResponseCancel => None,
+        _ => unreachable!(),
+    }
+}
+
 #[allow(clippy::cognitive_complexity)]
-pub(crate) fn get_file_dialog_path(
-    ty: FileDialogType,
-    mut options: FileDialogOptions,
-) -> Option<OsString> {
-    unsafe {
-        let panel: id = match ty {
-            FileDialogType::Open => msg_send![class!(NSOpenPanel), openPanel],
-            FileDialogType::Save => msg_send![class!(NSSavePanel), savePanel],
-        };
+pub(crate) unsafe fn build_panel(ty: FileDialogType, mut options: FileDialogOptions) -> id {
+    let panel: id = match ty {
+        FileDialogType::Open => msg_send![class!(NSOpenPanel), openPanel],
+        FileDialogType::Save => msg_send![class!(NSSavePanel), savePanel],
+    };
 
-        // Enable the user to choose whether file extensions are hidden in the dialog.
-        // This defaults to off, but is recommended to be turned on by Apple.
-        // https://developer.apple.com/design/human-interface-guidelines/macos/user-interaction/file-handling/
-        let () = msg_send![panel, setCanSelectHiddenExtension: YES];
+    // Enable the user to choose whether file extensions are hidden in the dialog.
+    // This defaults to off, but is recommended to be turned on by Apple.
+    // https://developer.apple.com/design/human-interface-guidelines/macos/user-interaction/file-handling/
+    let () = msg_send![panel, setCanSelectHiddenExtension: YES];
 
-        // Set open dialog specific options
-        // NSOpenPanel inherits from NSSavePanel and thus has more options.
-        let mut set_type_filter = true;
-        if let FileDialogType::Open = ty {
-            if options.select_directories {
-                let () = msg_send![panel, setCanChooseDirectories: YES];
-                // Disable the selection of files in directory selection mode,
-                // because other platforms like Windows have no support for it,
-                // and expecting it to work will lead to buggy cross-platform behavior.
-                let () = msg_send![panel, setCanChooseFiles: NO];
-                // File filters are used by macOS to determine which paths are packages.
-                // If we are going to treat packages as directories, then file filters
-                // need to be disabled. Otherwise macOS will allow picking of regular files
-                // that match the filters as if they were directories too.
-                set_type_filter = !options.packages_as_directories;
-            }
-            if options.multi_selection {
-                let () = msg_send![panel, setAllowsMultipleSelection: YES];
-            }
+    // Set open dialog specific options
+    // NSOpenPanel inherits from NSSavePanel and thus has more options.
+    let mut set_type_filter = true;
+    if let FileDialogType::Open = ty {
+        if options.select_directories {
+            let () = msg_send![panel, setCanChooseDirectories: YES];
+            // Disable the selection of files in directory selection mode,
+            // because other platforms like Windows have no support for it,
+            // and expecting it to work will lead to buggy cross-platform behavior.
+            let () = msg_send![panel, setCanChooseFiles: NO];
+            // File filters are used by macOS to determine which paths are packages.
+            // If we are going to treat packages as directories, then file filters
+            // need to be disabled. Otherwise macOS will allow picking of regular files
+            // that match the filters as if they were directories too.
+            set_type_filter = !options.packages_as_directories;
         }
-
-        // Set universal options
-        if options.packages_as_directories {
-            let () = msg_send![panel, setTreatsFilePackagesAsDirectories: YES];
-        }
-
-        if options.show_hidden {
-            let () = msg_send![panel, setShowsHiddenFiles: YES];
-        }
-
-        if let Some(default_name) = &options.default_name {
-            let () = msg_send![panel, setNameFieldStringValue: make_nsstring(default_name)];
-        }
-
-        if let Some(name_label) = &options.name_label {
-            let () = msg_send![panel, setNameFieldLabel: make_nsstring(name_label)];
-        }
-
-        if let Some(title) = &options.title {
-            let () = msg_send![panel, setTitle: make_nsstring(title)];
-        }
-
-        if let Some(text) = &options.button_text {
-            let () = msg_send![panel, setPrompt: make_nsstring(text)];
-        }
-
-        if let Some(path) = &options.starting_directory {
-            if let Some(path) = path.to_str() {
-                let url = NSURL::alloc(nil)
-                    .initFileURLWithPath_isDirectory_(make_nsstring(path), YES)
-                    .autorelease();
-                let () = msg_send![panel, setDirectoryURL: url];
-            }
-        }
-
-        if set_type_filter {
-            // If a default type was specified, then we must reorder the allowed types,
-            // because there's no way to specify the default type other than having it be first.
-            if let Some(dt) = &options.default_type {
-                let mut present = false;
-                if let Some(allowed_types) = options.allowed_types.as_mut() {
-                    if let Some(idx) = allowed_types.iter().position(|t| t == dt) {
-                        present = true;
-                        allowed_types.swap(idx, 0);
-                    }
-                }
-                if !present {
-                    log::warn!("The default type {:?} is not present in allowed types.", dt);
-                }
-            }
-
-            // A vector of NSStrings. this must outlive `nsarray_allowed_types`.
-            let allowed_types = options.allowed_types.as_ref().map(|specs| {
-                specs
-                    .iter()
-                    .flat_map(|spec| spec.extensions.iter().map(|s| make_nsstring(s)))
-                    .collect::<Vec<_>>()
-            });
-
-            let nsarray_allowed_types = allowed_types
-                .as_ref()
-                .map(|types| NSArray::arrayWithObjects(nil, types.as_slice()));
-            if let Some(nsarray) = nsarray_allowed_types {
-                let () = msg_send![panel, setAllowedFileTypes: nsarray];
-            }
-        }
-
-        let result: NSInteger = msg_send![panel, runModal];
-        match result {
-            NSModalResponseOK => {
-                let url: id = msg_send![panel, URL];
-                let path: id = msg_send![url, path];
-                let path: OsString = from_nsstring(path).into();
-                Some(path)
-            }
-            NSModalResponseCancel => None,
-            _ => unreachable!(),
+        if options.multi_selection {
+            let () = msg_send![panel, setAllowsMultipleSelection: YES];
         }
     }
+
+    // Set universal options
+    if options.packages_as_directories {
+        let () = msg_send![panel, setTreatsFilePackagesAsDirectories: YES];
+    }
+
+    if options.show_hidden {
+        let () = msg_send![panel, setShowsHiddenFiles: YES];
+    }
+
+    if let Some(default_name) = &options.default_name {
+        let () = msg_send![panel, setNameFieldStringValue: make_nsstring(default_name)];
+    }
+
+    if let Some(name_label) = &options.name_label {
+        let () = msg_send![panel, setNameFieldLabel: make_nsstring(name_label)];
+    }
+
+    if let Some(title) = &options.title {
+        let () = msg_send![panel, setTitle: make_nsstring(title)];
+    }
+
+    if let Some(text) = &options.button_text {
+        let () = msg_send![panel, setPrompt: make_nsstring(text)];
+    }
+
+    if let Some(path) = &options.starting_directory {
+        if let Some(path) = path.to_str() {
+            let url = NSURL::alloc(nil)
+                .initFileURLWithPath_isDirectory_(make_nsstring(path), YES)
+                .autorelease();
+            let () = msg_send![panel, setDirectoryURL: url];
+        }
+    }
+
+    if set_type_filter {
+        // If a default type was specified, then we must reorder the allowed types,
+        // because there's no way to specify the default type other than having it be first.
+        if let Some(dt) = &options.default_type {
+            let mut present = false;
+            if let Some(allowed_types) = options.allowed_types.as_mut() {
+                if let Some(idx) = allowed_types.iter().position(|t| t == dt) {
+                    present = true;
+                    allowed_types.swap(idx, 0);
+                }
+            }
+            if !present {
+                log::warn!("The default type {:?} is not present in allowed types.", dt);
+            }
+        }
+
+        // A vector of NSStrings. this must outlive `nsarray_allowed_types`.
+        let allowed_types = options.allowed_types.as_ref().map(|specs| {
+            specs
+                .iter()
+                .flat_map(|spec| spec.extensions.iter().map(|s| make_nsstring(s)))
+                .collect::<Vec<_>>()
+        });
+
+        let nsarray_allowed_types = allowed_types
+            .as_ref()
+            .map(|types| NSArray::arrayWithObjects(nil, types.as_slice()));
+        if let Some(nsarray) = nsarray_allowed_types {
+            let () = msg_send![panel, setAllowedFileTypes: nsarray];
+        }
+    }
+    panel
 }


### PR DESCRIPTION
This implements the new save/open (#1068) API on macOS.

The implementation here is slightly different; Cocoa uses the idea
of 'blocks' (a c extension for callbacks) in most of their async API,
so we don't need to to manually defer the work.