### PR TITLE
Respect max constraints for non-flex children in flex

### DIFF
--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -627,9 +627,10 @@ impl<T: Data> Widget<T> for Flex<T> {
             any_use_baseline &= child.params.alignment == Some(CrossAxisAlignment::Baseline);
 
             if child.params.flex == 0.0 {
+                let remaining_major = (self.direction.major(bc.max()) - major_non_flex).max(0.0);
                 let child_bc = self
                     .direction
-                    .constraints(&loosened_bc, 0., std::f64::INFINITY);
+                    .constraints(&loosened_bc, 0., remaining_major);
                 let child_size = child.widget.layout(ctx, &child_bc, data, env);
                 let baseline_offset = child.widget.baseline_offset();
 


### PR DESCRIPTION
Previously, if the sizes of the non-flex children were greater than the total size, they would spill over the end. With this change, they will end up with a zero-sized layout rect.

