### PR TITLE
Fix `TextLayout::set_text` not always setting the text when it should

### DIFF
--- a/druid/src/text/editable_text.rs
+++ b/druid/src/text/editable_text.rs
@@ -196,7 +196,10 @@ impl EditableText for Arc<String> {
         <String as EditableText>::cursor(self, position)
     }
     fn edit(&mut self, range: Range<usize>, new: impl Into<String>) {
-        Arc::make_mut(self).edit(range, new)
+        let new = new.into();
+        if !range.is_empty() || !new.is_empty() {
+            Arc::make_mut(self).edit(range, new)
+        }
     }
     fn slice(&self, range: Range<usize>) -> Option<Cow<str>> {
         Some(Cow::Borrowed(&self[range]))
@@ -368,6 +371,7 @@ pub fn len_utf8_from_first_byte(b: u8) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Data;
 
     #[test]
     fn replace() {
@@ -520,5 +524,13 @@ mod tests {
         assert_eq!(b.len(), b.next_line_break(11));
         assert_eq!(b.len(), b.next_line_break(13));
         assert_eq!(b.len(), b.next_line_break(19));
+    }
+
+    #[test]
+    fn arcstring_empty_edit() {
+        let a = Arc::new("hello".to_owned());
+        let mut b = a.clone();
+        b.edit(5..5, "");
+        assert!(a.same(&b));
     }
 }

--- a/druid/src/text/editor.rs
+++ b/druid/src/text/editor.rs
@@ -222,7 +222,10 @@ impl<T: TextStorage + EditableText> Editor<T> {
     /// the data before us while handling an event; if this is the case we ignore
     /// the event, and our data will be updated in `update`.
     fn data_is_stale(&self, data: &T) -> bool {
-        self.layout.text().map(|t| !t.same(data)).unwrap_or(true)
+        self.layout
+            .text()
+            .map(|t| t.as_str() != data.as_str())
+            .unwrap_or(true)
     }
 
     fn insert(&mut self, data: &mut T, text: &str) {


### PR DESCRIPTION
Fixes #1354 

The check on `as_str` here wasn't quite equivalent to `Data::same` when using `Arc<String>` as the datatype. Empty edits like pressing delete at the end of a textbox wouldn't update the text

Most of the calling code seems to check `Data::same` before calling this method so I just removed the extra checks. Alternatively we could skip empty edits in the impl of `EditableText` for `Arc<String>`?