### PR TITLE
The gallery example now requires a new feature.

### DIFF
--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -99,4 +99,4 @@ required-features = ["im"]
 
 [[example]]
 name = "widget_gallery"
-required-features = ["svg", "im", "image"]
+required-features = ["svg", "im", "image", "png"]


### PR DESCRIPTION
The image create now requires a feature to be passed through to enable loading `png`s, which the gallery example uses.