### PR TITLE
Allow setting the cursor in the update method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - `TextBox::with_text_color` and `TextBox::set_text_color` ([#1320] by [@cmyr])
 - `Checkbox::set_text` to update the label. ([#1346] by [@finnerale])
 - `Event::should_propagate_to_hidden` and `Lifecycle::should_propagate_to_hidden` to determine whether an event should be sent to hidden widgets (e.g. in `Tabs` or `Either`). ([#1351] by [@andrewhickman])
+- `set_cursor` can be called in the `update` method. ([#1361] by [@jneem])
 
 ### Changed
 
@@ -523,6 +524,7 @@ Last release without a changelog :(
 [#1328]: https://github.com/linebender/druid/pull/1328
 [#1346]: https://github.com/linebender/druid/pull/1346
 [#1351]: https://github.com/linebender/druid/pull/1351
+[#1361]: https://github.com/linebender/druid/pull/1361
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master
 [0.6.0]: https://github.com/linebender/druid/compare/v0.5.0...v0.6.0

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -92,6 +92,7 @@ pub struct LifeCycleCtx<'a, 'b> {
 pub struct UpdateCtx<'a, 'b> {
     pub(crate) state: &'a mut ContextState<'b>,
     pub(crate) widget_state: &'a mut WidgetState,
+    pub(crate) cursor: &'a mut Option<Cursor>,
     pub(crate) prev_env: Option<&'a Env>,
     pub(crate) env: &'a Env,
 }
@@ -251,6 +252,26 @@ impl_context_method!(
     }
 );
 
+impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, {
+    /// Set the cursor icon.
+    ///
+    /// Call this when handling a mouse move event, to set the cursor for the
+    /// widget. A container widget can safely call this method, then recurse
+    /// to its children, as a sequence of calls within an event propagation
+    /// only has the effect of the last one (ie no need to worry about
+    /// flashing).
+    ///
+    /// This method is expected to be called mostly from the [`MouseMove`]
+    /// event handler, but can also be called in response to other events,
+    /// for example pressing a key to change the behavior of a widget, or
+    /// in response to data changes.
+    ///
+    /// [`MouseMove`]: enum.Event.html#variant.MouseMove
+    pub fn set_cursor(&mut self, cursor: &Cursor) {
+        *self.cursor = Some(cursor.clone());
+    }
+});
+
 // methods on event, update, and lifecycle
 impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, {
     /// Request a [`paint`] pass. This is equivalent to calling
@@ -350,23 +371,6 @@ impl_context_method!(
 );
 
 impl EventCtx<'_, '_> {
-    /// Set the cursor icon.
-    ///
-    /// Call this when handling a mouse move event, to set the cursor for the
-    /// widget. A container widget can safely call this method, then recurse
-    /// to its children, as a sequence of calls within an event propagation
-    /// only has the effect of the last one (ie no need to worry about
-    /// flashing).
-    ///
-    /// This method is expected to be called mostly from the [`MouseMove`]
-    /// event handler, but can also be called in response to other events,
-    /// for example pressing a key to change the behavior of a widget.
-    ///
-    /// [`MouseMove`]: enum.Event.html#variant.MouseMove
-    pub fn set_cursor(&mut self, cursor: &Cursor) {
-        *self.cursor = Some(cursor.clone());
-    }
-
     /// Set the "active" state of the widget.
     ///
     /// See [`EventCtx::is_active`](struct.EventCtx.html#method.is_active).

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -873,6 +873,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         let mut child_ctx = UpdateCtx {
             state: ctx.state,
             widget_state: &mut self.state,
+            cursor: ctx.cursor,
             prev_env,
             env,
         };

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -277,14 +277,20 @@ impl<T: Data> Window<T> {
         let mut widget_state = WidgetState::new(self.root.id(), Some(self.size));
         let mut state =
             ContextState::new::<T>(queue, &self.ext_handle, &self.handle, self.id, self.focus);
+        let mut cursor = None;
         let mut update_ctx = UpdateCtx {
             widget_state: &mut widget_state,
+            cursor: &mut cursor,
             state: &mut state,
             prev_env: None,
             env,
         };
 
         self.root.update(&mut update_ctx, data, env);
+        if let Some(cursor) = cursor {
+            self.handle.set_cursor(&cursor);
+        }
+
         self.post_event_processing(&mut widget_state, queue, data, env, false);
     }
 


### PR DESCRIPTION
Motivation is that I have a widget that needs to change its cursor in response to the app data, but the data can get changed by keyboard shortcuts that don't cause an event to the relevant widget (e.g. keyboard shortcuts for menu entries).