### PR TITLE
Ensure that WindowHandle and IdleHandle have right Send/Sync markers

### DIFF
--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -97,3 +97,4 @@ features = ["Window", "MouseEvent", "CssStyleDeclaration", "WheelEvent", "KeyEve
 [dev-dependencies]
 piet-common = { version = "=0.2.0-pre6", features = ["png"] }
 simple_logger = { version = "1.9.0", default-features = false }
+static_assertions = "1.1.0"

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -654,3 +654,13 @@ impl From<platform::WindowHandle> for WindowHandle {
         WindowHandle(src)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use static_assertions as sa;
+
+    sa::assert_not_impl_any!(WindowHandle: Send, Sync);
+    sa::assert_impl_all!(IdleHandle: Send);
+}


### PR DESCRIPTION
This (hopefully) clears up some unsoundness in the GTK backend, and also enforces cross-platform Send/Sync markers for WindowHandle and IdleHandle.