### PR TITLE
Re-design dynamic length lists.

### DIFF
--- a/druid/examples/event_viewer.rs
+++ b/druid/examples/event_viewer.rs
@@ -186,7 +186,7 @@ fn event_list() -> impl Widget<AppState> {
         )
         .with_spacer(COLUMN_PADDING)
         .with_flex_child(
-            Scroll::new(List::new(make_list_item).lens(AppState::events)).expand_width(),
+            Scroll::new(List::vertical(make_list_item).lens(AppState::events)).expand_width(),
             1.0,
         )
         .padding(10.0)

--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -70,7 +70,7 @@ fn ui_builder() -> impl Widget<AppData> {
 
     // Build a simple list
     lists.add_flex_child(
-        Scroll::new(List::new(|| {
+        Scroll::new(List::column(|| {
             Label::new(|item: &u32, _env: &_| format!("List item #{}", item))
                 .align_vertical(UnitPoint::LEFT)
                 .padding(10.0)
@@ -85,7 +85,7 @@ fn ui_builder() -> impl Widget<AppData> {
 
     // Build a list with shared data
     lists.add_flex_child(
-        Scroll::new(List::new(|| {
+        Scroll::new(List::column(|| {
             Flex::row()
                 .with_child(
                     Label::new(|(_, item): &(Vector<u32>, u32), _env: &_| {
@@ -121,6 +121,12 @@ fn ui_builder() -> impl Widget<AppData> {
     );
 
     root.add_flex_child(lists, 1.0);
+
+    root.add_child(Label::new("Horizontal list"));
+    root.add_child(
+        List::row(|| Label::new(|pos: &u32, _env: &_| format!("List item #{}", pos)))
+            .lens(AppData::right),
+    );
 
     // Mark the widget as needing its layout rects painted
     root.debug_paint_layout()

--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -70,7 +70,7 @@ fn ui_builder() -> impl Widget<AppData> {
 
     // Build a simple list
     lists.add_flex_child(
-        Scroll::new(List::column(|| {
+        Scroll::new(List::vertical(|| {
             Label::new(|item: &u32, _env: &_| format!("List item #{}", item))
                 .align_vertical(UnitPoint::LEFT)
                 .padding(10.0)
@@ -85,7 +85,7 @@ fn ui_builder() -> impl Widget<AppData> {
 
     // Build a list with shared data
     lists.add_flex_child(
-        Scroll::new(List::column(|| {
+        Scroll::new(List::vertical(|| {
             Flex::row()
                 .with_child(
                     Label::new(|(_, item): &(Vector<u32>, u32), _env: &_| {
@@ -124,7 +124,8 @@ fn ui_builder() -> impl Widget<AppData> {
 
     root.add_child(Label::new("Horizontal list"));
     root.add_child(
-        List::row(|| Label::new(|pos: &u32, _env: &_| format!("List item #{}", pos)))
+        List::horizontal(|| Label::new(|pos: &u32, _env: &_| format!("List item #{}", pos)))
+            .with_flex(true)
             .lens(AppData::right),
     );
 

--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -16,9 +16,7 @@
 
 use druid::im::{vector, Vector};
 use druid::lens::{self, LensExt};
-use druid::widget::{
-    Button, CrossAxisAlignment, Flex, Label, List, ListMainAlignment, MainAxisAlignment, Scroll,
-};
+use druid::widget::{Button, CrossAxisAlignment, Flex, Label, List, ListSpacing, Scroll};
 use druid::{
     AppLauncher, Color, Data, Lens, LocalizedString, UnitPoint, Widget, WidgetExt, WindowDesc,
 };
@@ -72,17 +70,14 @@ fn ui_builder() -> impl Widget<AppData> {
 
     // Build a simple list
     lists.add_flex_child(
-        Scroll::new(
-            List::vertical(|| {
-                Label::new(|item: &u32, _env: &_| format!("List item #{}", item))
-                    .align_vertical(UnitPoint::LEFT)
-                    .padding(10.0)
-                    .expand()
-                    .height(50.0)
-                    .background(Color::rgb(0.5, 0.5, 0.5))
-            })
-            .with_main_alignment(MainAxisAlignment::Start),
-        )
+        Scroll::new(List::vertical(|| {
+            Label::new(|item: &u32, _env: &_| format!("List item #{}", item))
+                .align_vertical(UnitPoint::LEFT)
+                .padding(10.0)
+                .expand()
+                .height(50.0)
+                .background(Color::rgb(0.5, 0.5, 0.5))
+        }))
         .vertical()
         .lens(AppData::left),
         1.0,
@@ -90,29 +85,33 @@ fn ui_builder() -> impl Widget<AppData> {
 
     // Build a list with shared data
     lists.add_flex_child(
-        Scroll::new(List::vertical(|| {
-            Flex::row()
-                .with_child(
-                    Label::new(|(_, item): &(Vector<u32>, u32), _env: &_| {
-                        format!("List item #{}", item)
-                    })
-                    .align_vertical(UnitPoint::LEFT),
-                )
-                .with_flex_spacer(1.0)
-                .with_child(
-                    Button::new("Delete")
-                        .on_click(|_ctx, (shared, item): &mut (Vector<u32>, u32), _env| {
-                            // We have access to both child's data and shared data.
-                            // Remove element from right list.
-                            shared.retain(|v| v != item);
+        Scroll::new(
+            List::vertical(|| {
+                Flex::row()
+                    .with_child(
+                        Label::new(|(_, item): &(Vector<u32>, u32), _env: &_| {
+                            format!("List item #{}", item)
                         })
-                        .fix_size(80.0, 20.0)
-                        .align_vertical(UnitPoint::CENTER),
-                )
-                .padding(10.0)
-                .background(Color::rgb(0.5, 0.0, 0.5))
-                .fix_height(50.0)
-        }))
+                        .align_vertical(UnitPoint::LEFT),
+                    )
+                    .with_flex_spacer(1.0)
+                    .with_child(
+                        Button::new("Delete")
+                            .on_click(|_ctx, (shared, item): &mut (Vector<u32>, u32), _env| {
+                                // We have access to both child's data and shared data.
+                                // Remove element from right list.
+                                shared.retain(|v| v != item);
+                            })
+                            .fix_size(80.0, 20.0)
+                            .align_vertical(UnitPoint::CENTER),
+                    )
+                    .padding(10.0)
+                    .background(Color::rgb(0.5, 0.0, 0.5))
+                    .fix_height(50.0)
+            })
+            .with_spacing(ListSpacing::fixed(10.))
+            .padding((0., 5.)),
+        )
         .vertical()
         .lens(lens::Id.map(
             // Expose shared data with children data
@@ -127,10 +126,40 @@ fn ui_builder() -> impl Widget<AppData> {
 
     root.add_flex_child(lists, 1.0);
 
-    root.add_child(Label::new("Horizontal list"));
+    root.add_child(Label::new("Horizontal lists"));
+    let mut padding = [(0.0, 0.0), (0.0, 10.0)].iter().cycle();
+    root.add_child(
+        List::horizontal(move || {
+            Label::new(|pos: &u32, _env: &_| format!("List item #{}", pos))
+                .padding(*padding.next().unwrap())
+        })
+        .with_cross_alignment(CrossAxisAlignment::End)
+        .align_right()
+        .lens(AppData::right),
+    );
     root.add_child(
         List::horizontal(|| Label::new(|pos: &u32, _env: &_| format!("List item #{}", pos)))
-            .with_main_alignment(ListMainAlignment::FlexItems { spacing: 10. })
+            .with_spacing(ListSpacing::between(1.))
+            .expand_width()
+            .lens(AppData::right),
+    );
+    root.add_child(
+        List::horizontal(|| Label::new(|pos: &u32, _env: &_| format!("List item #{}", pos)))
+            .with_spacing(ListSpacing::around(1.))
+            .expand_width()
+            .lens(AppData::right),
+    );
+    root.add_child(
+        List::horizontal(|| Label::new(|pos: &u32, _env: &_| format!("List item #{}", pos)))
+            .with_spacing(ListSpacing::evenly(1.))
+            .expand_width()
+            .lens(AppData::right),
+    );
+    root.add_child(
+        List::horizontal(|| Label::new(|pos: &u32, _env: &_| format!("List item #{}", pos)))
+            .with_flex_items(true)
+            .with_spacing(ListSpacing::evenly(1.))
+            .expand_width()
             .lens(AppData::right),
     );
 

--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -16,7 +16,9 @@
 
 use druid::im::{vector, Vector};
 use druid::lens::{self, LensExt};
-use druid::widget::{Button, CrossAxisAlignment, Flex, Label, List, Scroll};
+use druid::widget::{
+    Button, CrossAxisAlignment, Flex, Label, List, ListMainAlignment, MainAxisAlignment, Scroll,
+};
 use druid::{
     AppLauncher, Color, Data, Lens, LocalizedString, UnitPoint, Widget, WidgetExt, WindowDesc,
 };
@@ -70,14 +72,17 @@ fn ui_builder() -> impl Widget<AppData> {
 
     // Build a simple list
     lists.add_flex_child(
-        Scroll::new(List::vertical(|| {
-            Label::new(|item: &u32, _env: &_| format!("List item #{}", item))
-                .align_vertical(UnitPoint::LEFT)
-                .padding(10.0)
-                .expand()
-                .height(50.0)
-                .background(Color::rgb(0.5, 0.5, 0.5))
-        }))
+        Scroll::new(
+            List::vertical(|| {
+                Label::new(|item: &u32, _env: &_| format!("List item #{}", item))
+                    .align_vertical(UnitPoint::LEFT)
+                    .padding(10.0)
+                    .expand()
+                    .height(50.0)
+                    .background(Color::rgb(0.5, 0.5, 0.5))
+            })
+            .with_main_alignment(MainAxisAlignment::Start),
+        )
         .vertical()
         .lens(AppData::left),
         1.0,
@@ -125,7 +130,7 @@ fn ui_builder() -> impl Widget<AppData> {
     root.add_child(Label::new("Horizontal list"));
     root.add_child(
         List::horizontal(|| Label::new(|pos: &u32, _env: &_| format!("List item #{}", pos)))
-            .with_flex(true)
+            .with_main_alignment(ListMainAlignment::FlexItems { spacing: 10. })
             .lens(AppData::right),
     );
 

--- a/druid/examples/widget_gallery.rs
+++ b/druid/examples/widget_gallery.rs
@@ -105,7 +105,7 @@ fn ui_builder() -> impl Widget<AppData> {
                 "Checkbox",
             ))
             .with_child(label_widget(
-                List::new(|| {
+                List::vertical(|| {
                     Label::new(|data: &String, _: &_| format!("List item: {}", data))
                         .center()
                         .background(Color::hlc(230.0, 50.0, 50.0))

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -262,7 +262,12 @@ impl Axis {
     }
 
     /// Generate constraints with new values on the major axis.
-    fn constraints(self, bc: &BoxConstraints, min_major: f64, major: f64) -> BoxConstraints {
+    pub(crate) fn constraints(
+        self,
+        bc: &BoxConstraints,
+        min_major: f64,
+        major: f64,
+    ) -> BoxConstraints {
         match self {
             Axis::Horizontal => BoxConstraints::new(
                 Size::new(min_major, bc.min().height),
@@ -789,7 +794,7 @@ impl CrossAxisAlignment {
     /// Given the difference between the size of the container and the size
     /// of the child (on their minor axis) return the necessary offset for
     /// this alignment.
-    fn align(self, val: f64) -> f64 {
+    pub(crate) fn align(self, val: f64) -> f64 {
         match self {
             CrossAxisAlignment::Start => 0.0,
             // in vertical layout, baseline is equivalent to center
@@ -799,7 +804,7 @@ impl CrossAxisAlignment {
     }
 }
 
-struct Spacing {
+pub(crate) struct Spacing {
     alignment: MainAxisAlignment,
     extra: f64,
     n_children: usize,
@@ -813,7 +818,7 @@ impl Spacing {
     /// this returns an iterator of `f64` spacing,
     /// where the first element is the spacing before any children
     /// and all subsequent elements are the spacing after children.
-    fn new(alignment: MainAxisAlignment, extra: f64, n_children: usize) -> Spacing {
+    pub(crate) fn new(alignment: MainAxisAlignment, extra: f64, n_children: usize) -> Spacing {
         let extra = if extra.is_finite() { extra } else { 0. };
         let equal_space = if n_children > 0 {
             match alignment {

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -12,60 +12,104 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Simple list view widget.
+//! List view widget.
+
+mod iter;
 
 use std::cmp::Ordering;
 use std::f64;
-use std::sync::Arc;
 
+pub use self::iter::ListIter;
 #[cfg(feature = "im")]
 use crate::im::Vector;
-use crate::kurbo::{Point, Rect, Size};
-use crate::widget::Axis;
+use crate::kurbo::{common::FloatExt, Point, Rect, Size};
+use crate::widget::{flex::Spacing, Axis, CrossAxisAlignment, MainAxisAlignment};
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
     UpdateCtx, Widget, WidgetPod,
 };
+
+#[derive(Copy, Clone)]
+pub enum ListMainAlignment {
+    /// Inherit options from `MainAxisAlignment`.
+    NoFlex(MainAxisAlignment),
+    /// Force children to use up all space evenly.
+    ///
+    /// Spacing will be added between items, but not at ends. If you don't want spacing set it to
+    /// `0.0`.
+    FlexItems { spacing: f64 },
+}
+
+impl From<MainAxisAlignment> for ListMainAlignment {
+    fn from(from: MainAxisAlignment) -> Self {
+        ListMainAlignment::NoFlex(from)
+    }
+}
 
 /// A list widget for a variable-size collection of items.
 pub struct List<T> {
     closure: Box<dyn Fn() -> Box<dyn Widget<T>>>,
     children: Vec<WidgetPod<T, Box<dyn Widget<T>>>>,
     axis: Axis,
-    flex: bool,
+    main_align: ListMainAlignment,
+    cross_align: CrossAxisAlignment,
 }
 
 impl<T: Data> List<T> {
     /// Create a new list widget. Closure will be called every time when a new child
     /// needs to be constructed.
+    #[inline]
     pub fn new<W: Widget<T> + 'static>(closure: impl Fn() -> W + 'static, axis: Axis) -> Self {
         List {
             closure: Box::new(move || Box::new(closure())),
             children: Vec::new(),
             axis,
-            flex: false,
+            main_align: MainAxisAlignment::Start.into(),
+            cross_align: CrossAxisAlignment::Start,
         }
     }
 
     /// Create a list where items are in a left -> right row
+    #[inline]
     pub fn horizontal<W: Widget<T> + 'static>(closure: impl Fn() -> W + 'static) -> Self {
         Self::new(closure, Axis::Horizontal)
     }
 
     /// Create a list where items are in a top -> bottom column
+    #[inline]
     pub fn vertical<W: Widget<T> + 'static>(closure: impl Fn() -> W + 'static) -> Self {
         Self::new(closure, Axis::Vertical)
     }
 
     /// If set to `true`, each element will be given an equal share of the space available.
-    pub fn with_flex(mut self, flex: bool) -> Self {
-        self.flex = flex;
+    ///
+    /// Can pass either a `ListMainAlignment` or a `MainAxisAlignment`.
+    #[inline]
+    pub fn with_main_alignment(mut self, main_align: impl Into<ListMainAlignment>) -> Self {
+        self.main_align = main_align.into();
         self
     }
 
     /// If set to `true`, each element will be given an equal share of the space available.
-    pub fn set_flex(&mut self, flex: bool) -> &mut Self {
-        self.flex = flex;
+    ///
+    /// Can pass either a `ListMainAlignment` or a `MainAxisAlignment`.
+    #[inline]
+    pub fn set_main_alignment(&mut self, main_align: impl Into<ListMainAlignment>) -> &mut Self {
+        self.main_align = main_align.into();
+        self
+    }
+
+    /// If non-zero, then spacing will be added between elements.
+    #[inline]
+    pub fn with_cross_alignment(mut self, cross_align: CrossAxisAlignment) -> Self {
+        self.cross_align = cross_align;
+        self
+    }
+
+    /// If non-zero, then spacing will be added between elements.
+    #[inline]
+    pub fn set_cross_alignment(&mut self, cross_align: CrossAxisAlignment) -> &mut Self {
+        self.cross_align = cross_align;
         self
     }
 
@@ -88,138 +132,11 @@ impl<T: Data> List<T> {
     }
 }
 
-/// This iterator enables writing List widget for any `Data`.
-pub trait ListIter<T>: Data {
-    /// Iterate over each data child.
-    fn for_each(&self, cb: impl FnMut(&T, usize));
-
-    /// Iterate over each data child. Keep track of changed data and update self.
-    fn for_each_mut(&mut self, cb: impl FnMut(&mut T, usize));
-
-    /// Return data length.
-    fn data_len(&self) -> usize;
-}
-
-#[cfg(feature = "im")]
-impl<T: Data> ListIter<T> for Vector<T> {
-    fn for_each(&self, mut cb: impl FnMut(&T, usize)) {
-        for (i, item) in self.iter().enumerate() {
-            cb(item, i);
-        }
-    }
-
-    fn for_each_mut(&mut self, mut cb: impl FnMut(&mut T, usize)) {
-        for (i, item) in self.iter_mut().enumerate() {
-            cb(item, i);
-        }
-    }
-
-    fn data_len(&self) -> usize {
-        self.len()
-    }
-}
-
-// S == shared data type
-#[cfg(feature = "im")]
-impl<S: Data, T: Data> ListIter<(S, T)> for (S, Vector<T>) {
-    fn for_each(&self, mut cb: impl FnMut(&(S, T), usize)) {
-        for (i, item) in self.1.iter().enumerate() {
-            let d = (self.0.to_owned(), item.to_owned());
-            cb(&d, i);
-        }
-    }
-
-    fn for_each_mut(&mut self, mut cb: impl FnMut(&mut (S, T), usize)) {
-        for (i, item) in self.1.iter_mut().enumerate() {
-            let mut d = (self.0.clone(), item.clone());
-            cb(&mut d, i);
-
-            if !self.0.same(&d.0) {
-                self.0 = d.0;
-            }
-            if !item.same(&d.1) {
-                *item = d.1;
-            }
-        }
-    }
-
-    fn data_len(&self) -> usize {
-        self.1.len()
-    }
-}
-
-impl<T: Data> ListIter<T> for Arc<Vec<T>> {
-    fn for_each(&self, mut cb: impl FnMut(&T, usize)) {
-        for (i, item) in self.iter().enumerate() {
-            cb(item, i);
-        }
-    }
-
-    fn for_each_mut(&mut self, mut cb: impl FnMut(&mut T, usize)) {
-        let mut new_data = Vec::with_capacity(self.data_len());
-        let mut any_changed = false;
-
-        for (i, item) in self.iter().enumerate() {
-            let mut d = item.to_owned();
-            cb(&mut d, i);
-
-            if !any_changed && !item.same(&d) {
-                any_changed = true;
-            }
-            new_data.push(d);
-        }
-
-        if any_changed {
-            *self = Arc::new(new_data);
-        }
-    }
-
-    fn data_len(&self) -> usize {
-        self.len()
-    }
-}
-
-// S == shared data type
-impl<S: Data, T: Data> ListIter<(S, T)> for (S, Arc<Vec<T>>) {
-    fn for_each(&self, mut cb: impl FnMut(&(S, T), usize)) {
-        for (i, item) in self.1.iter().enumerate() {
-            let d = (self.0.clone(), item.to_owned());
-            cb(&d, i);
-        }
-    }
-
-    fn for_each_mut(&mut self, mut cb: impl FnMut(&mut (S, T), usize)) {
-        let mut new_data = Vec::with_capacity(self.1.len());
-        let mut any_shared_changed = false;
-        let mut any_el_changed = false;
-
-        for (i, item) in self.1.iter().enumerate() {
-            let mut d = (self.0.clone(), item.to_owned());
-            cb(&mut d, i);
-
-            if !any_shared_changed && !self.0.same(&d.0) {
-                any_shared_changed = true;
-            }
-            if any_shared_changed {
-                self.0 = d.0;
-            }
-            if !any_el_changed && !item.same(&d.1) {
-                any_el_changed = true;
-            }
-            new_data.push(d.1);
-        }
-
-        if any_el_changed {
-            self.1 = Arc::new(new_data);
-        }
-    }
-
-    fn data_len(&self) -> usize {
-        self.1.len()
-    }
-}
-
-impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
+impl<C, T> Widget<T> for List<C>
+where
+    C: Data,
+    T: ListIter<C>,
+{
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         let mut children = self.children.iter_mut();
         data.for_each_mut(|child_data, _| {
@@ -261,54 +178,130 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
-        let axis = self.axis; // keep the borrow checker happy
+        // keep the borrow checker happy
+        let axis = self.axis;
+        let cross_align = self.cross_align;
+
         let mut minor = axis.minor(bc.min());
         let mut major = 0.0;
 
         let mut paint_rect = Rect::ZERO;
         let mut children = self.children.iter_mut();
 
-        // TODO quantize to whole pixels
+        // TODO quantize to whole pixels (do we need to)
         // major constraint
-        let mc = if self.flex {
-            let div = axis.major(bc.max()) / (data.data_len() as f64);
-            (div, div)
-        } else {
-            (0., f64::INFINITY)
+        let maj_c = match self.main_align {
+            // This is the only layout where children are constriained on the major axis.
+            ListMainAlignment::FlexItems { spacing } => {
+                let len = data.data_len() as f64;
+                // We need to take spacing into account when working out size, but we need to
+                // multiply by `(n - 1) / n` to fix the fence/fencepost problem.
+                let div = (axis.major(bc.max()) - spacing * (len - 1.)) / len;
+                (div, div)
+            }
+            _ => (0., f64::INFINITY),
         };
+        // TODO cross axis alignment
 
-        // keep track of children's sizes for warning the user.
-        data.for_each(|child_data, _| {
-            let child = match children.next() {
-                Some(child) => child,
-                None => {
-                    return;
-                }
-            };
-            let child_bc = match axis {
-                Axis::Horizontal => BoxConstraints::new(
-                    Size::new(mc.0, bc.min().height),
-                    Size::new(mc.1, bc.max().height),
-                ),
-                Axis::Vertical => BoxConstraints::new(
-                    Size::new(bc.min().width, mc.0),
-                    Size::new(bc.max().width, mc.1),
-                ),
-            };
-            let child_size = child.layout(ctx, &child_bc, child_data, env);
-            let rect = Rect::from_origin_size(Point::from(axis.pack(major, 0.0)), child_size);
-            child.set_layout_rect(ctx, child_data, env, rect);
-            paint_rect = paint_rect.union(child.paint_rect());
-            minor = minor.max(axis.minor(child_size));
-            major += axis.major(child_size);
-        });
+        // We branch on flex, because the flex option only requires 1 pass - we don't need to
+        // find out the sizes of the children because we will enforce size.
+        match self.main_align {
+            // 1 pass to layout items.
+            ListMainAlignment::FlexItems { spacing } => {
+                data.for_each(|child_data, _| {
+                    let child = match children.next() {
+                        Some(child) => child,
+                        None => {
+                            return;
+                        }
+                    };
+                    let child_bc = axis.constraints(bc, maj_c.0, maj_c.1);
+                    let child_size = child.layout(ctx, &child_bc, child_data, env);
+                    let rect =
+                        Rect::from_origin_size(Point::from(axis.pack(major, 0.0)), child_size);
+                    child.set_layout_rect(ctx, child_data, env, rect);
+                    paint_rect = paint_rect.union(child.paint_rect());
+                    minor = minor.max(axis.minor(child_size));
+                    major += axis.major(child_size) + spacing;
+                });
 
-        // TODO I don't understand this logic. If we end up constraining here then our layout for
-        // the child elements is broken, no?
-        let my_size = bc.constrain(Size::from(axis.pack(major, minor)));
-        let insets = paint_rect - Rect::ZERO.with_size(my_size);
-        ctx.set_paint_insets(insets);
-        my_size
+                // Correct for overshoot
+                major -= spacing;
+
+                let unconstrained_size: Size = axis.pack(major, minor).into();
+                let my_size = bc.constrain(unconstrained_size);
+                let insets = paint_rect - Rect::ZERO.with_size(my_size);
+                ctx.set_paint_insets(insets);
+                my_size
+            }
+            ListMainAlignment::NoFlex(main_align) => {
+                // Measure children.
+                let mut major_non_flex = 0.0;
+                let mut children = self.children.iter_mut();
+                data.for_each(|child_data, _| {
+                    let child = match children.next() {
+                        Some(child) => child,
+                        None => {
+                            return;
+                        }
+                    };
+                    let child_bc = axis.constraints(bc, maj_c.0, maj_c.1);
+                    let child_size = child.layout(ctx, &child_bc, child_data, env);
+
+                    if child_size.width.is_infinite() {
+                        log::warn!("A non-Flex child has an infinite width.");
+                    }
+
+                    if child_size.height.is_infinite() {
+                        log::warn!("A non-Flex child has an infinite height.");
+                    }
+
+                    major_non_flex += axis.major(child_size).expand();
+                    minor = minor.max(axis.minor(child_size).expand());
+                    // Stash size.
+                    let rect = child_size.to_rect();
+                    child.set_layout_rect(ctx, child_data, env, rect);
+                });
+
+                let total_major = axis.major(bc.max());
+                let extra = (total_major - major_non_flex).max(0.0);
+                let mut spacing = Spacing::new(main_align, extra, self.children.len());
+
+                // Lay out the children.
+                let mut major = spacing.next().unwrap_or(0.);
+                let mut child_paint_rect = Rect::ZERO;
+                let mut children = self.children.iter_mut();
+                data.for_each(|child_data, _| {
+                    let child = match children.next() {
+                        Some(child) => child,
+                        None => {
+                            return;
+                        }
+                    };
+                    let child_size = child.layout_rect().size();
+                    let child_minor_offset = {
+                        let extra_minor = minor - axis.minor(child_size);
+                        cross_align.align(extra_minor)
+                    };
+
+                    let child_pos: Point = axis.pack(major, child_minor_offset).into();
+                    let child_frame = Rect::from_origin_size(child_pos, child_size);
+                    child.set_layout_rect(ctx, child_data, env, child_frame);
+                    child_paint_rect = child_paint_rect.union(child.paint_rect());
+                    major += axis.major(child_size).expand();
+                    major += spacing.next().unwrap_or(0.);
+                });
+
+                let my_size: Size = axis.pack(major, minor).into();
+                let max_major = axis.major(bc.max());
+                let my_size = axis.constraints(bc, 0.0, max_major).constrain(my_size);
+
+                let my_bounds = Rect::ZERO.with_size(my_size);
+                let insets = child_paint_rect - my_bounds;
+                ctx.set_paint_insets(insets);
+                my_size
+            }
+        }
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -21,8 +21,6 @@ use std::f64;
 use std::fmt;
 
 pub use self::iter::ListIter;
-#[cfg(feature = "im")]
-use crate::im::Vector;
 use crate::kurbo::{Rect, Size};
 use crate::widget::{Axis, CrossAxisAlignment};
 use crate::{
@@ -39,32 +37,41 @@ pub enum Spacing {
         /// the space size and the item size. For example, a value of `2` would mean that spaces
         /// are twice the size of items.
         ratio: f64,
-        /// 0, 0.5, or 1 usually.
+        /// The ratio of the size of end spacing to middle. A value of 0. means no end spacing, 1.
+        /// means the same as the middle, and e.g. 0.5 matches `SpaceEvenly` behavor.
         end_ratio: f64,
     },
-    /// Spaces should be a fixed width of `.0` units.
-    Fixed { size: f64 },
+    /// Spaces should be a fixed width. In this case padding at the start and end of the axis
+    /// should be added using e.g. `WidgetExt::padding`.
+    Fixed {
+        /// The size, in logical pixels, that the space should be.
+        size: f64,
+    },
 }
 
 impl Spacing {
+    /// Create a spacing strategy like `SpaceAround`.
     pub fn around(ratio: f64) -> Self {
         Spacing::Flexed {
             ratio,
             end_ratio: 1.0,
         }
     }
+    /// Create a spacing strategy like `SpaceEvenly`.
     pub fn evenly(ratio: f64) -> Self {
         Spacing::Flexed {
             ratio,
             end_ratio: 0.5,
         }
     }
+    /// Create a spacing strategy like `SpaceBetween`.
     pub fn between(ratio: f64) -> Self {
         Spacing::Flexed {
             ratio,
             end_ratio: 0.0,
         }
     }
+    /// Create a spacing strategy with a fixed size spacer.
     pub fn fixed(size: f64) -> Self {
         Spacing::Fixed { size }
     }
@@ -118,46 +125,52 @@ impl<T: Data> List<T> {
 
     /// Create a list where items are in a left -> right row
     #[inline]
-    pub fn horizontal<W: Widget<T> + 'static>(mut closure: impl FnMut() -> W + 'static) -> Self {
+    pub fn horizontal<W: Widget<T> + 'static>(closure: impl FnMut() -> W + 'static) -> Self {
         Self::new(closure, Axis::Horizontal)
     }
 
     /// Create a list where items are in a top -> bottom column
     #[inline]
-    pub fn vertical<W: Widget<T> + 'static>(mut closure: impl FnMut() -> W + 'static) -> Self {
+    pub fn vertical<W: Widget<T> + 'static>(closure: impl FnMut() -> W + 'static) -> Self {
         Self::new(closure, Axis::Vertical)
     }
 
+    /// Set the strategy for adding spacing. Defaults to packing the items tightly to the left/top.
     #[inline]
     pub fn with_spacing(mut self, spacing: Spacing) -> Self {
         self.spacing = spacing;
         self
     }
 
+    /// Set the strategy for adding spacing. Defaults to packing the items tightly to the left/top.
     #[inline]
     pub fn set_spacing(&mut self, spacing: Spacing) -> &mut Self {
         self.spacing = spacing;
         self
     }
 
+    /// Whether items should expand to take up available space.
     #[inline]
     pub fn with_flex_items(mut self, flex_items: bool) -> Self {
         self.flex_items = flex_items;
         self
     }
 
+    /// Whether items should expand to take up available space.
     #[inline]
     pub fn set_flex_items(&mut self, flex_items: bool) -> &mut Self {
         self.flex_items = flex_items;
         self
     }
 
+    /// How to align elements if they are not all the same size in the cross axis.
     #[inline]
     pub fn with_cross_alignment(mut self, cross_alignment: CrossAxisAlignment) -> Self {
         self.cross_alignment = cross_alignment;
         self
     }
 
+    /// How to align elements if they are not all the same size in the cross axis.
     #[inline]
     pub fn set_cross_alignment(&mut self, cross_alignment: CrossAxisAlignment) -> &mut Self {
         self.cross_alignment = cross_alignment;

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -241,7 +241,7 @@ where
         let cross_align = self.cross_alignment;
         let len = self.children.len();
 
-        log::trace!("parameters: {:?}", self);
+        //log::trace!("parameters: {:?}", self);
 
         // Calculate main axis constraints: it's complicated by spacing.
         let main_constraints = if self.flex_items {
@@ -260,7 +260,7 @@ where
             (0., f64::INFINITY)
         };
         let item_bc = axis.constraints(bc, main_constraints.0, main_constraints.1);
-        log::trace!("Child constraints: {:?}", item_bc);
+        //log::trace!("Child constraints: {:?}", item_bc);
 
         // A 2-pass strategy is used: the first pass is to allow children to find their size, and
         // the second pass is then to position everything once we know the children's sizes.
@@ -280,7 +280,7 @@ where
             cross_max = cross_max.max(axis.minor(size));
             main_total += axis.major(size);
         });
-        log::trace!("cross_max: {}, main_total: {}", cross_max, main_total);
+        //log::trace!("cross_max: {}, main_total: {}", cross_max, main_total);
 
         // Pass 2 - position the children correctly.
         // We need to tell druid the bounds of where our children will paint.
@@ -299,7 +299,7 @@ where
                     }
                     let min_main = axis.major(bc.min());
                     let spare_space = main_total.max(min_main) - main_total;
-                    log::trace!("min_main = {}, spare_space = {}", min_main, spare_space);
+                    //log::trace!("min_main = {}, spare_space = {}", min_main, spare_space);
                     if spare_space < 1e-6 {
                         (0.0, 0.0)
                     } else {
@@ -310,7 +310,7 @@ where
             }
             Spacing::Fixed { size } => (size, 0.0),
         };
-        log::trace!("spacing = {}, main_position = {}", spacing, main_position);
+        //log::trace!("spacing = {}, main_position = {}", spacing, main_position);
 
         zip_children(&mut self.children, data, |child, data, _| {
             let size = child.layout_rect().size();
@@ -319,7 +319,7 @@ where
             let rect = Rect::from_origin_size(axis.pack(main_position, cross_position), size);
             child.set_layout_rect(ctx, data, env, rect);
             // for calculating insets
-            paint_rect = paint_rect.union(rect);
+            paint_rect = paint_rect.union(rect + child.paint_insets());
 
             main_position += axis.major(size) + spacing;
         });
@@ -330,13 +330,6 @@ where
             Spacing::Fixed { .. } => 0.0,
         };
         let main_end = main_position + spacing * (end_ratio - 1.0);
-        log::trace!(
-            "end_ratio = {}, main_position = {}, spacing = {}, main_end = {}",
-            end_ratio,
-            main_position,
-            spacing,
-            main_end
-        );
 
         // Calculate insets and return our size.
         let unconstrained_size: Size = axis.pack(main_end, cross_max).into();

--- a/druid/src/widget/list/iter.rs
+++ b/druid/src/widget/list/iter.rs
@@ -1,0 +1,135 @@
+use crate::Data;
+#[cfg(feature = "im")]
+use im::Vector;
+use std::sync::Arc;
+
+/// This iterator enables writing List widget for any `Data`.
+pub trait ListIter<T>: Data {
+    /// Iterate over each data child.
+    fn for_each(&self, cb: impl FnMut(&T, usize));
+
+    /// Iterate over each data child. Keep track of changed data and update self.
+    fn for_each_mut(&mut self, cb: impl FnMut(&mut T, usize));
+
+    /// Return data length.
+    fn data_len(&self) -> usize;
+}
+
+#[cfg(feature = "im")]
+impl<T: Data> ListIter<T> for Vector<T> {
+    fn for_each(&self, mut cb: impl FnMut(&T, usize)) {
+        for (i, item) in self.iter().enumerate() {
+            cb(item, i);
+        }
+    }
+
+    fn for_each_mut(&mut self, mut cb: impl FnMut(&mut T, usize)) {
+        for (i, item) in self.iter_mut().enumerate() {
+            cb(item, i);
+        }
+    }
+
+    fn data_len(&self) -> usize {
+        self.len()
+    }
+}
+
+// S == shared data type
+#[cfg(feature = "im")]
+impl<S: Data, T: Data> ListIter<(S, T)> for (S, Vector<T>) {
+    fn for_each(&self, mut cb: impl FnMut(&(S, T), usize)) {
+        for (i, item) in self.1.iter().enumerate() {
+            let d = (self.0.to_owned(), item.to_owned());
+            cb(&d, i);
+        }
+    }
+
+    fn for_each_mut(&mut self, mut cb: impl FnMut(&mut (S, T), usize)) {
+        for (i, item) in self.1.iter_mut().enumerate() {
+            let mut d = (self.0.clone(), item.clone());
+            cb(&mut d, i);
+
+            if !self.0.same(&d.0) {
+                self.0 = d.0;
+            }
+            if !item.same(&d.1) {
+                *item = d.1;
+            }
+        }
+    }
+
+    fn data_len(&self) -> usize {
+        self.1.len()
+    }
+}
+
+impl<T: Data> ListIter<T> for Arc<Vec<T>> {
+    fn for_each(&self, mut cb: impl FnMut(&T, usize)) {
+        for (i, item) in self.iter().enumerate() {
+            cb(item, i);
+        }
+    }
+
+    fn for_each_mut(&mut self, mut cb: impl FnMut(&mut T, usize)) {
+        let mut new_data = Vec::with_capacity(self.data_len());
+        let mut any_changed = false;
+
+        for (i, item) in self.iter().enumerate() {
+            let mut d = item.to_owned();
+            cb(&mut d, i);
+
+            if !any_changed && !item.same(&d) {
+                any_changed = true;
+            }
+            new_data.push(d);
+        }
+
+        if any_changed {
+            *self = Arc::new(new_data);
+        }
+    }
+
+    fn data_len(&self) -> usize {
+        self.len()
+    }
+}
+
+// S == shared data type
+impl<S: Data, T: Data> ListIter<(S, T)> for (S, Arc<Vec<T>>) {
+    fn for_each(&self, mut cb: impl FnMut(&(S, T), usize)) {
+        for (i, item) in self.1.iter().enumerate() {
+            let d = (self.0.clone(), item.to_owned());
+            cb(&d, i);
+        }
+    }
+
+    fn for_each_mut(&mut self, mut cb: impl FnMut(&mut (S, T), usize)) {
+        let mut new_data = Vec::with_capacity(self.1.len());
+        let mut any_shared_changed = false;
+        let mut any_el_changed = false;
+
+        for (i, item) in self.1.iter().enumerate() {
+            let mut d = (self.0.clone(), item.to_owned());
+            cb(&mut d, i);
+
+            if !any_shared_changed && !self.0.same(&d.0) {
+                any_shared_changed = true;
+            }
+            if any_shared_changed {
+                self.0 = d.0;
+            }
+            if !any_el_changed && !item.same(&d.1) {
+                any_el_changed = true;
+            }
+            new_data.push(d.1);
+        }
+
+        if any_el_changed {
+            self.1 = Arc::new(new_data);
+        }
+    }
+
+    fn data_len(&self) -> usize {
+        self.1.len()
+    }
+}

--- a/druid/src/widget/list/iter.rs
+++ b/druid/src/widget/list/iter.rs
@@ -1,6 +1,6 @@
-use crate::Data;
 #[cfg(feature = "im")]
-use im::Vector;
+use crate::im::Vector;
+use crate::Data;
 use std::sync::Arc;
 
 /// This iterator enables writing List widget for any `Data`.

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -69,7 +69,7 @@ pub use flex::{Axis, CrossAxisAlignment, Flex, FlexParams, MainAxisAlignment};
 pub use identity_wrapper::IdentityWrapper;
 pub use label::{Label, LabelText, LineBreaking, RawLabel};
 pub use lens_wrap::LensWrap;
-pub use list::{List, ListIter, ListMainAlignment};
+pub use list::{List, ListIter, Spacing as ListSpacing};
 pub use padding::Padding;
 pub use painter::{BackgroundBrush, Painter};
 pub use parse::Parse;

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -69,7 +69,7 @@ pub use flex::{Axis, CrossAxisAlignment, Flex, FlexParams, MainAxisAlignment};
 pub use identity_wrapper::IdentityWrapper;
 pub use label::{Label, LabelText, LineBreaking, RawLabel};
 pub use lens_wrap::LensWrap;
-pub use list::{List, ListIter};
+pub use list::{List, ListIter, ListMainAlignment};
 pub use padding::Padding;
 pub use painter::{BackgroundBrush, Painter};
 pub use parse::Parse;


### PR DESCRIPTION
I ended up redesigning this widget, moving it away from how `Flex` works. It could replace `List`, live alongside it, or live out of tree in the project I'll use it in (`jack-mixer`).

## Original notes

I need this for some work that I'm doing where I want a horizontal dynamic list with spacing. It might need some tidying before merge (i.e. the TODOs).

A future addition would be `{Main|Cross}AxisAlignment`. However I'm not sure if you actually need `MainAxisAlignment` since you can do stuff with wrapping widgets.