### PR TITLE
Add Crochet feature and a method to WidgetPod.

### DIFF
--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -25,6 +25,7 @@ gtk = ["druid-shell/gtk"]
 image = ["druid-shell/image"]
 svg = ["usvg", "harfbuzz-sys"]
 x11 = ["druid-shell/x11"]
+crochet = []
 
 # passing on all the image features. AVIF is not supported because it does not
 # support decoding, and that's all we use `Image` for.

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -515,6 +515,23 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         size
     }
 
+    /// Execute the closure with this widgets `EventCtx`.
+    #[cfg(feature = "crochet")]
+    pub fn with_event_context<F>(&mut self, parent_ctx: &mut EventCtx, mut fun: F)
+    where
+        F: FnMut(&mut W, &mut EventCtx),
+    {
+        let mut ctx = EventCtx {
+            state: parent_ctx.state,
+            widget_state: &mut self.state,
+            cursor: parent_ctx.cursor,
+            is_handled: false,
+            is_root: false,
+        };
+        fun(&mut self.inner, &mut ctx);
+        parent_ctx.widget_state.merge_up(&mut self.state);
+    }
+
     /// Propagate an event.
     ///
     /// Generally the [`event`] method of a container widget will call this

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -426,7 +426,7 @@ impl Static {
     }
 
     fn resolve(&mut self) -> bool {
-        let is_first_call = self.resolved;
+        let is_first_call = !self.resolved;
         self.resolved = true;
         is_first_call
     }


### PR DESCRIPTION
This PR will allow me to fix Crochet and update it to the newest Druid.

It does
- Add a feature gate "crochet"
- Add `WidgetPod::with_event_context` method to run a function with the widgets `EventCtx`. This is the most minimal change to allow Crochet to function properly.
- (Fix `LabelText::Static` `resolve` method)