### PR TITLE
Fixed broken doc links due to typo in container.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ You can find its changes [documented below](#060---2020-06-01).
 
 - Added documentation for the `Image` widget. ([#1018] by [@covercash2])
 - Fixed a link in `druid::command` documentation. ([#1008] by [@covercash2])
+- Fixed broken links in `druid::widget::Container` documentation. ([#1357] by [@StarfightLP])
 
 ### Examples
 

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -51,8 +51,8 @@ impl<T: Data> Container<T> {
     /// any gradient, or a fully custom [`Painter`] widget.
     ///
     /// [`BackgroundBrush`]: ../enum.BackgroundBrush.html
-    /// [`Color`]: ../struct.Color.thml
-    /// [`Key<Color>`]: ../struct.Key.thml
+    /// [`Color`]: ../enum.Color.html
+    /// [`Key<Color>`]: ../struct.Key.html
     /// [`Env`]: ../struct.Env.html
     /// [`Painter`]: struct.Painter.html
     pub fn background(mut self, brush: impl Into<BackgroundBrush<T>>) -> Self {
@@ -67,8 +67,8 @@ impl<T: Data> Container<T> {
     /// any gradient, or a fully custom [`Painter`] widget.
     ///
     /// [`BackgroundBrush`]: ../enum.BackgroundBrush.html
-    /// [`Color`]: ../struct.Color.thml
-    /// [`Key<Color>`]: ../struct.Key.thml
+    /// [`Color`]: ../enum.Color.html
+    /// [`Key<Color>`]: ../struct.Key.html
     /// [`Env`]: ../struct.Env.html
     /// [`Painter`]: struct.Painter.html
     pub fn set_background(&mut self, brush: impl Into<BackgroundBrush<T>>) {


### PR DESCRIPTION
Noticed some broken links in the Container widget docs and fixed them.

Tested locally with `cargo doc` and Firefox.