### PR TITLE
Allow user to specify different min-sizes for each side of a Split.

### DIFF
--- a/druid/examples/split_demo.rs
+++ b/druid/examples/split_demo.rs
@@ -52,7 +52,7 @@ fn build_app() -> impl Widget<u32> {
             .split_point(0.5)
             .draggable(true)
             .solid_bar(true)
-            .min_size(60.0),
+            .min_size(60.0, 60.0),
         )
         .border(Color::WHITE, 1.0),
     );

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -24,9 +24,9 @@ pub struct Split<T> {
     split_axis: Axis,
     split_point_chosen: f64,
     split_point_effective: f64,
-    min_size: f64,     // Integers only
-    bar_size: f64,     // Integers only
-    min_bar_area: f64, // Integers only
+    min_size: (f64, f64), // Integers only
+    bar_size: f64,        // Integers only
+    min_bar_area: f64,    // Integers only
     solid: bool,
     draggable: bool,
     child1: WidgetPod<T, Box<dyn Widget<T>>>,
@@ -47,7 +47,7 @@ impl<T> Split<T> {
             split_axis,
             split_point_chosen: 0.5,
             split_point_effective: 0.5,
-            min_size: 0.0,
+            min_size: (0.0, 0.0),
             bar_size: 6.0,
             min_bar_area: 6.0,
             solid: false,
@@ -86,9 +86,10 @@ impl<T> Split<T> {
     ///
     /// The value must be greater than or equal to `0.0`.
     /// The value will be rounded up to the nearest integer.
-    pub fn min_size(mut self, min_size: f64) -> Self {
-        assert!(min_size >= 0.0);
-        self.min_size = min_size.ceil();
+    pub fn min_size(mut self, first: f64, second: f64) -> Self {
+        assert!(first >= 0.0);
+        assert!(second >= 0.0);
+        self.min_size = (first.ceil(), second.ceil());
         self
     }
 
@@ -180,8 +181,8 @@ impl<T> Split<T> {
     fn split_side_limits(&self, size: Size) -> (f64, f64) {
         let split_axis_size = self.split_axis.major(size);
 
-        let mut min_limit = self.min_size;
-        let mut max_limit = (split_axis_size - min_limit).max(0.0);
+        let (mut min_limit, min_second) = self.min_size;
+        let mut max_limit = (split_axis_size - min_second).max(0.0);
 
         if min_limit > max_limit {
             min_limit = 0.5 * (min_limit + max_limit);


### PR DESCRIPTION
Right now the Split widget only accepts a single "min_size: f64" value which is applied to both halves of the split. In situations where the two child widgets have different min-sizes, the user has no way to specify this, leading to one component being overlarge or the other sometimes forced off the edge of the Split widget. This patch modifies the relevant functions to accept separate min-size values for the two child widgets.