### PR TITLE
Make platform-specific menus more portable

### DIFF
--- a/druid/src/menu.rs
+++ b/druid/src/menu.rs
@@ -47,7 +47,7 @@
 //! Creating the default Application menu for macOS:
 //!
 //! ```
-//! use druid::{Data, LocalizedString, MenuDesc, MenuItem, RawMods};
+//! use druid::{Data, LocalizedString, MenuDesc, MenuItem, SysMods};
 //! use druid::commands;
 //!
 //! fn macos_application_menu<T: Data>() -> MenuDesc<T> {
@@ -62,7 +62,7 @@
 //!                 LocalizedString::new("macos-menu-preferences"),
 //!                 commands::SHOW_PREFERENCES,
 //!             )
-//!             .hotkey(RawMods::Meta, ",")
+//!             .hotkey(SysMods::Cmd, ",")
 //!             .disabled(),
 //!         )
 //!         .append_separator()
@@ -72,14 +72,14 @@
 //!                 LocalizedString::new("macos-menu-hide-app"),
 //!                 commands::HIDE_APPLICATION,
 //!             )
-//!             .hotkey(RawMods::Meta, "h"),
+//!             .hotkey(SysMods::Cmd, "h"),
 //!         )
 //!         .append(
 //!             MenuItem::new(
 //!                 LocalizedString::new("macos-menu-hide-others"),
 //!                 commands::HIDE_OTHERS,
 //!             )
-//!             .hotkey(RawMods::AltMeta, "h"),
+//!             .hotkey(SysMods::AltCmd, "h"),
 //!         )
 //!         .append(
 //!             MenuItem::new(
@@ -94,7 +94,7 @@
 //!                 LocalizedString::new("macos-menu-quit-app"),
 //!                 commands::QUIT_APP,
 //!             )
-//!             .hotkey(RawMods::Meta, "q"),
+//!             .hotkey(SysMods::Cmd, "q"),
 //!         )
 //! }
 //! ```
@@ -489,7 +489,7 @@ pub mod sys {
 
             #[cfg(target_os = "windows")]
             {
-                item.hotkey(RawMods::Ctrl, "y")
+                item.hotkey(SysMods::Cmd, "y")
             }
             #[cfg(not(target_os = "windows"))]
             {
@@ -536,7 +536,7 @@ pub mod sys {
                     LocalizedString::new("common-menu-file-new"),
                     commands::NEW_FILE,
                 )
-                .hotkey(RawMods::Ctrl, "n")
+                .hotkey(SysMods::Cmd, "n")
             }
 
             /// The 'Open...' menu item.
@@ -545,7 +545,7 @@ pub mod sys {
                     LocalizedString::new("common-menu-file-open"),
                     commands::SHOW_OPEN_PANEL.with(FileDialogOptions::default()),
                 )
-                .hotkey(RawMods::Ctrl, "o")
+                .hotkey(SysMods::Cmd, "o")
             }
 
             /// The 'Close' menu item.
@@ -562,7 +562,7 @@ pub mod sys {
                     LocalizedString::new("common-menu-file-save"),
                     commands::SAVE_FILE.with(None),
                 )
-                .hotkey(RawMods::Ctrl, "s")
+                .hotkey(SysMods::Cmd, "s")
             }
 
             /// The 'Save...' menu item.
@@ -573,7 +573,7 @@ pub mod sys {
                     LocalizedString::new("common-menu-file-save-ellipsis"),
                     commands::SHOW_SAVE_PANEL.with(FileDialogOptions::default()),
                 )
-                .hotkey(RawMods::Ctrl, "s")
+                .hotkey(SysMods::Cmd, "s")
             }
 
             /// The 'Save as...' menu item.
@@ -582,7 +582,7 @@ pub mod sys {
                     LocalizedString::new("common-menu-file-save-as"),
                     commands::SHOW_SAVE_PANEL.with(FileDialogOptions::default()),
                 )
-                .hotkey(RawMods::CtrlShift, "S")
+                .hotkey(SysMods::CmdShift, "S")
             }
 
             /// The 'Print...' menu item.
@@ -591,7 +591,7 @@ pub mod sys {
                     LocalizedString::new("common-menu-file-print"),
                     commands::PRINT,
                 )
-                .hotkey(RawMods::Ctrl, "p")
+                .hotkey(SysMods::Cmd, "p")
             }
 
             /// The 'Print Preview' menu item.
