### PR TITLE
Use '=' on pre-release dependencies

### DIFF
--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -21,7 +21,7 @@ x11 = ["x11rb", "nix", "cairo-sys-rs"]
 [dependencies]
 # NOTE: When changing the piet or kurbo versions, ensure that
 #       the kurbo version included in piet is compatible with the kurbo version specified here.
-piet-common = "0.2.0-pre5"
+piet-common = "=0.2.0-pre5"
 kurbo = "0.6.3"
 
 log = "0.4.11"
@@ -77,5 +77,5 @@ version = "0.3.44"
 features = ["Window", "MouseEvent", "CssStyleDeclaration", "WheelEvent", "KeyEvent", "KeyboardEvent"]
 
 [dev-dependencies]
-piet-common = { version = "0.2.0-pre5", features = ["png"] }
+piet-common = { version = "=0.2.0-pre5", features = ["png"] }
 simple_logger = { version = "1.9.0", default-features = false }

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -54,7 +54,7 @@ console_log = "0.2.0"
 [dev-dependencies]
 float-cmp = { version = "0.8.0", features = ["std"], default-features = false }
 tempfile = "3.1.0"
-piet-common = { version = "0.2.0-pre5", features = ["png"] }
+piet-common = { version = "=0.2.0-pre5", features = ["png"] }
 
 [[example]]
 name = "cursor"


### PR DESCRIPTION
I'm going to do another piet pre-release shortly, and would like
to avoid breakage.