### PR TITLE
Add Formatter trait for validating & formatting text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ You can find its changes [documented below](#060---2020-06-01).
 ## [Unreleased]
 
 ### Highlights
+- Text improvements: `TextLayout` type ([#1182]) and cich text support ([#1245])
+- The `Formatter` trait provides more flexible handling of converions between
+values and their textual representations. ([#1377])
 
 ### Added
 
@@ -58,6 +61,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - Add default minimum size to `WindowConfig`. ([#1438] by [@colinfruit])
 - Open and save dialogs send configurable commands. ([#1463] by [@jneem])
 - Windows: Dialogs now respect the parameter passed to `force_starting_directory()` ([#1452] by [@MaximilianKoestler])
+- Value formatting with the `Formatter` trait ([#1377] by [@cmyr])
 
 ### Changed
 
@@ -88,6 +92,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - Part of the `SAVE_FILE` command is now `SAVE_FILE_AS` ([#1463] by [@jneem])
 
 ### Deprecated
+- Parse widget (replaced with `Formatter` trait) ([#1377] by [@cmyr])
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "docs/book_examples",
     "druid/examples/web",
     "druid/examples/hello_web",
+    "druid/examples/value_formatting",
 ]
 default-members = [
     "druid",

--- a/druid/examples/flex.rs
+++ b/druid/examples/flex.rs
@@ -17,12 +17,13 @@
 //! knobs to change all the parameters. 99% of the time you will want to
 //! hard-code these parameters, which will simplify your code considerably.
 
+use druid::text::format::ParseFormatter;
 use druid::widget::prelude::*;
 use druid::widget::{
     Button, Checkbox, CrossAxisAlignment, Flex, Label, MainAxisAlignment, ProgressBar, RadioGroup,
     SizedBox, Slider, Stepper, Switch, TextBox, WidgetExt,
 };
-use druid::{AppLauncher, Color, Data, Lens, LensExt, WindowDesc};
+use druid::{AppLauncher, Color, Data, Lens, WidgetId, WindowDesc};
 
 const DEFAULT_SPACER_SIZE: f64 = 8.;
 const SPACER_OPTIONS: [(&str, Spacers); 4] = [
@@ -210,11 +211,8 @@ fn make_spacer_select() -> impl Widget<Params> {
             Flex::row()
                 .with_child(
                     TextBox::new()
-                        .parse()
-                        .lens(
-                            Params::spacer_size
-                                .map(|x| Some(*x), |x, y| *x = y.unwrap_or(DEFAULT_SPACER_SIZE)),
-                        )
+                        .with_formatter(ParseFormatter::new())
+                        .lens(Params::spacer_size)
                         .fix_width(60.0),
                 )
                 .with_spacer(druid::theme::WIDGET_CONTROL_COMPONENT_PADDING)

--- a/druid/examples/parse.rs
+++ b/druid/examples/parse.rs
@@ -12,29 +12,540 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use druid::widget::{Align, Flex, Label, Parse, TextBox};
-use druid::{AppLauncher, LocalizedString, Widget, WindowDesc};
+//! Demonstrates how to use value formatters to constrain the contents
+//! of a text box.
+
+use druid::text::format::{Formatter, Validation, ValidationError};
+use druid::text::{Selection, TextLayout};
+use druid::widget::{prelude::*, Flex, Label, TextBox};
+use druid::{AppLauncher, Data, Lens, Point, Selector, WidgetExt, WidgetPod, WindowDesc};
+
+/// Various values that we are going to use with formatters.
+#[derive(Debug, Clone, Data, Lens)]
+struct AppData {
+    dollars: f64,
+    euros: f64,
+    pounds: f64,
+    postal_code: PostalCode,
+    dont_type_cat: String,
+}
 
 pub fn main() {
-    let main_window = WindowDesc::new(ui_builder).title(
-        LocalizedString::new("parse-demo-window-title").with_placeholder("Number Parsing Demo"),
-    );
-    let data = Some(0);
+    let main_window = WindowDesc::new(ui_builder).title("Formatting and Validation");
+
+    let data = AppData {
+        dollars: 12.2,
+        euros: -20.0,
+        pounds: 1337.,
+        postal_code: PostalCode::new("H0H0H0").unwrap(),
+        dont_type_cat: String::new(),
+    };
+
     AppLauncher::with_window(main_window)
         .use_simple_logger()
         .launch(data)
         .expect("launch failed");
 }
 
-fn ui_builder() -> impl Widget<Option<u32>> {
-    let label = Label::new(|data: &Option<u32>, _env: &_| {
-        data.map_or_else(|| "Invalid input".into(), |x| x.to_string())
-    });
-    let input = Parse::new(TextBox::new());
-
-    let mut col = Flex::column();
-    col.add_child(label);
-    col.add_default_spacer();
-    col.add_child(input);
-    Align::centered(col)
+fn ui_builder() -> impl Widget<AppData> {
+    Flex::column()
+        .cross_axis_alignment(druid::widget::CrossAxisAlignment::End)
+        .with_child(
+            error_displaying_value_textbox("Dollars:", NaiveCurrencyFormatter::DOLLARS, None, None)
+                .lens(AppData::dollars),
+        )
+        .with_default_spacer()
+        .with_child(
+            error_displaying_value_textbox(
+                "Euros, often:",
+                NaiveCurrencyFormatter::EUROS,
+                None,
+                None,
+            )
+            .lens(AppData::euros),
+        )
+        .with_default_spacer()
+        .with_child(
+            error_displaying_value_textbox(
+                "Sterling Quidpence:",
+                NaiveCurrencyFormatter::GBP,
+                None,
+                None,
+            )
+            .lens(AppData::pounds),
+        )
+        .with_default_spacer()
+        .with_child(
+            error_displaying_value_textbox(
+                "Postal Code:",
+                CanadianPostalCodeFormatter,
+                Some("H1M 0M0"),
+                None,
+            )
+            .lens(AppData::postal_code),
+        )
+        .with_default_spacer()
+        .with_child(
+            error_displaying_value_textbox(
+                "Cat selector:",
+                CatSelectingFormatter,
+                Some("Don't type 'cat'"),
+                Some(140.0),
+            )
+            .lens(AppData::dont_type_cat),
+        )
+        .center()
+        //.debug_paint_layout()
+        .debug_widget_id()
 }
+
+fn error_displaying_value_textbox<T: Data>(
+    label: &str,
+    formatter: impl Formatter<T> + 'static,
+    placeholder: Option<&str>,
+    textbox_width: Option<f64>,
+) -> impl Widget<T> {
+    const DEFAULT_WIDTH: f64 = 100.0;
+    let label = Label::new(label);
+    let textbox = TextBox::new()
+        .with_placeholder(placeholder.unwrap_or(""))
+        .with_formatter(formatter)
+        .fix_width(textbox_width.unwrap_or(DEFAULT_WIDTH));
+
+    ErrorDisplayTextbox::new(
+        Flex::row()
+            .cross_axis_alignment(druid::widget::CrossAxisAlignment::Baseline)
+            .with_child(label)
+            .with_default_spacer()
+            .with_child(textbox),
+    )
+}
+
+struct ErrorDisplayTextbox<T, W> {
+    textbox: WidgetPod<T, W>,
+    error: Option<TextLayout<String>>,
+}
+
+impl<T: Data, W: Widget<T>> ErrorDisplayTextbox<T, W> {
+    fn new(textbox: W) -> Self {
+        ErrorDisplayTextbox {
+            textbox: WidgetPod::new(textbox),
+            error: None,
+        }
+    }
+}
+
+impl<T: Data, W: Widget<T>> Widget<T> for ErrorDisplayTextbox<T, W> {
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
+        match event {
+            Event::Notification(n) if n.is(TextBox::VALIDATION_FAILED) => {
+                let text = n.get(TextBox::VALIDATION_FAILED).unwrap().to_string();
+                let mut layout = TextLayout::from_text(text);
+                layout.set_text_size(12.0);
+                layout.set_text_alignment(druid::TextAlignment::End);
+                self.error = Some(layout);
+                ctx.set_handled();
+            }
+            Event::Notification(n) if n.is(TextBox::EDITING_FINISHED) => {
+                self.error = None;
+                ctx.request_layout();
+                ctx.set_handled();
+            }
+            _ => self.textbox.event(ctx, event, data, env),
+        }
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        self.textbox.lifecycle(ctx, event, data, env);
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
+        self.textbox.update(ctx, data, env);
+        if !old_data.same(data) {
+            self.error = None;
+        } else if let Some(error) = &mut self.error {
+            if error.needs_rebuild_after_update(ctx) {
+                ctx.request_layout();
+            }
+        }
+    }
+
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
+        let textbox_size = self.textbox.layout(ctx, bc, data, env);
+        self.textbox.set_origin(ctx, data, env, Point::ZERO);
+        match &mut self.error {
+            Some(error) => {
+                error.set_wrap_width(textbox_size.width);
+                error.rebuild_if_needed(ctx.text(), env);
+                let error_size = error.size();
+                let total_width = textbox_size.width.max(error_size.width);
+                let v_padding = env.get(druid::theme::WIDGET_CONTROL_COMPONENT_PADDING);
+                let total_height = textbox_size.height + error_size.height + v_padding;
+                // set our baseline; we want to use the baseline of the TextBox.
+                let textbox_baseline = self.textbox.baseline_offset();
+                let our_baseline = textbox_baseline + v_padding + error_size.height;
+                ctx.set_baseline_offset(our_baseline);
+                Size::new(total_width, total_height)
+            }
+            None => {
+                // if we aren't drawing the label, our baseline is identical to textbox's
+                ctx.set_baseline_offset(self.textbox.baseline_offset());
+                textbox_size
+            }
+        }
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
+        let v_padding = env.get(druid::theme::WIDGET_CONTROL_COMPONENT_PADDING);
+        self.textbox.paint(ctx, data, env);
+        let textbox_size = self.textbox.layout_rect().size();
+        if let Some(error) = &mut self.error {
+            // we align the error to the right edge of the textbox, if allowed
+            let h_padding = (textbox_size.width - error.size().width).max(0.0);
+
+            let error_pos = Point::new(h_padding, self.textbox.layout_rect().height() + v_padding);
+            error.draw(ctx, error_pos);
+        }
+    }
+}
+
+/// A formatter that can display currency values.
+struct NaiveCurrencyFormatter {
+    currency_symbol: char,
+    thousands_separator: char,
+    decimal_separator: char,
+}
+
+/// Errors returned by [`NaiveCurrencyFormatter`].
+#[derive(Debug, Clone)]
+enum CurrencyValidationError {
+    Parse(std::num::ParseFloatError),
+    InvalidChar(char),
+    TooManyCharsAfterDecimal,
+}
+
+/// A `Formatter` for postal codes, which are the format A0A 0A0 where 'A' is
+/// any uppercase ascii character, and '0' is any numeral.
+///
+/// This formatter will accept lowercase characters as input, but will replace
+/// them with uppercase characters.
+struct CanadianPostalCodeFormatter;
+
+/// A Canadian postal code, in the format 'A0A0A0'.
+#[derive(Debug, Clone, Copy, Data)]
+struct PostalCode {
+    chars: [u8; 6],
+}
+
+/// Error returned by [`CanadianPostalCodeFormatter`].
+#[derive(Debug, Clone)]
+enum PostalCodeValidationError {
+    WrongNumberOfCharacters,
+    IncorrectFormat,
+}
+
+/// A formatter that sets the selection to the first occurance of the word 'cat'
+/// in an input string, if it is found.
+struct CatSelectingFormatter;
+
+impl NaiveCurrencyFormatter {
+    const DOLLARS: NaiveCurrencyFormatter = NaiveCurrencyFormatter {
+        currency_symbol: '$',
+        thousands_separator: ',',
+        decimal_separator: '.',
+    };
+
+    const EUROS: NaiveCurrencyFormatter = NaiveCurrencyFormatter {
+        currency_symbol: '€',
+        thousands_separator: '.',
+        decimal_separator: ',',
+    };
+
+    const GBP: NaiveCurrencyFormatter = NaiveCurrencyFormatter {
+        currency_symbol: '£',
+        thousands_separator: '.',
+        decimal_separator: ',',
+    };
+}
+
+impl Formatter<f64> for NaiveCurrencyFormatter {
+    fn format(&self, value: &f64) -> String {
+        if !value.is_normal() {
+            return format!("{}0{}00", self.currency_symbol, self.decimal_separator);
+        }
+
+        let mut components = Vec::new();
+        let mut major_part = value.abs().trunc() as usize;
+        let minor_part = (value.abs().fract() * 100.0).round() as usize;
+
+        let bonus_rounding_dollar = minor_part / 100;
+
+        components.push(format!("{}{:02}", self.decimal_separator, minor_part % 100));
+        if major_part == 0 {
+            components.push('0'.to_string());
+        }
+
+        while major_part > 0 {
+            let remain = major_part % 1000;
+            major_part /= 1000;
+            if major_part > 0 {
+                components.push(format!("{}{:03}", self.thousands_separator, remain));
+            } else {
+                components.push((remain + bonus_rounding_dollar).to_string());
+            }
+        }
+        if value.is_sign_negative() {
+            components.push(format!("-{}", self.currency_symbol));
+        } else {
+            components.push(self.currency_symbol.to_string());
+        }
+
+        components.iter().rev().flat_map(|s| s.chars()).collect()
+    }
+
+    fn format_for_editing(&self, value: &f64) -> String {
+        self.format(value)
+            .chars()
+            .filter(|c| *c != self.currency_symbol)
+            .collect()
+    }
+
+    fn value(&self, input: &str) -> Result<f64, ValidationError> {
+        // we need to convert from our naive localized representation back into
+        // rust's float representation
+        let decimal_pos = input
+            .bytes()
+            .rposition(|b| b as char == self.decimal_separator);
+        let (major, minor) = input.split_at(decimal_pos.unwrap_or_else(|| input.len()));
+        let canonical: String = major
+            .chars()
+            .filter(|c| *c != self.thousands_separator)
+            .chain(Some('.'))
+            .chain(minor.chars().skip(1))
+            .collect();
+        canonical
+            .parse()
+            .map_err(|err| ValidationError::new(CurrencyValidationError::Parse(err)))
+    }
+
+    fn validate_partial_input(&self, input: &str, _sel: &Selection) -> Validation {
+        if input.is_empty() {
+            return Validation::success();
+        }
+
+        let mut char_iter = input.chars();
+        if let Some(c) = char_iter.next() {
+            if !(c.is_ascii_digit() || c == '-') {
+                return Validation::failure();
+            }
+        }
+        let mut char_iter =
+            char_iter.skip_while(|c| c.is_ascii_digit() || *c == self.thousands_separator);
+        match char_iter.next() {
+            None => return Validation::success(),
+            Some(c) if c == self.decimal_separator => (),
+            Some(c) => return Validation::failure(CurrencyValidationError::InvalidChar(c)),
+        };
+
+        // we're after the decimal, allow up to 2 digits
+        let (d1, d2, d3) = (char_iter.next(), char_iter.next(), char_iter.next());
+        match (d1, d2, d3) {
+            (_, _, Some(_)) => {
+                Validation::failure(CurrencyValidationError::TooManyCharsAfterDecimal)
+            }
+            (Some(c), None, _) if c.is_ascii_digit() => Validation::success(),
+            (None, None, _) => Validation::success(),
+            (Some(c1), Some(c2), None) if c1.is_ascii_digit() && c2.is_ascii_digit() => {
+                Validation::success()
+            }
+            (Some(c1), other, _) => {
+                let bad_char = if c1.is_ascii_digit() {
+                    c1
+                } else {
+                    other.unwrap()
+                };
+                Validation::failure(CurrencyValidationError::InvalidChar(bad_char))
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+//TODO: never write parsing code like this again
+impl Formatter<PostalCode> for CanadianPostalCodeFormatter {
+    fn format(&self, value: &PostalCode) -> String {
+        value.to_string()
+    }
+
+    fn validate_partial_input(&self, input: &str, sel: &Selection) -> Validation {
+        let mut chars = input.chars();
+        let mut valid = true;
+        let mut has_space = false;
+        if matches!(chars.next(), Some(c) if !c.is_ascii_alphabetic()) {
+            valid = false;
+        }
+        if matches!(chars.next(), Some(c) if !c.is_ascii_digit()) {
+            valid = false;
+        }
+        if matches!(chars.next(), Some(c) if !c.is_ascii_alphabetic()) {
+            valid = false;
+        }
+        match chars.next() {
+            Some(' ') => {
+                has_space = true;
+                if matches!(chars.next(), Some(c) if !c.is_ascii_digit()) {
+                    valid = false;
+                }
+            }
+            Some(other) if !other.is_ascii_digit() => valid = false,
+            _ => (),
+        }
+
+        if matches!(chars.next(), Some(c) if !c.is_ascii_alphabetic()) {
+            valid = false;
+        }
+
+        if matches!(chars.next(), Some(c) if !c.is_ascii_digit()) {
+            valid = false;
+        }
+
+        if chars.next().is_some() {
+            valid = false;
+        }
+
+        if valid {
+            // if valid we convert to canonical format; h1h2h2 becomes H!H 2H2
+            let (replacement_text, sel) = if input.len() < 4 || has_space {
+                (input.to_uppercase(), None)
+            } else {
+                //let split_at = 3.min(input.len().saturating_sub(1));
+                let (first, second) = input.split_at(3);
+                let insert_space = if second.bytes().next() == Some(b' ') {
+                    None
+                } else {
+                    Some(' ')
+                };
+                let sel = if insert_space.is_some() && sel.is_caret() {
+                    Some(Selection::caret(sel.min() + 1))
+                } else {
+                    None
+                };
+                (
+                    first
+                        .chars()
+                        .map(|c| c.to_ascii_uppercase())
+                        .chain(insert_space)
+                        .chain(second.chars().map(|c| c.to_ascii_uppercase()))
+                        .collect(),
+                    sel,
+                )
+            };
+
+            if let Some(replacement_sel) = sel {
+                Validation::success()
+                    .change_text(replacement_text)
+                    .change_selection(replacement_sel)
+            } else {
+                Validation::success().change_text(replacement_text)
+            }
+        } else {
+            Validation::failure(ValidationError::new(
+                PostalCodeValidationError::IncorrectFormat,
+            ))
+        }
+    }
+
+    #[allow(clippy::clippy::many_single_char_names, clippy::clippy::match_ref_pats)]
+    fn value(&self, input: &str) -> Result<PostalCode, ValidationError> {
+        match input.as_bytes() {
+            &[a, b, c, d, e, f] => PostalCode::from_bytes([a, b, c, d, e, f]),
+            &[a, b, c, b' ', d, e, f] => PostalCode::from_bytes([a, b, c, d, e, f]),
+            _ => Err(PostalCodeValidationError::WrongNumberOfCharacters),
+        }
+        .map_err(ValidationError::new)
+    }
+}
+
+impl PostalCode {
+    fn new(s: &str) -> Result<Self, PostalCodeValidationError> {
+        if s.as_bytes().len() != 6 {
+            Err(PostalCodeValidationError::WrongNumberOfCharacters)
+        } else {
+            let b = s.as_bytes();
+            Self::from_bytes([b[0], b[1], b[2], b[3], b[4], b[5]])
+        }
+    }
+
+    fn from_bytes(bytes: [u8; 6]) -> Result<Self, PostalCodeValidationError> {
+        if [bytes[0], bytes[2], bytes[4]]
+            .iter()
+            .all(|b| (*b as char).is_ascii_uppercase())
+            && [bytes[1], bytes[3], bytes[5]]
+                .iter()
+                .all(|b| (*b as char).is_ascii_digit())
+        {
+            Ok(PostalCode { chars: bytes })
+        } else {
+            Err(PostalCodeValidationError::IncorrectFormat)
+        }
+    }
+}
+
+#[allow(clippy::clippy::many_single_char_names)]
+impl std::fmt::Display for PostalCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let [a, b, c, d, e, g] = self.chars;
+        write!(
+            f,
+            "{}{}{} {}{}{}",
+            a as char, b as char, c as char, d as char, e as char, g as char
+        )
+    }
+}
+
+impl Formatter<String> for CatSelectingFormatter {
+    fn format(&self, value: &String) -> String {
+        value.to_owned()
+    }
+
+    fn value(&self, input: &str) -> Result<String, ValidationError> {
+        Ok(input.to_owned())
+    }
+
+    fn validate_partial_input(&self, input: &str, _sel: &Selection) -> Validation {
+        if let Some(idx) = input.find("cat") {
+            Validation::success().change_selection(Selection::new(idx, idx + 3))
+        } else {
+            Validation::success()
+        }
+    }
+}
+
+impl std::fmt::Display for CurrencyValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            CurrencyValidationError::InvalidChar(c) => write!(f, "Invalid character '{}'", c),
+            CurrencyValidationError::Parse(err) => write!(f, "Parse failed: {}", err),
+            CurrencyValidationError::TooManyCharsAfterDecimal => {
+                write!(f, "Too many characters after decimal")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CurrencyValidationError {}
+
+impl std::fmt::Display for PostalCodeValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            PostalCodeValidationError::WrongNumberOfCharacters => {
+                write!(f, "Incorrect number of characters.")
+            }
+            PostalCodeValidationError::IncorrectFormat => {
+                write!(f, "Postal code must be of format A2A2A2")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PostalCodeValidationError {}

--- a/druid/examples/value_formatting/Cargo.toml
+++ b/druid/examples/value_formatting/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "value-formatting"
+version = "0.1.0"
+authors = ["Colin Rofls <colin@cmyr.net>"]
+edition = "2018"
+
+[dependencies]
+druid = { path = "../../" }

--- a/druid/examples/value_formatting/README.md
+++ b/druid/examples/value_formatting/README.md
@@ -1,0 +1,11 @@
+# Validation
+
+This example demonstrates how to add a formatter to a textbox in order to ensure
+that the textbox contains valid data.
+
+The example is reasonably complex, for a number of reasons: firstly there are
+currently no built-in implementations of the `Formatter` trait included in
+druid, which means we have to write versions for the example, and additionally
+the mechanism for reporting errors that occur during formatting are difficult to
+handle in druid's current architecture, and involve some fairly ugly use of
+`Command` in order to function.

--- a/druid/examples/value_formatting/src/main.rs
+++ b/druid/examples/value_formatting/src/main.rs
@@ -1,0 +1,184 @@
+// Copyright 2020 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod formatters;
+mod widgets;
+
+use druid::widget::{prelude::*, Flex, Label, TextBox};
+use druid::{AppLauncher, Data, Lens, WidgetExt, WidgetId, WindowDesc};
+
+use formatters::{
+    CanadianPostalCodeFormatter, CatSelectingFormatter, NaiveCurrencyFormatter, PostalCode,
+};
+use widgets::{RootController, TextBoxErrorDelegate};
+
+/// Various values that we are going to use with formatters.
+#[derive(Debug, Clone, Data, Lens)]
+pub struct AppData {
+    dollars: f64,
+    euros: f64,
+    pounds: f64,
+    postal_code: PostalCode,
+    dont_type_cat: String,
+    #[data(ignore)]
+    active_textbox: Option<WidgetId>,
+    active_message: Option<&'static str>,
+}
+
+pub fn main() {
+    let main_window = WindowDesc::new(ui_builder).title("Formatting and Validation");
+
+    let data = AppData {
+        dollars: 12.2,
+        euros: -20.0,
+        pounds: 1337.,
+        postal_code: PostalCode::new("H0H0H0").unwrap(),
+        dont_type_cat: String::new(),
+        active_textbox: None,
+        active_message: None,
+    };
+
+    AppLauncher::with_window(main_window)
+        .use_simple_logger()
+        .launch(data)
+        .expect("launch failed");
+}
+
+fn dollar_validation_scope() -> impl Widget<AppData> {
+    let textbox = TextBox::new()
+        .with_formatter(NaiveCurrencyFormatter::DOLLARS)
+        .validate_while_editing(false)
+        .delegate(
+            TextBoxErrorDelegate::new(widgets::DOLLAR_ERROR_WIDGET).sends_partial_errors(true),
+        );
+    Flex::column()
+        .cross_axis_alignment(druid::widget::CrossAxisAlignment::End)
+        .with_child(
+            Flex::row()
+                .cross_axis_alignment(druid::widget::CrossAxisAlignment::Baseline)
+                .with_child(Label::new("Dollars:"))
+                .with_default_spacer()
+                .with_child(textbox),
+        )
+        .with_child(widgets::error_display_widget(widgets::DOLLAR_ERROR_WIDGET))
+        .lens(AppData::dollars)
+}
+
+fn euro_validation_scope() -> impl Widget<AppData> {
+    let textbox = TextBox::new()
+        .with_formatter(NaiveCurrencyFormatter::EUROS)
+        .delegate(TextBoxErrorDelegate::new(widgets::EURO_ERROR_WIDGET).sends_partial_errors(true));
+    Flex::column()
+        .cross_axis_alignment(druid::widget::CrossAxisAlignment::End)
+        .with_child(
+            Flex::row()
+                .cross_axis_alignment(druid::widget::CrossAxisAlignment::Baseline)
+                .with_child(Label::new("Euros, often:"))
+                .with_default_spacer()
+                .with_child(textbox),
+        )
+        .with_child(widgets::error_display_widget(widgets::EURO_ERROR_WIDGET))
+        .lens(AppData::euros)
+}
+
+fn pound_validation_scope() -> impl Widget<AppData> {
+    let textbox = TextBox::new()
+        .with_formatter(NaiveCurrencyFormatter::GBP)
+        .update_data_while_editing(true)
+        .delegate(
+            TextBoxErrorDelegate::new(widgets::POUND_ERROR_WIDGET).sends_partial_errors(true),
+        );
+    Flex::column()
+        .cross_axis_alignment(druid::widget::CrossAxisAlignment::End)
+        .with_child(
+            Flex::row()
+                .cross_axis_alignment(druid::widget::CrossAxisAlignment::Baseline)
+                .with_child(Label::new("Sterling Quidpence:"))
+                .with_default_spacer()
+                .with_child(textbox),
+        )
+        .with_child(widgets::error_display_widget(widgets::POUND_ERROR_WIDGET))
+        .lens(AppData::pounds)
+}
+
+fn postal_validation_scope() -> impl Widget<AppData> {
+    let textbox = TextBox::new()
+        .with_formatter(CanadianPostalCodeFormatter)
+        .delegate(
+            TextBoxErrorDelegate::new(widgets::POSTAL_ERROR_WIDGET).sends_partial_errors(true),
+        );
+    Flex::column()
+        .cross_axis_alignment(druid::widget::CrossAxisAlignment::End)
+        .with_child(
+            Flex::row()
+                .cross_axis_alignment(druid::widget::CrossAxisAlignment::Baseline)
+                .with_child(Label::new("Postal code:"))
+                .with_default_spacer()
+                .with_child(textbox),
+        )
+        .with_child(widgets::error_display_widget(widgets::POSTAL_ERROR_WIDGET))
+        .lens(AppData::postal_code)
+}
+
+fn cat_validation_scope() -> impl Widget<AppData> {
+    let textbox = TextBox::new()
+        .with_placeholder("^(`.`)^")
+        .with_formatter(CatSelectingFormatter)
+        .delegate(TextBoxErrorDelegate::new(widgets::CAT_ERROR_WIDGET));
+    Flex::column()
+        .cross_axis_alignment(druid::widget::CrossAxisAlignment::End)
+        .with_child(
+            Flex::row()
+                .cross_axis_alignment(druid::widget::CrossAxisAlignment::Baseline)
+                .with_child(Label::new("Cat selector:"))
+                .with_default_spacer()
+                .with_child(textbox),
+        )
+        .lens(AppData::dont_type_cat)
+}
+
+fn ui_builder() -> impl Widget<AppData> {
+    Flex::column()
+        .with_child(
+            widgets::explainer()
+                .padding(10.0)
+                .border(druid::theme::BORDER_DARK, 4.0)
+                .rounded(10.0)
+                .padding(10.0),
+        )
+        .with_default_spacer()
+        .with_child(
+            Flex::column()
+                .cross_axis_alignment(druid::widget::CrossAxisAlignment::End)
+                .with_child(dollar_validation_scope())
+                .with_default_spacer()
+                .with_child(euro_validation_scope())
+                .with_default_spacer()
+                .with_child(pound_validation_scope())
+                .with_default_spacer()
+                .with_child(postal_validation_scope())
+                .with_default_spacer()
+                .with_child(cat_validation_scope())
+                .center(),
+        )
+        .with_default_spacer()
+        .with_child(
+            widgets::active_value()
+                .padding(10.0)
+                .border(druid::theme::BORDER_DARK, 4.0)
+                .rounded(10.0)
+                .padding(10.0),
+        )
+        .controller(RootController)
+}

--- a/druid/examples/value_formatting/src/widgets.rs
+++ b/druid/examples/value_formatting/src/widgets.rs
@@ -1,0 +1,256 @@
+// Copyright 2020 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Widgets, widget components, and functions for creating widgets
+
+use druid::text::format::ValidationError;
+use druid::widget::{
+    prelude::*, Controller, Either, Label, SizedBox, TextBoxEvent, ValidationDelegate,
+};
+use druid::{Color, Data, Point, Selector, WidgetExt, WidgetId, WidgetPod};
+
+use super::AppData;
+
+pub const DOLLAR_ERROR_WIDGET: WidgetId = WidgetId::reserved(2);
+pub const EURO_ERROR_WIDGET: WidgetId = WidgetId::reserved(3);
+pub const POUND_ERROR_WIDGET: WidgetId = WidgetId::reserved(4);
+pub const POSTAL_ERROR_WIDGET: WidgetId = WidgetId::reserved(5);
+pub const CAT_ERROR_WIDGET: WidgetId = WidgetId::reserved(6);
+
+/// Sent by the [`TextBoxErrorDelegate`] when an error should be displayed.
+const SHOW_ERROR: Selector<ValidationError> = Selector::new("druid-example.show-error");
+/// Sent by the [`TextBoxErrorDelegate`] when an error should be cleared.
+const CLEAR_ERROR: Selector = Selector::new("druid-example.clear-error");
+/// Sent by the [`TextBoxErrorDelegate`] when editing began.
+///
+/// This is used to set the contents of the help text.
+const EDIT_BEGAN: Selector<WidgetId> = Selector::new("druid-example.edit-began");
+/// Sent by the [`TextBoxErrorDelegate`] when editing finishes.
+///
+/// This is used to set the contents of the help text.
+const EDIT_FINISHED: Selector<WidgetId> = Selector::new("druid-example.edit-finished");
+
+static DEFAULT_EXPLAINER: &str = "This example shows various ways you can use a \
+                                 TextBox with a Formatter to control the display \
+                                 and validation of text.";
+
+static DOLLAR_EXPLAINER: &str = "This text field accepts any input, and performs \
+                                 validation when the user attempts to complete \
+                                 editing.";
+
+static EURO_EXPLAINER: &str = "This text field performs validation during editing, \
+                               rejecting invalid edits.";
+
+static POUND_EXPLAINER: &str = "This text field updates the application data \
+                                during editing, whenever the current input is \
+                                valid.";
+
+static POSTAL_EXPLAINER: &str = "This text field edits the contents to ensure \
+                                 all letters are capitalized, and the two triplets \
+                                 are space-separated.";
+
+static CAT_EXPLAINER: &str = "This text field does no formatting, but selects any \
+                              instance of the string 'cat'.";
+
+const ERROR_TEXT_COLOR: Color = Color::rgb8(0xB6, 0x00, 0x04);
+
+/// Create a widget that will display errors.
+///
+/// The `id` param is the `WidgetId` that this widget should use; that id
+/// will be sent messages when it should display or clear an error.
+pub fn error_display_widget<T: Data>(id: WidgetId) -> impl Widget<T> {
+    ErrorController::new(
+        Either::new(
+            |d: &Option<ValidationError>, _| d.is_some(),
+            Label::dynamic(|d: &Option<ValidationError>, _| {
+                d.as_ref().map(|d| d.to_string()).unwrap_or_default()
+            })
+            .with_text_color(ERROR_TEXT_COLOR)
+            .with_text_size(12.0),
+            SizedBox::empty(),
+        )
+        .with_id(id),
+    )
+}
+
+/// Create the 'explainer' widget.
+pub fn explainer() -> impl Widget<AppData> {
+    Label::dynamic(|d: &Option<&'static str>, _| d.unwrap_or(DEFAULT_EXPLAINER).to_string())
+        .with_line_break_mode(druid::widget::LineBreaking::WordWrap)
+        .with_text_color(druid::theme::FOREGROUND_DARK)
+        .with_font(druid::theme::UI_FONT_ITALIC)
+        .lens(AppData::active_message)
+}
+
+/// Create the 'active value' widget
+pub fn active_value() -> impl Widget<AppData> {
+    Label::dynamic(|d: &AppData, _| match d.active_textbox {
+        None => "No textfield is active".to_string(),
+        Some(id) => match id {
+            DOLLAR_ERROR_WIDGET => format!("Active value: {:2}", d.dollars),
+            EURO_ERROR_WIDGET => format!("Active value: {:2}", d.euros),
+            POUND_ERROR_WIDGET => format!("Active value: {:2}", d.pounds),
+            POSTAL_ERROR_WIDGET => format!("Active value: {}", d.postal_code),
+            CAT_ERROR_WIDGET => format!("Active value: {}", d.dont_type_cat),
+            _ => unreachable!(),
+        },
+    })
+    .with_text_color(druid::theme::FOREGROUND_DARK)
+    .with_font(druid::theme::UI_FONT_ITALIC)
+}
+
+/// A widget that manages a child which can display an error.
+///
+/// This is not a blessed pattern, but works around certain limitations of Druid,
+/// using Commands.
+///
+/// The basic idea is that this widget owns an `Option<Error>`, and it either
+/// clears or sets this error based on `Command`s sent to it from some other
+/// widget.
+///
+/// It's child's data is this `Option<Error>`; the incoming data is ignored
+/// completely.
+pub struct ErrorController<W> {
+    child: WidgetPod<Option<ValidationError>, W>,
+    error: Option<ValidationError>,
+}
+
+/// A controller that sits at the root of our widget tree and updates the
+/// helper text in response to messages about the currently focused widget.
+pub struct RootController;
+
+pub struct TextBoxErrorDelegate {
+    target: WidgetId,
+    sends_partial_errors: bool,
+}
+
+impl<W: Widget<Option<ValidationError>>> ErrorController<W> {
+    pub fn new(child: W) -> ErrorController<W> {
+        ErrorController {
+            child: WidgetPod::new(child),
+            error: None,
+        }
+    }
+}
+
+impl<T, W: Widget<Option<ValidationError>>> Widget<T> for ErrorController<W> {
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, _data: &mut T, env: &Env) {
+        match event {
+            Event::Command(cmd) if cmd.is(SHOW_ERROR) => {
+                self.error = Some(cmd.get_unchecked(SHOW_ERROR).to_owned());
+                ctx.request_update();
+            }
+            Event::Command(cmd) if cmd.is(CLEAR_ERROR) => {
+                self.error = None;
+                ctx.request_update();
+            }
+            _ => self.child.event(ctx, event, &mut self.error, env),
+        }
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _: &T, env: &Env) {
+        self.child.lifecycle(ctx, event, &self.error, env);
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, _: &T, _: &T, env: &Env) {
+        self.child.update(ctx, &self.error, env)
+    }
+
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, _: &T, env: &Env) -> Size {
+        let size = self.child.layout(ctx, bc, &self.error, env);
+        self.child.set_origin(ctx, &self.error, env, Point::ZERO);
+        size
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, _: &T, env: &Env) {
+        self.child.paint(ctx, &self.error, env);
+    }
+
+    fn id(&self) -> Option<WidgetId> {
+        Some(self.child.id())
+    }
+}
+
+impl<W: Widget<AppData>> Controller<AppData, W> for RootController {
+    fn event(
+        &mut self,
+        child: &mut W,
+        ctx: &mut EventCtx,
+        event: &Event,
+        data: &mut AppData,
+        env: &Env,
+    ) {
+        match event {
+            Event::Command(cmd) if cmd.is(EDIT_BEGAN) => {
+                let widget_id = cmd.get_unchecked(EDIT_BEGAN).clone();
+                data.active_message = match widget_id {
+                    DOLLAR_ERROR_WIDGET => Some(DOLLAR_EXPLAINER),
+                    EURO_ERROR_WIDGET => Some(EURO_EXPLAINER),
+                    POUND_ERROR_WIDGET => Some(POUND_EXPLAINER),
+                    POSTAL_ERROR_WIDGET => Some(POSTAL_EXPLAINER),
+                    CAT_ERROR_WIDGET => Some(CAT_EXPLAINER),
+                    _ => unreachable!(),
+                };
+                data.active_textbox = Some(widget_id);
+            }
+            Event::Command(cmd) if cmd.is(EDIT_FINISHED) => {
+                let finished_id = cmd.get_unchecked(EDIT_FINISHED).clone();
+                if data.active_textbox == Some(finished_id) {
+                    data.active_textbox = None;
+                    data.active_message = None;
+                }
+            }
+            _ => child.event(ctx, event, data, env),
+        }
+    }
+}
+
+impl TextBoxErrorDelegate {
+    pub fn new(target: WidgetId) -> TextBoxErrorDelegate {
+        TextBoxErrorDelegate {
+            target,
+            sends_partial_errors: false,
+        }
+    }
+
+    pub fn sends_partial_errors(mut self, flag: bool) -> Self {
+        self.sends_partial_errors = flag;
+        self
+    }
+}
+
+impl ValidationDelegate for TextBoxErrorDelegate {
+    fn event(&mut self, ctx: &mut EventCtx, event: TextBoxEvent, _current_text: &str) {
+        match event {
+            TextBoxEvent::Began => {
+                ctx.submit_command(CLEAR_ERROR.to(self.target));
+                ctx.submit_command(EDIT_BEGAN.with(self.target));
+            }
+            TextBoxEvent::Changed if self.sends_partial_errors => {
+                ctx.submit_command(CLEAR_ERROR.to(self.target));
+            }
+            TextBoxEvent::PartiallyInvalid(err) if self.sends_partial_errors => {
+                ctx.submit_command(SHOW_ERROR.with(err.to_owned()).to(self.target));
+            }
+            TextBoxEvent::Invalid(err) => {
+                ctx.submit_command(SHOW_ERROR.with(err.to_owned()).to(self.target));
+            }
+            TextBoxEvent::Cancel | TextBoxEvent::Complete => {
+                ctx.submit_command(CLEAR_ERROR.to(self.target));
+                ctx.submit_command(EDIT_FINISHED.with(self.target));
+            }
+            _ => (),
+        }
+    }
+}

--- a/druid/examples/web/src/lib.rs
+++ b/druid/examples/web/src/lib.rs
@@ -72,7 +72,6 @@ impl_example!(list);
 impl_example!(multiwin);
 impl_example!(open_save);
 impl_example!(panels.unwrap());
-impl_example!(parse);
 impl_example!(scroll_colors);
 impl_example!(scroll);
 impl_example!(split_demo);

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -1139,6 +1139,7 @@ impl CursorChange {
 mod tests {
     use super::*;
     use crate::ext_event::ExtEventHost;
+    use crate::text::format::ParseFormatter;
     use crate::widget::{Flex, Scroll, Split, TextBox};
     use crate::{WidgetExt, WindowHandle, WindowId};
 
@@ -1148,13 +1149,13 @@ mod tests {
 
     #[test]
     fn register_children() {
-        fn make_widgets() -> impl Widget<Option<u32>> {
+        fn make_widgets() -> impl Widget<u32> {
             Split::columns(
-                Flex::<Option<u32>>::row()
-                    .with_child(TextBox::new().with_id(ID_1).parse())
-                    .with_child(TextBox::new().with_id(ID_2).parse())
-                    .with_child(TextBox::new().with_id(ID_3).parse()),
-                Scroll::new(TextBox::new().parse()),
+                Flex::<u32>::row()
+                    .with_child(TextBox::new().with_formatter(ParseFormatter).with_id(ID_1))
+                    .with_child(TextBox::new().with_formatter(ParseFormatter).with_id(ID_2))
+                    .with_child(TextBox::new().with_formatter(ParseFormatter).with_id(ID_3)),
+                Scroll::new(TextBox::new().with_formatter(ParseFormatter)),
             )
         }
 
@@ -1181,7 +1182,7 @@ mod tests {
 
         let env = Env::default();
 
-        widget.lifecycle(&mut ctx, &LifeCycle::WidgetAdded, &None, &env);
+        widget.lifecycle(&mut ctx, &LifeCycle::WidgetAdded, &1, &env);
         assert!(ctx.widget_state.children.may_contain(&ID_1));
         assert!(ctx.widget_state.children.may_contain(&ID_2));
         assert!(ctx.widget_state.children.may_contain(&ID_3));

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -1152,10 +1152,22 @@ mod tests {
         fn make_widgets() -> impl Widget<u32> {
             Split::columns(
                 Flex::<u32>::row()
-                    .with_child(TextBox::new().with_formatter(ParseFormatter).with_id(ID_1))
-                    .with_child(TextBox::new().with_formatter(ParseFormatter).with_id(ID_2))
-                    .with_child(TextBox::new().with_formatter(ParseFormatter).with_id(ID_3)),
-                Scroll::new(TextBox::new().with_formatter(ParseFormatter)),
+                    .with_child(
+                        TextBox::new()
+                            .with_formatter(ParseFormatter::new())
+                            .with_id(ID_1),
+                    )
+                    .with_child(
+                        TextBox::new()
+                            .with_formatter(ParseFormatter::new())
+                            .with_id(ID_2),
+                    )
+                    .with_child(
+                        TextBox::new()
+                            .with_formatter(ParseFormatter::new())
+                            .with_id(ID_3),
+                    ),
+                Scroll::new(TextBox::new().with_formatter(ParseFormatter::new())),
             )
         }
 

--- a/druid/src/text/editor.rs
+++ b/druid/src/text/editor.rs
@@ -88,12 +88,25 @@ impl<T: TextStorage + EditableText> Editor<T> {
     ///
     /// [`WidgetAdded`]: ../enum.LifeCycle.html#variant.WidgetAdded
     pub fn set_text(&mut self, text: T) {
-        self.layout.set_text(text)
+        self.selection = self.selection.constrained(&text);
+        self.layout.set_text(text);
     }
 
     /// Return the current selection.
     pub fn selection(&self) -> &Selection {
         &self.selection
+    }
+
+    /// Set the current selection.
+    ///
+    /// The selection will be constrained to the current text.
+    pub fn set_selection(&mut self, selection: Selection) {
+        let selection = self
+            .layout
+            .text()
+            .map(|t| selection.constrained(t))
+            .unwrap_or_else(|| Selection::caret(0));
+        self.selection = selection;
     }
 
     /// Returns the `Rect`s representing the  current selection.

--- a/druid/src/text/format.rs
+++ b/druid/src/text/format.rs
@@ -107,6 +107,8 @@ pub struct ValidationError {
 ///
 /// [`Formatter`]: Formatter
 /// [`FromStr`]: std::str::FromStr
+#[non_exhaustive]
+//TODO: take a fmt string (like `{:.2}` to allow user to customize output
 pub struct ParseFormatter;
 
 impl Validation {
@@ -159,6 +161,13 @@ impl ValidationError {
     }
 }
 
+impl ParseFormatter {
+    /// Create a new `ParseFormatter`.
+    pub fn new() -> Self {
+        ParseFormatter
+    }
+}
+
 impl<T> Formatter<T> for ParseFormatter
 where
     T: FromStr + std::fmt::Display,
@@ -189,5 +198,11 @@ impl std::fmt::Display for ValidationError {
 impl std::error::Error for ValidationError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(&*self.inner)
+    }
+}
+
+impl Default for ParseFormatter {
+    fn default() -> Self {
+        ParseFormatter
     }
 }

--- a/druid/src/text/format.rs
+++ b/druid/src/text/format.rs
@@ -1,0 +1,193 @@
+// Copyright 2020 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Creating, interpreting, and validating textual representations of values.
+
+use std::str::FromStr;
+use std::sync::Arc;
+
+use super::Selection;
+use crate::Data;
+
+/// A trait for types that create, interpret, and validate textual representations
+/// of values.
+///
+/// A formatter has two responsiblities: converting a value into an appropriate
+/// string representation, and attempting to convert a string back into the
+/// appropriate value.
+///
+/// In addition, a formatter performs validation on *partial* strings; that is,
+/// it determines whether or not a string represents a potentially valid value,
+/// even if it is not currently valid.
+pub trait Formatter<T> {
+    /// Return the string representation of this value.
+    fn format(&self, value: &T) -> String;
+    /// Return the string representation of this value, to be used during editing.
+    ///
+    /// This can be used if you want the text to differ based on whether or not
+    /// it is being edited; for instance you might display a dollar sign when
+    /// not editing, but not display it during editing.
+    fn format_for_editing(&self, value: &T) -> String {
+        self.format(value)
+    }
+
+    /// Determine whether the newly edited text is valid for this value type.
+    ///
+    /// This always returns a [`Validation`] object which indicates if
+    /// validation was successful or not, and which can also optionally,
+    /// regardless of success or failure, include new text and selection values
+    /// that should replace the current ones.
+    ///
+    ///
+    /// # Replacing the text or selection during validation
+    ///
+    /// Your `Formatter` may wish to change the current text or selection during
+    /// editing for a number of reasons. For instance if validation fails, you
+    /// may wish to allow editing to continue, but select the invalid region;
+    /// alternatively you may consider input valid but want to transform it,
+    /// such as by changing case or inserting spaces.
+    ///
+    /// If you do *not* explicitly set replacement text, and validation is not
+    /// successful, the edit will be ignored.
+    ///
+    /// [`Validation`]: Validation
+    fn validate_partial_input(&self, input: &str, sel: &Selection) -> Validation;
+
+    /// The value represented by the input, or an error if the input is invalid.
+    ///
+    /// This must return `Ok()` for any string created by [`format`].
+    ///
+    /// [`format`]: #tymethod.format
+    fn value(&self, input: &str) -> Result<T, ValidationError>;
+}
+
+/// The result of a [`Formatter`] attempting to validate some partial input.
+///
+/// [`Formatter`]: Formatter
+pub struct Validation {
+    result: Result<(), ValidationError>,
+    /// A manual selection override.
+    ///
+    /// This will be set as the new selection (regardless of whether or not
+    /// validation succeeded or failed)
+    pub selection_change: Option<Selection>,
+    /// A manual text override.
+    ///
+    /// This will be set as the new text, regardless of whether or not
+    /// validation failed.
+    pub text_change: Option<String>,
+}
+
+/// An error returned by a [`Formatter`] when it cannot parse input.
+///
+/// This implements [`source`] so you can access the inner error type.
+///
+/// [`source`]: std::Error::source;
+// This is currently just a wrapper around the inner error; in the future
+// it may grow to contain information such as invalid spans?
+// TODO: the fact that this uses `Arc` to work with `Data` is a bit inefficient;
+// it means that we will update when a new instance of an identical error occurs.
+#[derive(Debug, Clone, Data)]
+pub struct ValidationError {
+    inner: Arc<dyn std::error::Error>,
+}
+
+/// A naive [`Formatter`] for types that implement [`FromStr`].
+///
+/// [`Formatter`]: Formatter
+/// [`FromStr`]: std::str::FromStr
+pub struct ParseFormatter;
+
+impl Validation {
+    /// Create a `Validation` indicating succes.
+    pub fn success() -> Self {
+        Validation {
+            result: Ok(()),
+            selection_change: None,
+            text_change: None,
+        }
+    }
+
+    /// Create a `Validation` with an error indicating the failure reason.
+    pub fn failure(err: impl std::error::Error + 'static) -> Self {
+        Validation {
+            result: Err(ValidationError::new(err)),
+            ..Validation::success()
+        }
+    }
+
+    /// Optionally set a `String` that will replace the current contents.
+    pub fn change_text(mut self, text: String) -> Self {
+        self.text_change = Some(text);
+        self
+    }
+
+    /// Optionally set a [`Selection`] that will replace the current one.
+    pub fn change_selection(mut self, sel: Selection) -> Self {
+        self.selection_change = Some(sel);
+        self
+    }
+
+    /// Returns `true` if this `Validation` indicates success.
+    pub fn is_err(&self) -> bool {
+        self.result.is_err()
+    }
+
+    /// If validation failed, return the underlying [`ValidationError`].
+    ///
+    /// [`ValidationError`]: ValidationError
+    pub fn error(&self) -> Option<&ValidationError> {
+        self.result.as_ref().err()
+    }
+}
+
+impl ValidationError {
+    /// Create a new `ValidationError` with the given error type.
+    pub fn new(e: impl std::error::Error + 'static) -> Self {
+        ValidationError { inner: Arc::new(e) }
+    }
+}
+
+impl<T> Formatter<T> for ParseFormatter
+where
+    T: FromStr + std::fmt::Display,
+    <T as FromStr>::Err: std::error::Error + 'static,
+{
+    fn format(&self, value: &T) -> String {
+        value.to_string()
+    }
+
+    fn validate_partial_input(&self, input: &str, _sel: &Selection) -> Validation {
+        match input.parse::<T>() {
+            Ok(_) => Validation::success(),
+            Err(e) => Validation::failure(e),
+        }
+    }
+
+    fn value(&self, input: &str) -> Result<T, ValidationError> {
+        input.parse().map_err(ValidationError::new)
+    }
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", &self.inner)
+    }
+}
+
+impl std::error::Error for ValidationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&*self.inner)
+    }
+}

--- a/druid/src/text/mod.rs
+++ b/druid/src/text/mod.rs
@@ -19,6 +19,7 @@ pub mod backspace;
 mod editable_text;
 mod editor;
 mod font_descriptor;
+pub mod format;
 mod layout;
 pub mod movement;
 pub mod selection;

--- a/druid/src/text/selection.rs
+++ b/druid/src/text/selection.rs
@@ -44,12 +44,19 @@ impl Selection {
         }
     }
 
-    /// Create a new selection constrained to the length of the provided text.
+    /// Create a new selection that is guaranteed to be valid for the provided
+    /// text.
     #[must_use = "constrained constructs a new Selection"]
     pub fn constrained(mut self, s: &impl EditableText) -> Self {
         let s_len = s.len();
         self.start = min(self.start, s_len);
         self.end = min(self.end, s_len);
+        while s.cursor(self.start).is_none() {
+            self.start += 1;
+        }
+        while s.cursor(self.end).is_none() {
+            self.end += 1;
+        }
         self
     }
 

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -86,7 +86,7 @@ pub use stepper::Stepper;
 pub use svg::{Svg, SvgData};
 pub use switch::Switch;
 pub use tabs::{TabInfo, Tabs, TabsEdge, TabsPolicy, TabsState, TabsTransition};
-pub use textbox::TextBox;
+pub use textbox::{TextBox, TextBoxEvent, ValidationDelegate, ValueTextBox};
 pub use view_switcher::ViewSwitcher;
 #[doc(hidden)]
 pub use widget::{Widget, WidgetId};

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -314,8 +314,11 @@ impl TextBox<String> {
     /// Turn this `TextBox` into a [`ValueTextBox`], using the [`Formatter`] to
     /// manage the value.
     ///
+    /// For simple value formatting, you can use the [`ParseFormatter`].
+    ///
     /// [`ValueTextBox`]: ValueTextBox
     /// [`Formatter`]: crate::text::format::Formatter
+    /// [`ParseFormatter`]: crate::text::format::ParseFormatter
     pub fn with_formatter<T: Data>(
         self,
         formatter: impl Formatter<T> + 'static,

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -16,19 +16,24 @@
 
 use std::time::Duration;
 
-use crate::kurbo::Vec2;
+use crate::piet::PietText;
 use crate::text::{
-    BasicTextInput, EditAction, EditableText, Editor, LayoutMetrics, TextInput, TextLayout,
-    TextStorage,
+    format::{Formatter, ValidationError},
+    BasicTextInput, EditAction, EditableText, Editor, LayoutMetrics, Selection, TextInput,
+    TextLayout, TextStorage,
 };
 use crate::widget::prelude::*;
 use crate::{
-    theme, Affine, Color, Cursor, FontDescriptor, HotKey, KbKey, KeyOrValue, Point, Selector,
-    SysMods, TextAlignment, TimerToken,
+    theme, Affine, Color, Cursor, Data, FontDescriptor, HotKey, KbKey, KeyOrValue, Point, Selector,
+    SysMods, TextAlignment, TimerToken, Vec2,
 };
 
 const MAC_OR_LINUX: bool = cfg!(any(target_os = "macos", target_os = "linux"));
 const CURSOR_BLINK_DURATION: Duration = Duration::from_millis(500);
+
+const BEGIN_EDITING: Selector = Selector::new("druid.builtin.textbox-begin-editing");
+const COMPLETE_EDITING: Selector = Selector::new("druid.builtin.textbox-complete-editing");
+const CANCEL_EDITING: Selector = Selector::new("druid.builtin.textbox-cancel-editing");
 
 /// A widget that allows user text input.
 #[derive(Debug, Clone)]
@@ -54,8 +59,57 @@ pub struct TextBox<T> {
     was_focused_from_click: bool,
 }
 
+/// A `TextBox` that uses a [`Formatter`] to handle formatting and validation
+/// of its data.
+///
+/// [`Formatter`]: crate::text::Formatter;
+pub struct ValueTextBox<T> {
+    inner: TextBox<String>,
+    formatter: Box<dyn Formatter<T>>,
+    callback: Option<Box<dyn ValidationDelegate>>,
+    is_editing: bool,
+    validate_while_editing: bool,
+    update_data_while_editing: bool,
+    /// the last data that this textbox saw or created.
+    /// This is used to determine when a change to the data is originating
+    /// elsewhere in the application, which we need to special-case
+    last_known_data: Option<T>,
+    force_selection: Option<Selection>,
+    old_buffer: String,
+    buffer: String,
+}
+
+/// A type that can be registered to receive callbacks as the state of a
+/// [`ValueTextBox`] changes.
+pub trait ValidationDelegate {
+    /// Called with a [`TextBoxEvent`] whenever the validation state of a
+    /// [`ValueTextBox`] changes.
+    fn event(&mut self, ctx: &mut EventCtx, event: TextBoxEvent, current_text: &str);
+}
+
+/// Events sent to a [`ValidationDelegate`].
+pub enum TextBoxEvent {
+    /// The textbox began editing.
+    Began,
+    /// An edit occured which was considered valid by the [`Formatter`].
+    Changed,
+    /// An edit occured which was rejected by the [`Formatter`].
+    PartiallyInvalid(ValidationError),
+    /// The user attempted to finish editing, but the input was not valid.
+    Invalid(ValidationError),
+    /// The user finished editing, with valid input.
+    Complete,
+    /// Editing was cancelled.
+    Cancel,
+}
+
 impl TextBox<()> {
     /// Perform an `EditAction`.
+    ///
+    /// You can send a [`Command`] to a textbox containing an [`EditAction`]
+    /// that the textbox should perform.
+    ///
+    /// [`Command`]: crate::Command
     pub const PERFORM_EDIT: Selector<EditAction> =
         Selector::new("druid-builtin.textbox.perform-edit");
 }
@@ -234,9 +288,38 @@ impl<T> TextBox<T> {
     pub fn text_position(&self) -> Point {
         self.text_pos
     }
+
+    /// Return a mutable reference to the [`Editor`] used by this `TextBox`.
+    ///
+    /// [`Editor`]: crate::text::Editor
+    //TODO: document the ways you should and shouldn't use this
+    pub fn editor_mut(&mut self) -> &mut Editor<T> {
+        &mut self.editor
+    }
+}
+
+impl TextBox<String> {
+    /// Turn this `TextBox` into a [`ValueTextBox`], using the [`Formatter`] to
+    /// manage the value.
+    ///
+    /// [`ValueTextBox`]: ValueTextBox
+    /// [`Formatter`]: crate::text::format::Formatter
+    pub fn with_formatter<T: Data>(
+        self,
+        formatter: impl Formatter<T> + 'static,
+    ) -> ValueTextBox<T> {
+        ValueTextBox::new(self, formatter)
+    }
 }
 
 impl<T: TextStorage + EditableText> TextBox<T> {
+    /// Set the text and force the editor to update.
+    //FIXME: do we need this? can we not just rely on `update`?
+    pub fn force_rebuild(&mut self, text: T, factory: &mut PietText, env: &Env) {
+        self.editor.set_text(text);
+        self.editor.rebuild_if_needed(factory, env);
+    }
+
     /// Calculate a stateful scroll offset
     fn update_hscroll(&mut self, self_width: f64, env: &Env) {
         let cursor_x = self.editor.cursor_line().p0.x;
@@ -518,6 +601,262 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
 
         // Paint the border
         ctx.stroke(clip_rect, &border_color, border_width);
+    }
+}
+
+impl<T: Data> ValueTextBox<T> {
+    /// Create a new `ValueTextBox` from a normal [`TextBox`] and a [`Formatter`].
+    ///
+    /// [`TextBox`]: crate::widget::TextBox
+    /// [`Formatter`]: crate::text::format::Formatter
+    pub fn new(inner: TextBox<String>, formatter: impl Formatter<T> + 'static) -> Self {
+        ValueTextBox {
+            inner,
+            formatter: Box::new(formatter),
+            callback: None,
+            is_editing: false,
+            last_known_data: None,
+            validate_while_editing: true,
+            update_data_while_editing: false,
+            old_buffer: String::new(),
+            buffer: String::new(),
+            force_selection: None,
+        }
+    }
+
+    /// Builder-style method to set an optional [`ValidationDelegate`] on this
+    /// textbox.
+    pub fn delegate(mut self, delegate: impl ValidationDelegate + 'static) -> Self {
+        self.callback = Some(Box::new(delegate));
+        self
+    }
+
+    /// Builder-style method to set whether or not this text box validates
+    /// its contents during editing.
+    ///
+    /// If `true` (the default) edits that fail validation
+    /// ([`Formatter::validate_partial_input`]) will be rejected. If `false`,
+    /// those edits will be accepted, and the text box will be updated.
+    pub fn validate_while_editing(mut self, validate: bool) -> Self {
+        self.validate_while_editing = validate;
+        self
+    }
+
+    /// Builder-style method to set whether or not this text box updates the
+    /// incoming data during editing.
+    ///
+    /// If `false` (the default) the data is only updated when editing completes.
+    pub fn update_data_while_editing(mut self, flag: bool) -> Self {
+        self.update_data_while_editing = flag;
+        self
+    }
+
+    fn complete(&mut self, ctx: &mut EventCtx, data: &mut T, env: &Env) {
+        match self.formatter.value(&self.buffer) {
+            Ok(new_data) => {
+                *data = new_data;
+                self.inner
+                    .force_rebuild(self.formatter.format(data), ctx.text(), env);
+                self.is_editing = false;
+                ctx.request_layout();
+                if ctx.has_focus() {
+                    ctx.resign_focus();
+                }
+                self.send_event(ctx, TextBoxEvent::Complete);
+            }
+            Err(err) => {
+                // don't tab away from here if we're editing
+                if !ctx.has_focus() {
+                    ctx.request_focus();
+                }
+
+                ctx.submit_command(
+                    TextBox::PERFORM_EDIT
+                        .with(EditAction::SelectAll)
+                        .to(ctx.widget_id()),
+                );
+                self.send_event(ctx, TextBoxEvent::Invalid(err));
+                // our content isn't valid
+                // ideally we would flash the background or something
+            }
+        }
+    }
+
+    fn cancel(&mut self, ctx: &mut EventCtx, data: &T, env: &Env) {
+        self.is_editing = false;
+        self.buffer = self.formatter.format(data);
+        ctx.request_layout();
+        ctx.resign_focus();
+        self.inner
+            .force_rebuild(self.buffer.clone(), ctx.text(), env);
+        self.send_event(ctx, TextBoxEvent::Cancel);
+    }
+
+    fn begin(&mut self, ctx: &mut EventCtx, data: &T, env: &Env) {
+        self.is_editing = true;
+        self.buffer = self.formatter.format_for_editing(data);
+        self.last_known_data = Some(data.clone());
+        self.inner
+            .force_rebuild(self.buffer.clone(), ctx.text(), env);
+        self.old_buffer = self.buffer.clone();
+        ctx.request_layout();
+        self.send_event(ctx, TextBoxEvent::Began);
+    }
+
+    fn send_event(&mut self, ctx: &mut EventCtx, event: TextBoxEvent) {
+        if let Some(delegate) = self.callback.as_mut() {
+            delegate.event(ctx, event, &self.buffer)
+        }
+    }
+}
+
+impl<T: Data> Widget<T> for ValueTextBox<T> {
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
+        if matches!(event, Event::Command(cmd) if cmd.is(BEGIN_EDITING)) {
+            return self.begin(ctx, data, env);
+        }
+
+        if self.is_editing {
+            // if we reject an edit we want to reset the selection
+            let pre_sel = *self.inner.editor().selection();
+            match event {
+                Event::Command(cmd) if cmd.is(COMPLETE_EDITING) => {
+                    return self.complete(ctx, data, env)
+                }
+                Event::Command(cmd) if cmd.is(CANCEL_EDITING) => {
+                    return self.cancel(ctx, data, env)
+                }
+                Event::KeyDown(k_e) if HotKey::new(None, KbKey::Enter).matches(k_e) => {
+                    ctx.set_handled();
+                    self.complete(ctx, data, env);
+                    return;
+                }
+                Event::KeyDown(k_e) if HotKey::new(None, KbKey::Escape).matches(k_e) => {
+                    ctx.set_handled();
+                    self.cancel(ctx, data, env);
+                    return;
+                }
+                event => {
+                    self.inner.event(ctx, event, &mut self.buffer, env);
+                    ctx.request_paint();
+                }
+            }
+            // if an edit occured, validate it with the formatter
+            if self.buffer != self.old_buffer {
+                let mut validation = self
+                    .formatter
+                    .validate_partial_input(&self.buffer, &self.inner.editor().selection());
+
+                if self.validate_while_editing {
+                    let new_buf = match (validation.text_change.take(), validation.is_err()) {
+                        (Some(new_text), _) => {
+                            // be helpful: if the formatter is misbehaved, log it.
+                            if self
+                                .formatter
+                                .validate_partial_input(&new_text, &Selection::caret(0))
+                                .is_err()
+                            {
+                                log::warn!(
+                                    "formatter replacement text does not validate: '{}'",
+                                    &new_text
+                                );
+                                None
+                            } else {
+                                Some(new_text)
+                            }
+                        }
+                        (None, true) => Some(self.old_buffer.clone()),
+                        _ => None,
+                    };
+
+                    let new_sel = match (validation.selection_change.take(), validation.is_err()) {
+                        (Some(new_sel), _) => Some(new_sel),
+                        (None, true) => Some(pre_sel),
+                        _ => None,
+                    };
+
+                    if let Some(new_buf) = new_buf {
+                        self.buffer = new_buf.clone();
+                        self.inner.editor_mut().set_text(new_buf);
+                    }
+                    //FIXME we stash this and set it in update; can we do the same with `new_buf`?
+                    self.force_selection = new_sel;
+
+                    if self.update_data_while_editing && !validation.is_err() {
+                        if let Ok(new_data) = self.formatter.value(&self.buffer) {
+                            *data = new_data;
+                            self.last_known_data = Some(data.clone());
+                        }
+                    }
+                }
+
+                match validation.error() {
+                    Some(err) => {
+                        self.send_event(ctx, TextBoxEvent::PartiallyInvalid(err.to_owned()))
+                    }
+                    None => self.send_event(ctx, TextBoxEvent::Changed),
+                };
+            }
+            ctx.request_update();
+        } else if let Event::MouseDown(_) = event {
+            self.begin(ctx, data, env);
+            self.inner.event(ctx, event, &mut self.buffer, env);
+        }
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        if let LifeCycle::WidgetAdded = event {
+            self.buffer = self.formatter.format(data);
+            self.old_buffer = self.buffer.clone();
+        }
+        self.inner.lifecycle(ctx, event, &self.buffer, env);
+
+        if let LifeCycle::FocusChanged(focus) = event {
+            // if the user focuses elsewhere, we need to reset ourselves
+            if !focus {
+                ctx.submit_command(COMPLETE_EDITING.to(ctx.widget_id()));
+            } else if !self.is_editing {
+                ctx.submit_command(BEGIN_EDITING.to(ctx.widget_id()));
+            }
+        }
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
+        let changed_by_us = self
+            .last_known_data
+            .as_ref()
+            .map(|d| d.same(data))
+            .unwrap_or(false);
+        if self.is_editing {
+            if changed_by_us {
+                self.inner.update(ctx, &self.old_buffer, &self.buffer, env);
+                self.old_buffer = self.buffer.clone();
+            } else {
+                log::warn!(
+                    "ValueTextBox data changed externally, idk: '{}'",
+                    self.formatter.format(data)
+                );
+            }
+        } else if !old_data.same(data) {
+            // we aren't editing and data changed
+            let new_text = self.formatter.format(data);
+            self.old_buffer = std::mem::replace(&mut self.buffer, new_text);
+            self.inner.update(ctx, &self.old_buffer, &self.buffer, env);
+        } else if ctx.env_changed() {
+            self.inner.update(ctx, &self.buffer, &self.buffer, env);
+            ctx.request_layout();
+        }
+        if let Some(sel) = self.force_selection.take() {
+            self.inner.editor_mut().set_selection(sel);
+        }
+    }
+
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, _data: &T, env: &Env) -> Size {
+        self.inner.layout(ctx, bc, &self.buffer, env)
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, _data: &T, env: &Env) {
+        self.inner.paint(ctx, &self.buffer, env);
     }
 }
 

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -220,6 +220,7 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     }
 
     /// Parse a `Widget<String>`'s contents
+    #[deprecated(since = "0.7.0", note = "Use TextBox::with_formatter instead")]
     fn parse(self) -> Parse<Self>
     where
         Self: Widget<String>,


### PR DESCRIPTION
This is a mechanism for handling conversions back and forth
between values and their textual representations. Its major
use case is managing user input in text fields when the input
is intended to represent some other value type.

This patch includes the trait, a simple implementation based
on `FromStr` (intended as a replacement for the `Parse` widget)
and a new ValueTextBox widget that uses some Formatter to manage
a TextBox.

The behaviour of the ValueTextBox differs from the normal TextBox
in one very important way; it does not attempt to update the data
until editing has 'completed'. Editing is completed when the user
presses <kbd>return</kbd> or attempts to navigate away from the textbox;
the user can also manually cancel editing by pressing <kbd>esc</kbd>, which
discards the edit.

These interactions (especially the hard-wired key handling) feels
a bit brittle, and I'd like to try and find a more systematic
approach.

This is *very* strongly inspired by Cocoa's [`Formatter`](https://developer.apple.com/documentation/foundation/formatter#) class.

update:

This patch led me down a rabbit hole, because it encounters a bunch of situations that are hard to deal with given druid's current data model. In this particular case, this is related to error handling; the solution here is not satisfactory, (it involves setting a callback on the textbox and then manually sending commands as errors occur) but it makes error handling at least *possible*, until we're able to come up with a more robust, longer-term solution.

I intend to write up the problems i encountered and how I'm thinking about them in a subsequent document.

This now replaces the `parse` example with an example *package*, `validation`, which can  be run with,

```sh
cargo run --package=validation
```
![2020-11-25 16 26 25](https://user-images.githubusercontent.com/3330916/100283860-3ba2cb80-2f3c-11eb-99f1-38b6e716fcd9.gif)

progress on #1140