@@ -664,7 +664,7 @@ pub mod sys {
                     LocalizedString::new("macos-menu-preferences"),
                     commands::SHOW_PREFERENCES,
                 )
-                .hotkey(RawMods::Meta, ",")
+                .hotkey(SysMods::Cmd, ",")
             }
 
             /// The 'Hide' builtin menu item.
@@ -673,7 +673,7 @@ pub mod sys {
                     LocalizedString::new("macos-menu-hide-app"),
                     commands::HIDE_APPLICATION,
                 )
-                .hotkey(RawMods::Meta, "h")
+                .hotkey(SysMods::Cmd, "h")
             }
 
             /// The 'Hide Others' builtin menu item.
@@ -682,7 +682,7 @@ pub mod sys {
                     LocalizedString::new("macos-menu-hide-others"),
                     commands::HIDE_OTHERS,
                 )
-                .hotkey(RawMods::AltMeta, "h")
+                .hotkey(SysMods::AltCmd, "h")
             }
 
             /// The 'show all' builtin menu item
@@ -700,7 +700,7 @@ pub mod sys {
                     LocalizedString::new("macos-menu-quit-app"),
                     commands::QUIT_APP,
                 )
-                .hotkey(RawMods::Meta, "q")
+                .hotkey(SysMods::Cmd, "q")
             }
         }
         /// The file menu.
@@ -739,7 +739,7 @@ pub mod sys {
                     LocalizedString::new("common-menu-file-new"),
                     commands::NEW_FILE,
                 )
-                .hotkey(RawMods::Meta, "n")
+                .hotkey(SysMods::Cmd, "n")
             }
 
             /// The 'Open...' menu item. Will display the system file-chooser.
@@ -748,7 +748,7 @@ pub mod sys {
                     LocalizedString::new("common-menu-file-open"),
                     commands::SHOW_OPEN_PANEL.with(FileDialogOptions::default()),
                 )
-                .hotkey(RawMods::Meta, "o")
+                .hotkey(SysMods::Cmd, "o")
             }
 
             /// The 'Close' menu item.
@@ -757,7 +757,7 @@ pub mod sys {
                     LocalizedString::new("common-menu-file-close"),
                     commands::CLOSE_WINDOW,
                 )
-                .hotkey(RawMods::Meta, "w")
+                .hotkey(SysMods::Cmd, "w")
             }
 
             /// The 'Save' menu item.
@@ -766,7 +766,7 @@ pub mod sys {
                     LocalizedString::new("common-menu-file-save"),
                     commands::SAVE_FILE.with(None),
                 )
-                .hotkey(RawMods::Meta, "s")
+                .hotkey(SysMods::Cmd, "s")
             }
 
             /// The 'Save...' menu item.
@@ -777,7 +777,7 @@ pub mod sys {
                     LocalizedString::new("common-menu-file-save-ellipsis"),
                     commands::SHOW_SAVE_PANEL.with(FileDialogOptions::default()),
                 )
-                .hotkey(RawMods::Meta, "s")
+                .hotkey(SysMods::Cmd, "s")
             }
 
             /// The 'Save as...'
@@ -786,7 +786,7 @@ pub mod sys {
                     LocalizedString::new("common-menu-file-save-as"),
                     commands::SHOW_SAVE_PANEL.with(FileDialogOptions::default()),
                 )
-                .hotkey(RawMods::MetaShift, "S")
+                .hotkey(SysMods::CmdShift, "S")
             }
 
             /// The 'Page Setup...' menu item.
@@ -795,7 +795,7 @@ pub mod sys {
                     LocalizedString::new("common-menu-file-page-setup"),
                     commands::PRINT_SETUP,
                 )
-                .hotkey(RawMods::MetaShift, "P")
+                .hotkey(SysMods::CmdShift, "P")
             }
 
             /// The 'Print...' menu item.
@@ -804,7 +804,7 @@ pub mod sys {
                     LocalizedString::new("common-menu-file-print"),
                     commands::PRINT,
                 )
-                .hotkey(RawMods::Meta, "p")
+                .hotkey(SysMods::Cmd, "p")
             }
         }
     }


### PR DESCRIPTION
If an application were to misuse a platform-specific for the wrong
platform, it would get unusable keybindings. With this patch, it might
not be the most appropriate for the platform, but it would work.

The linked bug below suggests a more systematic approach, but this is a
minimal patch to get things to a less broken state.

Part of work tracked in #1306.