### PR TITLE
macOS text input

### DIFF
--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -98,3 +98,4 @@ features = ["Window", "MouseEvent", "CssStyleDeclaration", "WheelEvent", "KeyEve
 piet-common = { version = "=0.2.0-pre6", features = ["png"] }
 simple_logger = { version = "1.9.0", default-features = false }
 static_assertions = "1.1.0"
+unicode-segmentation = "1.7.0"

--- a/druid-shell/examples/edit_text.rs
+++ b/druid-shell/examples/edit_text.rs
@@ -1,0 +1,378 @@
+// Copyright 2020 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This example shows a how a single-line text field might be implemented for druid-shell.
+//! Beyond the omission of multiple lines and text wrapping, it also is missing many motions
+//! (like "move to previous word") and bidirectional text support.
+
+use std::any::Any;
+use std::borrow::Cow;
+use std::cell::RefCell;
+use std::ops::Range;
+use std::rc::Rc;
+
+use unicode_segmentation::GraphemeCursor;
+
+use druid_shell::kurbo::Size;
+use druid_shell::piet::{
+    Color, FontFamily, HitTestPoint, PietText, PietTextLayout, RenderContext, Text, TextLayout,
+    TextLayoutBuilder,
+};
+
+use druid_shell::{
+    keyboard_types::Key, Affinity, Application, KeyEvent, Region, TextDirection, TextInputAction,
+    TextInputHandler, TextInputToken, TextInputUpdate, TextMovement, TextSelection,
+    VerticalMovement, WinHandler, WindowBuilder, WindowHandle,
+};
+
+use druid_shell::kurbo::{Point, Rect};
+
+const BG_COLOR: Color = Color::rgb8(0xff, 0xff, 0xff);
+const COMPOSITION_BG_COLOR: Color = Color::rgb8(0xff, 0xd8, 0x6e);
+const SELECTION_BG_COLOR: Color = Color::rgb8(0x87, 0xc5, 0xff);
+const CARET_COLOR: Color = Color::rgb8(0x00, 0x82, 0xfc);
+const FONT: FontFamily = FontFamily::SANS_SERIF;
+const FONT_SIZE: f64 = 16.0;
+
+#[derive(Default)]
+struct AppState {
+    size: Size,
+    handle: WindowHandle,
+    document: Rc<RefCell<DocumentState>>,
+    text_input_token: Option<TextInputToken>,
+}
+
+#[derive(Default)]
+struct DocumentState {
+    text: String,
+    selection: TextSelection,
+    composition: Option<Range<usize>>,
+    text_engine: Option<PietText>,
+    layout: Option<PietTextLayout>,
+}
+
+impl DocumentState {
+    fn refresh_layout(&mut self) {
+        let text_engine = self.text_engine.as_mut().unwrap();
+        self.layout = Some(
+            text_engine
+                .new_text_layout(self.text.clone())
+                .font(FONT, FONT_SIZE)
+                .build()
+                .unwrap(),
+        );
+    }
+}
+
+impl WinHandler for AppState {
+    fn connect(&mut self, handle: &WindowHandle) {
+        self.handle = handle.clone();
+        let token = self.handle.add_text_input();
+        self.handle.set_active_text_input(Some(token));
+        self.text_input_token = Some(token);
+        let mut doc = self.document.borrow_mut();
+        doc.text_engine = Some(handle.text());
+        doc.refresh_layout();
+    }
+
+    fn prepare_paint(&mut self) {
+        self.handle.invalidate();
+    }
+
+    fn paint(&mut self, piet: &mut piet_common::Piet, _: &Region) {
+        let rect = self.size.to_rect();
+        piet.fill(rect, &BG_COLOR);
+        let doc = self.document.borrow();
+        let layout = doc.layout.as_ref().unwrap();
+        if let Some(composition_range) = doc.composition.as_ref() {
+            let left_x = layout
+                .hit_test_text_position(composition_range.start)
+                .point
+                .x;
+            let right_x = layout.hit_test_text_position(composition_range.end).point.x;
+            piet.fill(
+                Rect::new(left_x, 0.0, right_x, FONT_SIZE),
+                &COMPOSITION_BG_COLOR,
+            );
+        }
+        if !doc.selection.is_caret() {
+            let left_x = layout
+                .hit_test_text_position(doc.selection.upstream_index())
+                .point
+                .x;
+            let right_x = layout
+                .hit_test_text_position(doc.selection.downstream_index())
+                .point
+                .x;
+            piet.fill(
+                Rect::new(left_x, 0.0, right_x, FONT_SIZE),
+                &SELECTION_BG_COLOR,
+            );
+        }
+        piet.draw_text(layout, (0.0, 0.0));
+
+        // draw caret
+        let caret_x = layout.hit_test_text_position(doc.selection.extent).point.x;
+        piet.fill(
+            Rect::new(caret_x - 1.0, 0.0, caret_x + 1.0, FONT_SIZE),
+            &CARET_COLOR,
+        );
+    }
+
+    fn command(&mut self, id: u32) {
+        match id {
+            0x100 => {
+                self.handle.close();
+                Application::global().quit()
+            }
+            _ => println!("unexpected id {}", id),
+        }
+    }
+
+    fn key_down(&mut self, event: KeyEvent) -> bool {
+        if event.key == Key::Character("c".to_string()) {
+            // custom hotkey for pressing "c"
+            println!("user pressed c! wow! setting selection to 0");
+
+            // update internal selection state
+            self.document.borrow_mut().selection = TextSelection::new_caret(0);
+
+            // notify the OS that we've updated the selection
+            self.handle.update_text_input(
+                self.text_input_token.unwrap(),
+                TextInputUpdate::SelectionChanged,
+            );
+
+            // repaint window
+            self.handle.request_anim_frame();
+
+            // return true prevents the keypress event from being handled as text input
+            return true;
+        }
+        false
+    }
+
+    fn text_input(&mut self, _token: TextInputToken, _mutable: bool) -> Box<dyn TextInputHandler> {
+        Box::new(AppTextInputHandler {
+            state: self.document.clone(),
+            window_size: self.size,
+            window_handle: self.handle.clone(),
+        })
+    }
+
+    fn size(&mut self, size: Size) {
+        self.size = size;
+    }
+
+    fn request_close(&mut self) {
+        self.handle.close();
+    }
+
+    fn destroy(&mut self) {
+        Application::global().quit()
+    }
+
+    fn as_any(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+struct AppTextInputHandler {
+    state: Rc<RefCell<DocumentState>>,
+    window_size: Size,
+    window_handle: WindowHandle,
+}
+
+impl TextInputHandler for AppTextInputHandler {
+    fn selection(&mut self) -> TextSelection {
+        self.state.borrow().selection.clone()
+    }
+    fn composition_range(&mut self) -> Option<Range<usize>> {
+        self.state.borrow().composition.clone()
+    }
+    fn set_selection(&mut self, range: TextSelection) {
+        self.state.borrow_mut().selection = range;
+        self.window_handle.request_anim_frame();
+    }
+    fn set_composition_range(&mut self, range: Option<Range<usize>>) {
+        self.state.borrow_mut().composition = range;
+        self.window_handle.request_anim_frame();
+    }
+    fn replace_range(&mut self, range: Range<usize>, text: &str) {
+        let mut doc = self.state.borrow_mut();
+        doc.text.replace_range(range.clone(), text);
+        if doc.selection.anchor < range.start && doc.selection.extent < range.start {
+            // no need to update selection
+        } else if doc.selection.anchor > range.end && doc.selection.extent > range.end {
+            doc.selection.anchor -= range.len();
+            doc.selection.extent -= range.len();
+            doc.selection.anchor += text.len();
+            doc.selection.extent += text.len();
+        } else {
+            doc.selection.anchor = range.start + text.len();
+            doc.selection.extent = range.start + text.len();
+        }
+        doc.refresh_layout();
+        doc.composition = None;
+        self.window_handle.request_anim_frame();
+    }
+    fn slice<'a>(&'a mut self, range: Range<usize>) -> Cow<'a, str> {
+        self.state.borrow().text[range].to_string().into()
+    }
+    fn is_char_boundary(&mut self, i: usize) -> bool {
+        self.state.borrow().text.is_char_boundary(i)
+    }
+    fn len(&mut self) -> usize {
+        self.state.borrow().text.len()
+    }
+    fn hit_test_point(&mut self, point: Point) -> HitTestPoint {
+        self.state
+            .borrow()
+            .layout
+            .as_ref()
+            .unwrap()
+            .hit_test_point(point)
+    }
+    fn bounding_box(&mut self) -> Option<Rect> {
+        Some(Rect::new(
+            0.0,
+            0.0,
+            self.window_size.width,
+            self.window_size.height,
+        ))
+    }
+    fn slice_bounding_box(&mut self, range: Range<usize>) -> Option<Rect> {
+        let doc = self.state.borrow();
+        let layout = doc.layout.as_ref().unwrap();
+        let range_start_x = layout.hit_test_text_position(range.start).point.x;
+        let range_end_x = layout.hit_test_text_position(range.end).point.x;
+        Some(Rect::new(range_start_x, 0.0, range_end_x, FONT_SIZE))
+    }
+    fn line_range(&mut self, _char_index: usize, _affinity: Affinity) -> Range<usize> {
+        // we don't have multiple lines, so no matter the input, output is the whole document
+        0..self.state.borrow().text.len()
+    }
+
+    fn handle_action(&mut self, action: TextInputAction) {
+        let handled = apply_default_behavior(self, action);
+        println!("action: {:?} handled: {:?}", action, handled);
+    }
+}
+
+fn apply_default_behavior(handler: &mut AppTextInputHandler, action: TextInputAction) -> bool {
+    let is_caret = handler.selection().is_caret();
+    match action {
+        TextInputAction::Move(movement) => {
+            let selection = handler.selection();
+            let index = if movement_goes_downstream(movement) {
+                selection.downstream_index()
+            } else {
+                selection.upstream_index()
+            };
+            let updated_index = if let (false, TextMovement::Grapheme(_)) = (is_caret, movement) {
+                // handle special cases of pressing left/right when the selection is not a caret
+                index
+            } else {
+                match apply_movement(handler, movement, index) {
+                    Some(v) => v,
+                    None => return false,
+                }
+            };
+            handler.set_selection(TextSelection::new_caret(updated_index));
+        }
+        TextInputAction::MoveExtent(movement) => {
+            let mut selection = handler.selection();
+            selection.extent = match apply_movement(handler, movement, selection.extent) {
+                Some(v) => v,
+                None => return false,
+            };
+            handler.set_selection(selection);
+        }
+        TextInputAction::SelectAll => {
+            let len = handler.len();
+            let selection = TextSelection {
+                anchor: 0,
+                extent: len,
+            };
+            handler.set_selection(selection);
+        }
+        TextInputAction::Delete(_) if !is_caret => {
+            // movement is ignored for non-caret selections
+            let selection = handler.selection();
+            handler.replace_range(selection.to_range(), "");
+        }
+        TextInputAction::Delete(movement) => {
+            let mut selection = handler.selection();
+            selection.extent = match apply_movement(handler, movement, selection.extent) {
+                Some(v) => v,
+                None => return false,
+            };
+            handler.replace_range(selection.to_range(), "");
+        }
+        _ => return false,
+    }
+    true
+}
+
+fn movement_goes_downstream(movement: TextMovement) -> bool {
+    match movement {
+        TextMovement::Grapheme(dir) => direction_goes_downstream(dir),
+        TextMovement::Word(dir) => direction_goes_downstream(dir),
+        TextMovement::Line(dir) => direction_goes_downstream(dir),
+        TextMovement::ParagraphEnd => true,
+        TextMovement::Vertical(VerticalMovement::LineDown) => true,
+        TextMovement::Vertical(VerticalMovement::PageDown) => true,
+        TextMovement::Vertical(VerticalMovement::DocumentEnd) => true,
+        _ => false,
+    }
+}
+
+fn direction_goes_downstream(direction: TextDirection) -> bool {
+    match direction {
+        TextDirection::Left => false,
+        TextDirection::Right => true,
+        TextDirection::Upstream => false,
+        TextDirection::Downstream => true,
+    }
+}
+
+fn apply_movement(
+    edit_lock: &mut AppTextInputHandler,
+    movement: TextMovement,
+    index: usize,
+) -> Option<usize> {
+    match movement {
+        TextMovement::Grapheme(dir) => {
+            let doc_len = edit_lock.len();
+            let mut cursor = GraphemeCursor::new(index, doc_len, true);
+            let doc = edit_lock.slice(0..doc_len);
+            if direction_goes_downstream(dir) {
+                cursor.next_boundary(&doc, 0).unwrap()
+            } else {
+                cursor.prev_boundary(&doc, 0).unwrap()
+            }
+        }
+        _ => None,
+    }
+}
+
+fn main() {
+    let app = Application::new().unwrap();
+    let mut builder = WindowBuilder::new(app.clone());
+    builder.set_handler(Box::new(AppState::default()));
+    builder.set_title("Text editing example");
+    let window = builder.build().unwrap();
+    window.show();
+    app.run(None);
+}

--- a/druid-shell/examples/edit_text.rs
+++ b/druid-shell/examples/edit_text.rs
@@ -97,23 +97,14 @@ impl WinHandler for AppState {
         let layout = doc.layout.as_ref().unwrap();
         // TODO(lord): rects for range on layout
         if let Some(composition_range) = doc.composition.as_ref() {
-            let left_x = layout
-                .hit_test_text_position(composition_range.start)
-                .point
-                .x;
-            let right_x = layout.hit_test_text_position(composition_range.end).point.x;
-            piet.fill(
-                Rect::new(left_x, 0.0, right_x, FONT_SIZE),
-                &COMPOSITION_BG_COLOR,
-            );
+            for rect in layout.rects_for_range(composition_range.clone()) {
+                piet.fill(rect, &COMPOSITION_BG_COLOR);
+            }
         }
         if !doc.selection.is_caret() {
-            let left_x = layout.hit_test_text_position(doc.selection.min()).point.x;
-            let right_x = layout.hit_test_text_position(doc.selection.max()).point.x;
-            piet.fill(
-                Rect::new(left_x, 0.0, right_x, FONT_SIZE),
-                &SELECTION_BG_COLOR,
-            );
+            for rect in layout.rects_for_range(doc.selection.to_range()) {
+                piet.fill(rect, &SELECTION_BG_COLOR);
+            }
         }
         piet.draw_text(layout, (0.0, 0.0));
 

--- a/druid-shell/examples/edit_text.rs
+++ b/druid-shell/examples/edit_text.rs
@@ -32,7 +32,7 @@ use druid_shell::piet::{
 
 use druid_shell::{
     keyboard_types::Key, text, text::Action, text::Event, text::InputHandler, text::Selection,
-    text::VerticalMovement, Application, KeyEvent, Region, TextInputToken, WinHandler,
+    text::VerticalMovement, Application, KeyEvent, Region, TextFieldToken, WinHandler,
     WindowBuilder, WindowHandle,
 };
 
@@ -50,7 +50,7 @@ struct AppState {
     size: Size,
     handle: WindowHandle,
     document: Rc<RefCell<DocumentState>>,
-    text_input_token: Option<TextInputToken>,
+    text_input_token: Option<TextFieldToken>,
 }
 
 #[derive(Default)]
@@ -78,8 +78,8 @@ impl DocumentState {
 impl WinHandler for AppState {
     fn connect(&mut self, handle: &WindowHandle) {
         self.handle = handle.clone();
-        let token = self.handle.add_text_input();
-        self.handle.set_focused_text_input(Some(token));
+        let token = self.handle.add_text_field();
+        self.handle.set_focused_text_field(Some(token));
         self.text_input_token = Some(token);
         let mut doc = self.document.borrow_mut();
         doc.text_engine = Some(handle.text());
@@ -145,7 +145,7 @@ impl WinHandler for AppState {
 
             // notify the OS that we've updated the selection
             self.handle
-                .update_text_input(self.text_input_token.unwrap(), Event::SelectionChanged);
+                .update_text_field(self.text_input_token.unwrap(), Event::SelectionChanged);
 
             // repaint window
             self.handle.request_anim_frame();
@@ -156,7 +156,7 @@ impl WinHandler for AppState {
         false
     }
 
-    fn text_input(&mut self, _token: TextInputToken, _mutable: bool) -> Box<dyn InputHandler> {
+    fn text_input(&mut self, _token: TextFieldToken, _mutable: bool) -> Box<dyn InputHandler> {
         Box::new(AppInputHandler {
             state: self.document.clone(),
             window_size: self.size,

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -56,8 +56,9 @@ mod platform;
 mod region;
 mod scale;
 mod screen;
-mod text_input;
 mod window;
+
+pub mod text;
 
 pub use crate::image::ImageBuf;
 pub use application::{AppHandler, Application};
@@ -72,13 +73,9 @@ pub use mouse::{Cursor, CursorDesc, MouseButton, MouseButtons, MouseEvent};
 pub use region::Region;
 pub use scale::{Scalable, Scale, ScaledArea};
 pub use screen::{Monitor, Screen};
-pub use text_input::{
-    Affinity, TextDirection, TextInputAction, TextInputHandler, TextInputToken, TextInputUpdate,
-    TextMovement, TextSelection, VerticalMovement, WritingDirection,
-};
 pub use window::{
-    FileDialogToken, IdleHandle, IdleToken, TimerToken, WinHandler, WindowBuilder, WindowHandle,
-    WindowLevel, WindowState,
+    FileDialogToken, IdleHandle, IdleToken, TextInputToken, TimerToken, WinHandler, WindowBuilder,
+    WindowHandle, WindowLevel, WindowState,
 };
 
 pub use keyboard_types;

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -74,7 +74,7 @@ pub use region::Region;
 pub use scale::{Scalable, Scale, ScaledArea};
 pub use screen::{Monitor, Screen};
 pub use window::{
-    FileDialogToken, IdleHandle, IdleToken, TextInputToken, TimerToken, WinHandler, WindowBuilder,
+    FileDialogToken, IdleHandle, IdleToken, TextFieldToken, TimerToken, WinHandler, WindowBuilder,
     WindowHandle, WindowLevel, WindowState,
 };
 

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -56,6 +56,7 @@ mod platform;
 mod region;
 mod scale;
 mod screen;
+mod text_input;
 mod window;
 
 pub use crate::image::ImageBuf;
@@ -71,6 +72,10 @@ pub use mouse::{Cursor, CursorDesc, MouseButton, MouseButtons, MouseEvent};
 pub use region::Region;
 pub use scale::{Scalable, Scale, ScaledArea};
 pub use screen::{Monitor, Screen};
+pub use text_input::{
+    Affinity, TextDirection, TextInputAction, TextInputHandler, TextInputToken, TextInputUpdate,
+    TextMovement, TextSelection, VerticalMovement, WritingDirection,
+};
 pub use window::{
     FileDialogToken, IdleHandle, IdleToken, TimerToken, WinHandler, WindowBuilder, WindowHandle,
     WindowLevel, WindowState,

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -46,7 +46,7 @@ use crate::scale::{Scalable, Scale, ScaledArea};
 use crate::text::{simulate_input, Event};
 use crate::window;
 use crate::window::{
-    DeferredOp, FileDialogToken, IdleToken, TextInputToken, TimerToken, WinHandler, WindowLevel,
+    FileDialogToken, IdleToken, TextInputToken, TimerToken, WinHandler, WindowLevel,
 };
 
 use super::application::Application;

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -43,9 +43,11 @@ use crate::mouse::{Cursor, CursorDesc, MouseButton, MouseButtons, MouseEvent};
 use crate::piet::ImageFormat;
 use crate::region::Region;
 use crate::scale::{Scalable, Scale, ScaledArea};
-use crate::text_input::{simulate_text_input, TextInputToken, TextInputUpdate};
+use crate::text::{simulate_input, Event};
 use crate::window;
-use crate::window::{FileDialogToken, IdleToken, TimerToken, WinHandler, WindowLevel};
+use crate::window::{
+    DeferredOp, FileDialogToken, IdleToken, TextInputToken, TimerToken, WinHandler, WindowLevel,
+};
 
 use super::application::Application;
 use super::dialog;
@@ -596,7 +598,7 @@ impl WindowBuilder {
                     state.current_keycode.set(Some(hw_keycode));
 
                     state.with_handler(|h|
-                        simulate_text_input(h, state.active_text_input.get(), make_key_event(key, repeat, KeyState::Down))
+                        simulate_input(h, state.active_text_input.get(), make_key_event(key, repeat, KeyState::Down))
                     );
                 }
 
@@ -953,13 +955,13 @@ impl WindowHandle {
         }
     }
 
-    pub fn set_active_text_input(&self, active_field: Option<TextInputToken>) {
+    pub fn set_focused_text_input(&self, active_field: Option<TextInputToken>) {
         if let Some(state) = self.state.upgrade() {
             state.active_text_input.set(active_field);
         }
     }
 
-    pub fn update_text_input(&self, _token: TextInputToken, _update: TextInputUpdate) {
+    pub fn update_text_input(&self, _token: TextInputToken, _update: Event) {
         // noop until we get a real text input implementation
     }
 

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -46,7 +46,7 @@ use crate::scale::{Scalable, Scale, ScaledArea};
 use crate::text::{simulate_input, Event};
 use crate::window;
 use crate::window::{
-    FileDialogToken, IdleToken, TextInputToken, TimerToken, WinHandler, WindowLevel,
+    FileDialogToken, IdleToken, TextFieldToken, TimerToken, WinHandler, WindowLevel,
 };
 
 use super::application::Application;
@@ -161,7 +161,7 @@ pub(crate) struct WindowState {
     pub(crate) handler: RefCell<Box<dyn WinHandler>>,
     idle_queue: Arc<Mutex<Vec<IdleKind>>>,
     current_keycode: Cell<Option<u16>>,
-    active_text_input: Cell<Option<TextInputToken>>,
+    active_text_input: Cell<Option<TextFieldToken>>,
     last_click: Cell<(f64, f64)>,
     last_click_time: Cell<Instant>,
     last_click_count: Cell<u8>,
@@ -943,11 +943,11 @@ impl WindowHandle {
         PietText::new()
     }
 
-    pub fn add_text_input(&self) -> TextInputToken {
-        TextInputToken::next()
+    pub fn add_text_field(&self) -> TextFieldToken {
+        TextFieldToken::next()
     }
 
-    pub fn remove_text_input(&self, token: TextInputToken) {
+    pub fn remove_text_field(&self, token: TextFieldToken) {
         if let Some(state) = self.state.upgrade() {
             if state.active_text_input.get() == Some(token) {
                 state.active_text_input.set(None)
@@ -955,13 +955,13 @@ impl WindowHandle {
         }
     }
 
-    pub fn set_focused_text_input(&self, active_field: Option<TextInputToken>) {
+    pub fn set_focused_text_field(&self, active_field: Option<TextFieldToken>) {
         if let Some(state) = self.state.upgrade() {
             state.active_text_input.set(active_field);
         }
     }
 
-    pub fn update_text_input(&self, _token: TextInputToken, _update: Event) {
+    pub fn update_text_field(&self, _token: TextFieldToken, _update: Event) {
         // noop until we get a real text input implementation
     }
 

--- a/druid-shell/src/platform/mac/keyboard.rs
+++ b/druid-shell/src/platform/mac/keyboard.rs
@@ -31,7 +31,7 @@ use super::util::from_nsstring;
 /// be the authoritative source of truth for Unicode string values of keys.
 ///
 /// Most of the logic in this module is adapted from Mozilla, and in particular
-/// TextInputHandler.mm.
+/// InputHandler.mm.
 pub(crate) struct KeyboardState {
     last_mods: NSEventModifierFlags,
 }

--- a/druid-shell/src/platform/mac/mod.rs
+++ b/druid-shell/src/platform/mac/mod.rs
@@ -24,5 +24,6 @@ pub mod error;
 mod keyboard;
 pub mod menu;
 pub mod screen;
+pub mod text_input;
 pub mod util;
 pub mod window;

--- a/druid-shell/src/platform/mac/text_input.rs
+++ b/druid-shell/src/platform/mac/text_input.rs
@@ -1,0 +1,679 @@
+// Copyright 2020 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// massive thanks to github.com/yvt and their project tcw3 (https://github.com/yvt/Stella2), which is some
+// of the most solid/well documented input method code for mac written in Rust that we've found. tcw3 was
+// instrumental in this file's implementation.
+
+// apple's documentation on text editing is also very helpful:
+// https://developer.apple.com/library/archive/documentation/TextFonts/Conceptual/CocoaTextArchitecture/TextEditing/TextEditing.html#//apple_ref/doc/uid/TP40009459-CH3-SW3
+
+#![allow(non_snake_case)]
+
+use std::ffi::c_void;
+use std::ops::Range;
+use std::os::raw::c_uchar;
+
+use super::window::get_edit_lock_from_window;
+use crate::kurbo::Point;
+use crate::text_input::{
+    Affinity, TextDirection, TextInputAction, TextInputHandler, TextMovement, TextSelection,
+    VerticalMovement, WritingDirection,
+};
+use cocoa::base::{id, nil, BOOL};
+use cocoa::foundation::{NSArray, NSPoint, NSRect, NSSize, NSString, NSUInteger};
+use cocoa::{appkit::NSWindow, foundation::NSNotFound};
+use objc::runtime::{Object, Sel};
+use objc::{class, msg_send, sel, sel_impl};
+
+// thanks to winit for the custom NSRange code:
+// https://github.com/rust-windowing/winit/pull/518/files#diff-61be96e960785f102cb20ad8464eafeb6edd4245ea40224b3c3206c72cd5bf56R12-R34
+#[repr(C)]
+#[derive(Debug)]
+pub struct NSRange {
+    pub location: NSUInteger,
+    pub length: NSUInteger,
+}
+impl NSRange {
+    pub const NONE: NSRange = NSRange::new(NSNotFound as NSUInteger, 0);
+    #[inline]
+    pub const fn new(location: NSUInteger, length: NSUInteger) -> NSRange {
+        NSRange { location, length }
+    }
+}
+unsafe impl objc::Encode for NSRange {
+    fn encode() -> objc::Encoding {
+        let encoding = format!(
+            "{{NSRange={}{}}}",
+            NSUInteger::encode().as_str(),
+            NSUInteger::encode().as_str(),
+        );
+        unsafe { objc::Encoding::from_str(&encoding) }
+    }
+}
+
+pub extern "C" fn has_marked_text(this: &mut Object, _: Sel) -> BOOL {
+    get_edit_lock_from_window(this, false)
+        .map(|mut edit_lock| edit_lock.composition_range().is_some())
+        .unwrap_or(false)
+        .into()
+}
+
+pub extern "C" fn marked_range(this: &mut Object, _: Sel) -> NSRange {
+    get_edit_lock_from_window(this, false)
+        .and_then(|mut edit_lock| {
+            edit_lock
+                .composition_range()
+                .map(|range| encode_nsrange(&mut edit_lock, range))
+        })
+        .unwrap_or(NSRange::NONE)
+}
+
+pub extern "C" fn selected_range(this: &mut Object, _: Sel) -> NSRange {
+    let mut edit_lock = match get_edit_lock_from_window(this, false) {
+        Some(v) => v,
+        None => return NSRange::NONE,
+    };
+    let range = edit_lock.selection().to_range();
+    encode_nsrange(&mut edit_lock, range)
+}
+
+pub extern "C" fn set_marked_text(
+    this: &mut Object,
+    _: Sel,
+    text: id,
+    selected_range: NSRange,
+    replacement_range: NSRange,
+) {
+    let mut edit_lock = match get_edit_lock_from_window(this, false) {
+        Some(v) => v,
+        None => return,
+    };
+    let mut composition_range = edit_lock.composition_range().unwrap_or_else(|| {
+        // no existing composition range? default to replacement range, interpreted in absolute coordinates
+        // undocumented by apple, see
+        // https://github.com/yvt/Stella2/blob/076fb6ee2294fcd1c56ed04dd2f4644bf456e947/tcw3/pal/src/macos/window.rs#L1144-L1146
+        decode_nsrange(&mut edit_lock, &replacement_range, 0).unwrap_or_else(|| {
+            // no replacement range either? apparently we default to the selection in this case
+            edit_lock.selection().to_range()
+        })
+    });
+
+    let replace_range_offset = edit_lock
+        .composition_range()
+        .map(|range| range.start)
+        .unwrap_or(0);
+
+    let replace_range = decode_nsrange(&mut edit_lock, &replacement_range, replace_range_offset)
+        .unwrap_or_else(|| {
+            // default replacement range is already-exsiting composition range
+            // undocumented by apple, see
+            // https://github.com/yvt/Stella2/blob/076fb6ee2294fcd1c56ed04dd2f4644bf456e947/tcw3/pal/src/macos/window.rs#L1124-L1125
+            composition_range.clone()
+        });
+
+    let text_string = parse_attributed_string(&text);
+    edit_lock.replace_range(replace_range.clone(), text_string);
+
+    // Update the composition range
+    composition_range.end -= replace_range.len();
+    composition_range.end += text_string.len();
+    if composition_range.is_empty() {
+        edit_lock.set_composition_range(None);
+    } else {
+        edit_lock.set_composition_range(Some(composition_range));
+    };
+
+    // Update the selection
+    if let Some(selection_range) =
+        decode_nsrange(&mut edit_lock, &selected_range, replace_range.start)
+    {
+        // preserve ordering of anchor and extent
+        let existing_selection = edit_lock.selection();
+        let new_selection = if existing_selection.anchor < existing_selection.extent {
+            TextSelection {
+                anchor: selection_range.start,
+                extent: selection_range.end,
+            }
+        } else {
+            TextSelection {
+                extent: selection_range.start,
+                anchor: selection_range.end,
+            }
+        };
+        edit_lock.set_selection(new_selection);
+    }
+}
+
+pub extern "C" fn unmark_text(this: &mut Object, _: Sel) {
+    let mut edit_lock = match get_edit_lock_from_window(this, false) {
+        Some(v) => v,
+        None => return,
+    };
+    edit_lock.set_composition_range(None);
+}
+
+pub extern "C" fn valid_attributes_for_marked_text(_this: &mut Object, _: Sel) -> id {
+    // we don't support any attributes
+    unsafe { NSArray::array(nil) }
+}
+
+pub extern "C" fn attributed_substring_for_proposed_range(
+    this: &mut Object,
+    _: Sel,
+    proposed_range: NSRange,
+    actual_range: *mut c_void,
+) -> id {
+    let mut edit_lock = match get_edit_lock_from_window(this, false) {
+        Some(v) => v,
+        None => return nil,
+    };
+    let range = match decode_nsrange(&mut edit_lock, &proposed_range, 0) {
+        Some(v) => v,
+        None => return nil,
+    };
+    if !actual_range.is_null() {
+        let ptr = actual_range as *mut NSRange;
+        let range_utf16 = encode_nsrange(&mut edit_lock, range.clone());
+        unsafe {
+            *ptr = range_utf16;
+        }
+    }
+    let text = edit_lock.slice(range);
+    unsafe {
+        let ns_string = NSString::alloc(nil).init_str(&text);
+        let attr_string: id = msg_send![class!(NSAttributedString), alloc];
+        msg_send![attr_string, initWithString: ns_string]
+    }
+}
+
+pub extern "C" fn insert_text(this: &mut Object, _: Sel, text: id, replacement_range: NSRange) {
+    let mut edit_lock = match get_edit_lock_from_window(this, true) {
+        Some(v) => v,
+        None => return,
+    };
+    let text_string = parse_attributed_string(&text);
+
+    // yvt notes:
+    // [The null range case] is undocumented, but it seems that it means
+    // the whole marked text or selected text should be finalized
+    // and replaced with the given string.
+    // https://github.com/yvt/Stella2/blob/076fb6ee2294fcd1c56ed04dd2f4644bf456e947/tcw3/pal/src/macos/window.rs#L1041-L1043
+    let converted_range = decode_nsrange(&mut edit_lock, &replacement_range, 0)
+        .or_else(|| edit_lock.composition_range())
+        .unwrap_or_else(|| edit_lock.selection().to_range());
+
+    edit_lock.replace_range(converted_range.clone(), text_string);
+    edit_lock.set_composition_range(None);
+    // move the caret next to the inserted text
+    let caret_index = converted_range.start + text_string.len();
+    edit_lock.set_selection(TextSelection::new_caret(caret_index));
+}
+
+pub extern "C" fn character_index_for_point(
+    this: &mut Object,
+    _: Sel,
+    point: NSPoint,
+) -> NSUInteger {
+    let mut edit_lock = match get_edit_lock_from_window(this, true) {
+        Some(v) => v,
+        None => return 0,
+    };
+    let hit_test = edit_lock.hit_test_point(Point::new(point.x, point.y));
+    hit_test.idx as NSUInteger
+}
+
+pub extern "C" fn first_rect_for_character_range(
+    this: &mut Object,
+    _: Sel,
+    character_range: NSRange,
+    actual_range: *mut c_void,
+) -> NSRect {
+    let mut edit_lock = match get_edit_lock_from_window(this, true) {
+        Some(v) => v,
+        None => return NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(0.0, 0.0)),
+    };
+    let mut range = decode_nsrange(&mut edit_lock, &character_range, 0).unwrap_or(0..0);
+    {
+        let line_range = edit_lock.line_range(range.start, Affinity::Downstream);
+        range.end = usize::min(range.end, line_range.end);
+    }
+    let rect = match edit_lock.slice_bounding_box(range.clone()) {
+        Some(v) => v,
+        None => return NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(0.0, 0.0)),
+    };
+    if !actual_range.is_null() {
+        let ptr = actual_range as *mut NSRange;
+        let range_utf16 = encode_nsrange(&mut edit_lock, range);
+        unsafe {
+            *ptr = range_utf16;
+        }
+    }
+    let view_space_rect = NSRect::new(
+        NSPoint::new(rect.x0, rect.y0),
+        NSSize::new(rect.width(), rect.height()),
+    );
+    unsafe {
+        let window_space_rect: NSRect =
+            msg_send![this as *const _, convertRect: view_space_rect toView: nil];
+        let window: id = msg_send![this as *const _, window];
+        window.convertRectToScreen_(window_space_rect)
+    }
+}
+
+pub extern "C" fn do_command_by_selector(this: &mut Object, _: Sel, cmd: Sel) {
+    let mut edit_lock = match get_edit_lock_from_window(this, true) {
+        Some(v) => v,
+        None => return,
+    };
+    match cmd.name() {
+        // see https://developer.apple.com/documentation/appkit/nsstandardkeybindingresponding?language=objc
+        // and https://support.apple.com/en-us/HT201236
+        // and https://support.apple.com/lv-lv/guide/mac-help/mh21243/mac
+        "centerSelectionInVisibleArea:" => {
+            edit_lock.handle_action(TextInputAction::ScrollToSelection)
+        }
+        "deleteBackward:" => edit_lock.handle_action(TextInputAction::Delete(
+            TextMovement::Grapheme(TextDirection::Upstream),
+        )),
+        "deleteBackwardByDecomposingPreviousCharacter:" => {
+            edit_lock.handle_action(TextInputAction::DecomposingBackspace)
+        }
+        "deleteForward:" => edit_lock.handle_action(TextInputAction::Delete(
+            TextMovement::Grapheme(TextDirection::Downstream),
+        )),
+        "deleteToBeginningOfLine:" => edit_lock.handle_action(TextInputAction::Delete(
+            TextMovement::Line(TextDirection::Upstream),
+        )),
+        "deleteToBeginningOfParagraph:" => {
+            // TODO(lord): this seems to also kill the text into a buffer that can get pasted with yank
+            edit_lock.handle_action(TextInputAction::Delete(TextMovement::ParagraphStart))
+        }
+        "deleteToEndOfLine:" => edit_lock.handle_action(TextInputAction::Delete(
+            TextMovement::Line(TextDirection::Downstream),
+        )),
+        "deleteToEndOfParagraph:" => {
+            // TODO(lord): this seems to also kill the text into a buffer that can get pasted with yank
+            edit_lock.handle_action(TextInputAction::Delete(TextMovement::ParagraphEnd))
+        }
+        "deleteWordBackward:" => edit_lock.handle_action(TextInputAction::Delete(
+            TextMovement::Word(TextDirection::Upstream),
+        )),
+        "deleteWordForward:" => edit_lock.handle_action(TextInputAction::Delete(
+            TextMovement::Word(TextDirection::Downstream),
+        )),
+        "insertBacktab:" => edit_lock.handle_action(TextInputAction::InsertBacktab),
+        "insertLineBreak:" => edit_lock.handle_action(TextInputAction::InsertNewLine {
+            ignore_hotkey: false,
+            newline_type: '\u{2028}',
+        }),
+        "insertNewline:" => edit_lock.handle_action(TextInputAction::InsertNewLine {
+            ignore_hotkey: false,
+            newline_type: '\n',
+        }),
+        "insertNewlineIgnoringFieldEditor:" => {
+            edit_lock.handle_action(TextInputAction::InsertNewLine {
+                ignore_hotkey: true,
+                newline_type: '\n',
+            })
+        }
+        "insertParagraphSeparator:" => edit_lock.handle_action(TextInputAction::InsertNewLine {
+            ignore_hotkey: false,
+            newline_type: '\u{2029}',
+        }),
+        "insertTab:" => edit_lock.handle_action(TextInputAction::InsertTab {
+            ignore_hotkey: false,
+        }),
+        "insertTabIgnoringFieldEditor:" => edit_lock.handle_action(TextInputAction::InsertTab {
+            ignore_hotkey: true,
+        }),
+        "makeBaseWritingDirectionLeftToRight:" => edit_lock.handle_action(
+            TextInputAction::SetParagraphWritingDirection(WritingDirection::LeftToRight),
+        ),
+        "makeBaseWritingDirectionNatural:" => edit_lock.handle_action(
+            TextInputAction::SetParagraphWritingDirection(WritingDirection::Natural),
+        ),
+        "makeBaseWritingDirectionRightToLeft:" => edit_lock.handle_action(
+            TextInputAction::SetParagraphWritingDirection(WritingDirection::RightToLeft),
+        ),
+        "makeTextWritingDirectionLeftToRight:" => edit_lock.handle_action(
+            TextInputAction::SetSelectionWritingDirection(WritingDirection::LeftToRight),
+        ),
+        "makeTextWritingDirectionNatural:" => edit_lock.handle_action(
+            TextInputAction::SetSelectionWritingDirection(WritingDirection::Natural),
+        ),
+        "makeTextWritingDirectionRightToLeft:" => edit_lock.handle_action(
+            TextInputAction::SetSelectionWritingDirection(WritingDirection::RightToLeft),
+        ),
+        "moveBackward:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Grapheme(
+            TextDirection::Upstream,
+        ))),
+        "moveBackwardAndModifySelection:" => edit_lock.handle_action(TextInputAction::MoveExtent(
+            TextMovement::Grapheme(TextDirection::Upstream),
+        )),
+        "moveDown:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Vertical(
+            VerticalMovement::LineDown,
+        ))),
+        "moveDownAndModifySelection:" => edit_lock.handle_action(TextInputAction::MoveExtent(
+            TextMovement::Vertical(VerticalMovement::LineDown),
+        )),
+        "moveForward:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Grapheme(
+            TextDirection::Downstream,
+        ))),
+        "moveForwardAndModifySelection:" => edit_lock.handle_action(TextInputAction::MoveExtent(
+            TextMovement::Grapheme(TextDirection::Downstream),
+        )),
+        "moveLeft:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Grapheme(
+            TextDirection::Left,
+        ))),
+        "moveLeftAndModifySelection:" => edit_lock.handle_action(TextInputAction::MoveExtent(
+            TextMovement::Grapheme(TextDirection::Left),
+        )),
+        "moveParagraphBackwardAndModifySelection:" => {
+            let selection = edit_lock.selection();
+            let is_extent_after_anchor = selection.extent > selection.anchor;
+            edit_lock.handle_action(TextInputAction::MoveExtent(TextMovement::Grapheme(
+                TextDirection::Upstream,
+            )));
+            edit_lock.handle_action(TextInputAction::MoveExtent(TextMovement::ParagraphStart));
+            if is_extent_after_anchor && selection.extent <= selection.anchor {
+                // textedit testing showed that this operation never fully inverts a selection; if this action
+                // would cause a selection's extent and anchor to swap order, it makes a caret instead. applying
+                // the operation a second time (on the selection that is now a caret) is required to invert.
+                edit_lock.set_selection(TextSelection::new_caret(selection.anchor));
+            }
+        }
+        "moveParagraphForwardAndModifySelection:" => {
+            let selection = edit_lock.selection();
+            let is_anchor_after_extent = selection.extent < selection.anchor;
+            edit_lock.handle_action(TextInputAction::MoveExtent(TextMovement::Grapheme(
+                TextDirection::Downstream,
+            )));
+            edit_lock.handle_action(TextInputAction::MoveExtent(TextMovement::ParagraphEnd));
+            if is_anchor_after_extent && selection.extent >= selection.anchor {
+                // textedit testing showed that this operation never fully inverts a selection; if this action
+                // would cause a selection's extent and anchor to swap order, it makes a caret instead. applying
+                // the operation a second time (on the selection that is now a caret) is required to invert.
+                edit_lock.set_selection(TextSelection::new_caret(selection.anchor));
+            }
+        }
+        "moveRight:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Grapheme(
+            TextDirection::Right,
+        ))),
+        "moveRightAndModifySelection:" => edit_lock.handle_action(TextInputAction::MoveExtent(
+            TextMovement::Grapheme(TextDirection::Right),
+        )),
+        "moveToBeginningOfDocument:" => edit_lock.handle_action(TextInputAction::Move(
+            TextMovement::Vertical(VerticalMovement::DocumentStart),
+        )),
+        "moveToBeginningOfDocumentAndModifySelection:" => edit_lock.handle_action(
+            TextInputAction::MoveExtent(TextMovement::Vertical(VerticalMovement::DocumentStart)),
+        ),
+        "moveToBeginningOfLine:" => edit_lock.handle_action(TextInputAction::Move(
+            TextMovement::Line(TextDirection::Upstream),
+        )),
+        "moveToBeginningOfLineAndModifySelection:" => edit_lock.handle_action(
+            TextInputAction::MoveExtent(TextMovement::Line(TextDirection::Upstream)),
+        ),
+        "moveToBeginningOfParagraph:" => {
+            // initially, it may seem like this and moveToEndOfParagraph shouldn't be idempotent. after all,
+            // option-up and option-down aren't idempotent, and those seem to call this method. however, on
+            // further inspection, you can find that option-up first calls `moveBackward` before calling this.
+            // if you send the raw command to TextEdit by editing your `DefaultKeyBinding.dict`, you can find
+            // that this operation is in fact idempotent.
+            edit_lock.handle_action(TextInputAction::Move(TextMovement::ParagraphStart))
+        }
+        "moveToBeginningOfParagraphAndModifySelection:" => {
+            edit_lock.handle_action(TextInputAction::MoveExtent(TextMovement::ParagraphStart))
+        }
+        "moveToEndOfDocument:" => edit_lock.handle_action(TextInputAction::Move(
+            TextMovement::Vertical(VerticalMovement::DocumentEnd),
+        )),
+        "moveToEndOfDocumentAndModifySelection:" => edit_lock.handle_action(
+            TextInputAction::MoveExtent(TextMovement::Vertical(VerticalMovement::DocumentEnd)),
+        ),
+        "moveToEndOfLine:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Line(
+            TextDirection::Downstream,
+        ))),
+        "moveToEndOfLineAndModifySelection:" => edit_lock.handle_action(
+            TextInputAction::MoveExtent(TextMovement::Line(TextDirection::Downstream)),
+        ),
+        "moveToEndOfParagraph:" => {
+            edit_lock.handle_action(TextInputAction::Move(TextMovement::ParagraphEnd))
+        }
+        "moveToEndOfParagraphAndModifySelection:" => {
+            edit_lock.handle_action(TextInputAction::MoveExtent(TextMovement::ParagraphEnd))
+        }
+        "moveToLeftEndOfLine:" => edit_lock.handle_action(TextInputAction::Move(
+            TextMovement::Line(TextDirection::Left),
+        )),
+        "moveToLeftEndOfLineAndModifySelection:" => edit_lock.handle_action(
+            TextInputAction::MoveExtent(TextMovement::Line(TextDirection::Left)),
+        ),
+        "moveToRightEndOfLine:" => edit_lock.handle_action(TextInputAction::Move(
+            TextMovement::Line(TextDirection::Right),
+        )),
+        "moveToRightEndOfLineAndModifySelection:" => edit_lock.handle_action(
+            TextInputAction::MoveExtent(TextMovement::Line(TextDirection::Right)),
+        ),
+        "moveUp:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Vertical(
+            VerticalMovement::LineUp,
+        ))),
+        "moveUpAndModifySelection:" => edit_lock.handle_action(TextInputAction::MoveExtent(
+            TextMovement::Vertical(VerticalMovement::LineUp),
+        )),
+        "moveWordBackward:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Word(
+            TextDirection::Upstream,
+        ))),
+        "moveWordBackwardAndModifySelection:" => edit_lock.handle_action(
+            TextInputAction::MoveExtent(TextMovement::Word(TextDirection::Upstream)),
+        ),
+        "moveWordForward:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Word(
+            TextDirection::Downstream,
+        ))),
+        "moveWordForwardAndModifySelection:" => edit_lock.handle_action(
+            TextInputAction::MoveExtent(TextMovement::Word(TextDirection::Downstream)),
+        ),
+        "moveWordLeft:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Word(
+            TextDirection::Left,
+        ))),
+        "moveWordLeftAndModifySelection:" => edit_lock.handle_action(TextInputAction::MoveExtent(
+            TextMovement::Word(TextDirection::Left),
+        )),
+        "moveWordRight:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Word(
+            TextDirection::Right,
+        ))),
+        "moveWordRightAndModifySelection:" => edit_lock.handle_action(TextInputAction::MoveExtent(
+            TextMovement::Word(TextDirection::Right),
+        )),
+        "pageDown:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Vertical(
+            VerticalMovement::PageDown,
+        ))),
+        "pageDownAndModifySelection:" => edit_lock.handle_action(TextInputAction::MoveExtent(
+            TextMovement::Vertical(VerticalMovement::PageDown),
+        )),
+        "pageUp:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Vertical(
+            VerticalMovement::PageUp,
+        ))),
+        "pageUpAndModifySelection:" => edit_lock.handle_action(TextInputAction::MoveExtent(
+            TextMovement::Vertical(VerticalMovement::PageUp),
+        )),
+        "scrollLineDown:" => {
+            edit_lock.handle_action(TextInputAction::Scroll(VerticalMovement::LineDown))
+        }
+        "scrollLineUp:" => {
+            edit_lock.handle_action(TextInputAction::Scroll(VerticalMovement::LineUp))
+        }
+        "scrollPageDown:" => {
+            edit_lock.handle_action(TextInputAction::Scroll(VerticalMovement::PageDown))
+        }
+        "scrollPageUp:" => {
+            edit_lock.handle_action(TextInputAction::Scroll(VerticalMovement::PageUp))
+        }
+        "scrollToBeginningOfDocument:" => {
+            edit_lock.handle_action(TextInputAction::Scroll(VerticalMovement::DocumentStart))
+        }
+        "scrollToEndOfDocument:" => {
+            edit_lock.handle_action(TextInputAction::Scroll(VerticalMovement::DocumentEnd))
+        }
+        "selectAll:" => edit_lock.handle_action(TextInputAction::SelectAll),
+        "selectLine:" => edit_lock.handle_action(TextInputAction::SelectLine),
+        "selectParagraph:" => edit_lock.handle_action(TextInputAction::SelectParagraph),
+        "selectWord:" => edit_lock.handle_action(TextInputAction::SelectWord),
+        "transpose:" => {
+            // transpose is a tricky-to-implement-correctly mac-specific operation, and so we implement it using
+            // edit_lock commands directly instead of allowing applications to implement it directly through an
+            // action handler. it seems extremely unlikely anybody would want to override its behavior, anyway.
+
+            // Swaps the graphemes before and after the caret, and then moves the caret downstream one grapheme. If the caret is at the
+            // end of a hard-wrapped line or document, act as though the caret was one grapheme upstream instead. If the caret is at the
+            // beginning of the document, this is a no-op. This is a no-op on non-caret selections (when `anchor != extent`).
+
+            {
+                let selection = edit_lock.selection();
+                if !selection.is_caret() || selection.anchor == 0 {
+                    return;
+                }
+            }
+
+            // move caret to the end of the transpose region
+            {
+                let old_selection = edit_lock.selection();
+                edit_lock.handle_action(TextInputAction::MoveExtent(TextMovement::Grapheme(
+                    TextDirection::Downstream,
+                )));
+                let new_selection = edit_lock.selection().to_range();
+                let next_grapheme = edit_lock.slice(new_selection.clone());
+                let next_char = next_grapheme.chars().next();
+
+                if next_char == Some('\n')
+                    || next_char == Some('\r')
+                    || next_char == Some('\u{2029}')
+                    || next_char == Some('\u{2028}')
+                    || next_char == None
+                {
+                    // next char is a newline or end of doc; so end of transpose range will actually be the starting selection.anchor
+                    edit_lock.set_selection(old_selection);
+                } else {
+                    // normally, end of transpose range will be next grapheme
+                    edit_lock.set_selection(TextSelection::new_caret(new_selection.end));
+                }
+            }
+
+            // now find the previous two graphemes
+            edit_lock.handle_action(TextInputAction::MoveExtent(TextMovement::Grapheme(
+                TextDirection::Upstream,
+            )));
+            let middle_idx = edit_lock.selection().extent;
+            edit_lock.handle_action(TextInputAction::MoveExtent(TextMovement::Grapheme(
+                TextDirection::Upstream,
+            )));
+            let selection = edit_lock.selection();
+            let first_grapheme = edit_lock
+                .slice(selection.upstream_index()..middle_idx)
+                .into_owned();
+            let second_grapheme = edit_lock.slice(middle_idx..selection.downstream_index());
+            let new_string = format!("{}{}", second_grapheme, first_grapheme);
+            // replace_range should automatically set selection to end of inserted range
+            edit_lock.replace_range(selection.to_range(), &new_string);
+        }
+        "capitalizeWord:" => {
+            // this command expands the selection to words, and then applies titlecase to that selection
+            // not actually sure what keyboard shortcut corresponds to this or the other case changing commands,
+            // but textedit seems to have this behavior when this action is simulated by editing DefaultKeyBinding.dict.
+            edit_lock.handle_action(TextInputAction::SelectWord);
+            edit_lock.handle_action(TextInputAction::TitlecaseSelection)
+        }
+        "lowercaseWord:" => {
+            // this command expands the selection to words, and then applies uppercase to that selection
+            edit_lock.handle_action(TextInputAction::SelectWord);
+            edit_lock.handle_action(TextInputAction::LowercaseSelection);
+        }
+        "uppercaseWord:" => {
+            // this command expands the selection to words, and then applies uppercase to that selection
+            edit_lock.handle_action(TextInputAction::SelectWord);
+            edit_lock.handle_action(TextInputAction::UppercaseSelection);
+        }
+        "insertDoubleQuoteIgnoringSubstitution:" => {
+            edit_lock.handle_action(TextInputAction::InsertDoubleQuoteIgnoringSmartQuotes)
+        }
+        "insertSingleQuoteIgnoringSubstitution:" => {
+            edit_lock.handle_action(TextInputAction::InsertSingleQuoteIgnoringSmartQuotes)
+        }
+        "cancelOperation:" => edit_lock.handle_action(TextInputAction::Cancel),
+        // "deleteToMark:" => {}          // TODO(lord): selectToMark, then delete selection. also puts selection in yank buffer
+        // "selectToMark:" => {}          // TODO(lord): extends the selection to include the mark
+        // "setMark:" => {}               // TODO(lord): remembers index in document (but what about grapheme clusters??)
+        // "swapWithMark:" => {}          // TODO(lord): swaps current and stored mark indices
+        // "yank:" => {}                  // TODO(lord): triggered with control-y, inserts in the text previously killed deleteTo*OfParagraph
+        "transposeWords:" => {} // textedit doesn't support, so neither will we
+        "changeCaseOfLetter:" => {} // textedit doesn't support, so neither will we
+        "indent:" => {}         // textedit doesn't support, so neither will we
+        "insertContainerBreak:" => {} // textedit and pages don't seem to support, so neither will we
+        "quickLookPreviewItems:" => {} // don't seem to apply to text editing?? hopefully
+        "complete:" => {}             // intercepted by the IME; if it gets to us, noop
+        "noop:" => {}
+        e => {
+            eprintln!("unknown text editing command from macos: {}", e);
+        }
+    };
+}
+
+/// Parses the UTF-16 `NSRange` into a UTF-8 `Range<usize>`.
+/// `start_offset` is the UTF-8 offset into the document that `range` values are relative to. Set it to `0` if `range`
+/// is absolute instead of relative.
+/// Returns `None` if `range` was invalid; macOS often uses this to indicate some special null value.
+fn decode_nsrange(
+    edit_lock: &mut Box<dyn TextInputHandler>,
+    range: &NSRange,
+    start_offset: usize,
+) -> Option<Range<usize>> {
+    if range.location as usize >= i32::max_value() as usize {
+        return None;
+    }
+    let start_offset_utf16 = edit_lock.utf8_to_utf16(0..start_offset);
+    let location_utf16 = range.location as usize + start_offset_utf16;
+    let length_utf16 = range.length as usize;
+    let start_utf8 = edit_lock.utf16_to_utf8(0..location_utf16);
+    let end_utf8 =
+        start_utf8 + edit_lock.utf16_to_utf8(location_utf16..location_utf16 + length_utf16);
+    Some(start_utf8..end_utf8)
+}
+
+// Encodes the UTF-8 `Range<usize>` into a UTF-16 `NSRange`.
+fn encode_nsrange(edit_lock: &mut Box<dyn TextInputHandler>, mut range: Range<usize>) -> NSRange {
+    while !edit_lock.is_char_boundary(range.start) {
+        range.start -= 1;
+    }
+    while !edit_lock.is_char_boundary(range.end) {
+        range.end -= 1;
+    }
+    let start = edit_lock.utf8_to_utf16(0..range.start);
+    let len = edit_lock.utf8_to_utf16(range);
+    NSRange::new(start as NSUInteger, len as NSUInteger)
+}
+
+fn parse_attributed_string(text: &id) -> &str {
+    unsafe {
+        let nsstring = if msg_send![*text, isKindOfClass: class!(NSAttributedString)] {
+            msg_send![*text, string]
+        } else {
+            // already a NSString
+            *text
+        };
+        let slice =
+            std::slice::from_raw_parts(nsstring.UTF8String() as *const c_uchar, nsstring.len());
+        std::str::from_utf8_unchecked(slice)
+    }
+}

--- a/druid-shell/src/platform/mac/text_input.rs
+++ b/druid-shell/src/platform/mac/text_input.rs
@@ -601,11 +601,13 @@ pub extern "C" fn do_command_by_selector(this: &mut Object, _: Sel, cmd: Sel) {
         "insertContainerBreak:" => {} // textedit and pages don't seem to support, so neither will we
         "quickLookPreviewItems:" => {} // don't seem to apply to text editing?? hopefully
         // TODO(lord): reply to cmyr comment
-        "complete:" => {} // intercepted by the IME; if it gets to us, noop
+        "complete:" => {
+            // these are normally intercepted by the IME; if it gets to us, log
+            eprintln!("got an unexpected 'complete' text input command from macOS");
+        }
         "noop:" => {}
         e => {
-            eprintln!("unknown text editing command from macos: {}", e);
-            {};
+            eprintln!("unknown text editing command from macOS: {}", e);
         }
     };
 }

--- a/druid-shell/src/platform/mac/text_input.rs
+++ b/druid-shell/src/platform/mac/text_input.rs
@@ -27,9 +27,9 @@ use std::os::raw::c_uchar;
 
 use super::window::get_edit_lock_from_window;
 use crate::kurbo::Point;
-use crate::text_input::{
-    Affinity, TextDirection, TextInputAction, TextInputHandler, TextMovement, TextSelection,
-    VerticalMovement, WritingDirection,
+use crate::text::{
+    Action, Affinity, Direction, InputHandler, Movement, Selection, VerticalMovement,
+    WritingDirection,
 };
 use cocoa::base::{id, nil, BOOL};
 use cocoa::foundation::{NSArray, NSPoint, NSRect, NSSize, NSString, NSUInteger};
@@ -39,6 +39,8 @@ use objc::{class, msg_send, sel, sel_impl};
 
 // thanks to winit for the custom NSRange code:
 // https://github.com/rust-windowing/winit/pull/518/files#diff-61be96e960785f102cb20ad8464eafeb6edd4245ea40224b3c3206c72cd5bf56R12-R34
+// this is necessary until objc implements objc::Encode for their NSRange; ideally this code could get upstreamed
+// and we could delete it.
 #[repr(C)]
 #[derive(Debug)]
 pub struct NSRange {
@@ -142,12 +144,12 @@ pub extern "C" fn set_marked_text(
         // preserve ordering of anchor and extent
         let existing_selection = edit_lock.selection();
         let new_selection = if existing_selection.anchor < existing_selection.extent {
-            TextSelection {
+            Selection {
                 anchor: selection_range.start,
                 extent: selection_range.end,
             }
         } else {
-            TextSelection {
+            Selection {
                 extent: selection_range.start,
                 anchor: selection_range.end,
             }
@@ -218,7 +220,7 @@ pub extern "C" fn insert_text(this: &mut Object, _: Sel, text: id, replacement_r
     edit_lock.set_composition_range(None);
     // move the caret next to the inserted text
     let caret_index = converted_range.start + text_string.len();
-    edit_lock.set_selection(TextSelection::new_caret(caret_index));
+    edit_lock.set_selection(Selection::new_caret(caret_index));
 }
 
 pub extern "C" fn character_index_for_point(
@@ -275,262 +277,244 @@ pub extern "C" fn first_rect_for_character_range(
 pub extern "C" fn do_command_by_selector(this: &mut Object, _: Sel, cmd: Sel) {
     let mut edit_lock = match get_edit_lock_from_window(this, true) {
         Some(v) => v,
-        None => return,
+        None => {
+            // we're not a text field, so forward commands to our parent
+            if let Some(superclass) = this.class().superclass() {
+                unsafe { msg_send![superclass, doCommandBySelector: cmd] }
+            }
+            return;
+        }
     };
     match cmd.name() {
         // see https://developer.apple.com/documentation/appkit/nsstandardkeybindingresponding?language=objc
         // and https://support.apple.com/en-us/HT201236
         // and https://support.apple.com/lv-lv/guide/mac-help/mh21243/mac
-        "centerSelectionInVisibleArea:" => {
-            edit_lock.handle_action(TextInputAction::ScrollToSelection)
+        "centerSelectionInVisibleArea:" => edit_lock.handle_action(Action::ScrollToSelection),
+        "deleteBackward:" => {
+            edit_lock.handle_action(Action::Delete(Movement::Grapheme(Direction::Upstream)))
         }
-        "deleteBackward:" => edit_lock.handle_action(TextInputAction::Delete(
-            TextMovement::Grapheme(TextDirection::Upstream),
-        )),
         "deleteBackwardByDecomposingPreviousCharacter:" => {
-            edit_lock.handle_action(TextInputAction::DecomposingBackspace)
+            edit_lock.handle_action(Action::DecomposingBackspace)
         }
-        "deleteForward:" => edit_lock.handle_action(TextInputAction::Delete(
-            TextMovement::Grapheme(TextDirection::Downstream),
-        )),
-        "deleteToBeginningOfLine:" => edit_lock.handle_action(TextInputAction::Delete(
-            TextMovement::Line(TextDirection::Upstream),
-        )),
+        "deleteForward:" => {
+            edit_lock.handle_action(Action::Delete(Movement::Grapheme(Direction::Downstream)))
+        }
+        "deleteToBeginningOfLine:" => {
+            edit_lock.handle_action(Action::Delete(Movement::Line(Direction::Upstream)))
+        }
         "deleteToBeginningOfParagraph:" => {
             // TODO(lord): this seems to also kill the text into a buffer that can get pasted with yank
-            edit_lock.handle_action(TextInputAction::Delete(TextMovement::ParagraphStart))
+            edit_lock.handle_action(Action::Delete(Movement::ParagraphStart))
         }
-        "deleteToEndOfLine:" => edit_lock.handle_action(TextInputAction::Delete(
-            TextMovement::Line(TextDirection::Downstream),
-        )),
+        "deleteToEndOfLine:" => {
+            edit_lock.handle_action(Action::Delete(Movement::Line(Direction::Downstream)))
+        }
         "deleteToEndOfParagraph:" => {
             // TODO(lord): this seems to also kill the text into a buffer that can get pasted with yank
-            edit_lock.handle_action(TextInputAction::Delete(TextMovement::ParagraphEnd))
+            edit_lock.handle_action(Action::Delete(Movement::ParagraphEnd))
         }
-        "deleteWordBackward:" => edit_lock.handle_action(TextInputAction::Delete(
-            TextMovement::Word(TextDirection::Upstream),
-        )),
-        "deleteWordForward:" => edit_lock.handle_action(TextInputAction::Delete(
-            TextMovement::Word(TextDirection::Downstream),
-        )),
-        "insertBacktab:" => edit_lock.handle_action(TextInputAction::InsertBacktab),
-        "insertLineBreak:" => edit_lock.handle_action(TextInputAction::InsertNewLine {
+        "deleteWordBackward:" => {
+            edit_lock.handle_action(Action::Delete(Movement::Word(Direction::Upstream)))
+        }
+        "deleteWordForward:" => {
+            edit_lock.handle_action(Action::Delete(Movement::Word(Direction::Downstream)))
+        }
+        "insertBacktab:" => edit_lock.handle_action(Action::InsertBacktab),
+        "insertLineBreak:" => edit_lock.handle_action(Action::InsertNewLine {
             ignore_hotkey: false,
             newline_type: '\u{2028}',
         }),
-        "insertNewline:" => edit_lock.handle_action(TextInputAction::InsertNewLine {
+        "insertNewline:" => edit_lock.handle_action(Action::InsertNewLine {
             ignore_hotkey: false,
             newline_type: '\n',
         }),
-        "insertNewlineIgnoringFieldEditor:" => {
-            edit_lock.handle_action(TextInputAction::InsertNewLine {
-                ignore_hotkey: true,
-                newline_type: '\n',
-            })
-        }
-        "insertParagraphSeparator:" => edit_lock.handle_action(TextInputAction::InsertNewLine {
+        "insertNewlineIgnoringFieldEditor:" => edit_lock.handle_action(Action::InsertNewLine {
+            ignore_hotkey: true,
+            newline_type: '\n',
+        }),
+        "insertParagraphSeparator:" => edit_lock.handle_action(Action::InsertNewLine {
             ignore_hotkey: false,
             newline_type: '\u{2029}',
         }),
-        "insertTab:" => edit_lock.handle_action(TextInputAction::InsertTab {
+        "insertTab:" => edit_lock.handle_action(Action::InsertTab {
             ignore_hotkey: false,
         }),
-        "insertTabIgnoringFieldEditor:" => edit_lock.handle_action(TextInputAction::InsertTab {
+        "insertTabIgnoringFieldEditor:" => edit_lock.handle_action(Action::InsertTab {
             ignore_hotkey: true,
         }),
         "makeBaseWritingDirectionLeftToRight:" => edit_lock.handle_action(
-            TextInputAction::SetParagraphWritingDirection(WritingDirection::LeftToRight),
+            Action::SetParagraphWritingDirection(WritingDirection::LeftToRight),
         ),
         "makeBaseWritingDirectionNatural:" => edit_lock.handle_action(
-            TextInputAction::SetParagraphWritingDirection(WritingDirection::Natural),
+            Action::SetParagraphWritingDirection(WritingDirection::Natural),
         ),
         "makeBaseWritingDirectionRightToLeft:" => edit_lock.handle_action(
-            TextInputAction::SetParagraphWritingDirection(WritingDirection::RightToLeft),
+            Action::SetParagraphWritingDirection(WritingDirection::RightToLeft),
         ),
         "makeTextWritingDirectionLeftToRight:" => edit_lock.handle_action(
-            TextInputAction::SetSelectionWritingDirection(WritingDirection::LeftToRight),
+            Action::SetSelectionWritingDirection(WritingDirection::LeftToRight),
         ),
         "makeTextWritingDirectionNatural:" => edit_lock.handle_action(
-            TextInputAction::SetSelectionWritingDirection(WritingDirection::Natural),
+            Action::SetSelectionWritingDirection(WritingDirection::Natural),
         ),
         "makeTextWritingDirectionRightToLeft:" => edit_lock.handle_action(
-            TextInputAction::SetSelectionWritingDirection(WritingDirection::RightToLeft),
+            Action::SetSelectionWritingDirection(WritingDirection::RightToLeft),
         ),
-        "moveBackward:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Grapheme(
-            TextDirection::Upstream,
-        ))),
-        "moveBackwardAndModifySelection:" => edit_lock.handle_action(TextInputAction::MoveExtent(
-            TextMovement::Grapheme(TextDirection::Upstream),
+        "moveBackward:" => {
+            edit_lock.handle_action(Action::Move(Movement::Grapheme(Direction::Upstream)))
+        }
+        "moveBackwardAndModifySelection:" => {
+            edit_lock.handle_action(Action::MoveExtent(Movement::Grapheme(Direction::Upstream)))
+        }
+        "moveDown:" => {
+            edit_lock.handle_action(Action::Move(Movement::Vertical(VerticalMovement::LineDown)))
+        }
+        "moveDownAndModifySelection:" => edit_lock.handle_action(Action::MoveExtent(
+            Movement::Vertical(VerticalMovement::LineDown),
         )),
-        "moveDown:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Vertical(
-            VerticalMovement::LineDown,
-        ))),
-        "moveDownAndModifySelection:" => edit_lock.handle_action(TextInputAction::MoveExtent(
-            TextMovement::Vertical(VerticalMovement::LineDown),
+        "moveForward:" => {
+            edit_lock.handle_action(Action::Move(Movement::Grapheme(Direction::Downstream)))
+        }
+        "moveForwardAndModifySelection:" => edit_lock.handle_action(Action::MoveExtent(
+            Movement::Grapheme(Direction::Downstream),
         )),
-        "moveForward:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Grapheme(
-            TextDirection::Downstream,
-        ))),
-        "moveForwardAndModifySelection:" => edit_lock.handle_action(TextInputAction::MoveExtent(
-            TextMovement::Grapheme(TextDirection::Downstream),
-        )),
-        "moveLeft:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Grapheme(
-            TextDirection::Left,
-        ))),
-        "moveLeftAndModifySelection:" => edit_lock.handle_action(TextInputAction::MoveExtent(
-            TextMovement::Grapheme(TextDirection::Left),
-        )),
+        "moveLeft:" => edit_lock.handle_action(Action::Move(Movement::Grapheme(Direction::Left))),
+        "moveLeftAndModifySelection:" => {
+            edit_lock.handle_action(Action::MoveExtent(Movement::Grapheme(Direction::Left)))
+        }
         "moveParagraphBackwardAndModifySelection:" => {
             let selection = edit_lock.selection();
             let is_extent_after_anchor = selection.extent > selection.anchor;
-            edit_lock.handle_action(TextInputAction::MoveExtent(TextMovement::Grapheme(
-                TextDirection::Upstream,
-            )));
-            edit_lock.handle_action(TextInputAction::MoveExtent(TextMovement::ParagraphStart));
+            edit_lock.handle_action(Action::MoveExtent(Movement::Grapheme(Direction::Upstream)));
+            edit_lock.handle_action(Action::MoveExtent(Movement::ParagraphStart));
             if is_extent_after_anchor && selection.extent <= selection.anchor {
                 // textedit testing showed that this operation never fully inverts a selection; if this action
                 // would cause a selection's extent and anchor to swap order, it makes a caret instead. applying
                 // the operation a second time (on the selection that is now a caret) is required to invert.
-                edit_lock.set_selection(TextSelection::new_caret(selection.anchor));
+                edit_lock.set_selection(Selection::new_caret(selection.anchor));
             }
         }
         "moveParagraphForwardAndModifySelection:" => {
             let selection = edit_lock.selection();
             let is_anchor_after_extent = selection.extent < selection.anchor;
-            edit_lock.handle_action(TextInputAction::MoveExtent(TextMovement::Grapheme(
-                TextDirection::Downstream,
+            edit_lock.handle_action(Action::MoveExtent(Movement::Grapheme(
+                Direction::Downstream,
             )));
-            edit_lock.handle_action(TextInputAction::MoveExtent(TextMovement::ParagraphEnd));
+            edit_lock.handle_action(Action::MoveExtent(Movement::ParagraphEnd));
             if is_anchor_after_extent && selection.extent >= selection.anchor {
                 // textedit testing showed that this operation never fully inverts a selection; if this action
                 // would cause a selection's extent and anchor to swap order, it makes a caret instead. applying
                 // the operation a second time (on the selection that is now a caret) is required to invert.
-                edit_lock.set_selection(TextSelection::new_caret(selection.anchor));
+                edit_lock.set_selection(Selection::new_caret(selection.anchor));
             }
         }
-        "moveRight:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Grapheme(
-            TextDirection::Right,
+        "moveRight:" => edit_lock.handle_action(Action::Move(Movement::Grapheme(Direction::Right))),
+        "moveRightAndModifySelection:" => {
+            edit_lock.handle_action(Action::MoveExtent(Movement::Grapheme(Direction::Right)))
+        }
+        "moveToBeginningOfDocument:" => edit_lock.handle_action(Action::Move(Movement::Vertical(
+            VerticalMovement::DocumentStart,
         ))),
-        "moveRightAndModifySelection:" => edit_lock.handle_action(TextInputAction::MoveExtent(
-            TextMovement::Grapheme(TextDirection::Right),
-        )),
-        "moveToBeginningOfDocument:" => edit_lock.handle_action(TextInputAction::Move(
-            TextMovement::Vertical(VerticalMovement::DocumentStart),
-        )),
         "moveToBeginningOfDocumentAndModifySelection:" => edit_lock.handle_action(
-            TextInputAction::MoveExtent(TextMovement::Vertical(VerticalMovement::DocumentStart)),
+            Action::MoveExtent(Movement::Vertical(VerticalMovement::DocumentStart)),
         ),
-        "moveToBeginningOfLine:" => edit_lock.handle_action(TextInputAction::Move(
-            TextMovement::Line(TextDirection::Upstream),
-        )),
-        "moveToBeginningOfLineAndModifySelection:" => edit_lock.handle_action(
-            TextInputAction::MoveExtent(TextMovement::Line(TextDirection::Upstream)),
-        ),
+        "moveToBeginningOfLine:" => {
+            edit_lock.handle_action(Action::Move(Movement::Line(Direction::Upstream)))
+        }
+        "moveToBeginningOfLineAndModifySelection:" => {
+            edit_lock.handle_action(Action::MoveExtent(Movement::Line(Direction::Upstream)))
+        }
         "moveToBeginningOfParagraph:" => {
             // initially, it may seem like this and moveToEndOfParagraph shouldn't be idempotent. after all,
             // option-up and option-down aren't idempotent, and those seem to call this method. however, on
             // further inspection, you can find that option-up first calls `moveBackward` before calling this.
             // if you send the raw command to TextEdit by editing your `DefaultKeyBinding.dict`, you can find
             // that this operation is in fact idempotent.
-            edit_lock.handle_action(TextInputAction::Move(TextMovement::ParagraphStart))
+            edit_lock.handle_action(Action::Move(Movement::ParagraphStart))
         }
         "moveToBeginningOfParagraphAndModifySelection:" => {
-            edit_lock.handle_action(TextInputAction::MoveExtent(TextMovement::ParagraphStart))
+            edit_lock.handle_action(Action::MoveExtent(Movement::ParagraphStart))
         }
-        "moveToEndOfDocument:" => edit_lock.handle_action(TextInputAction::Move(
-            TextMovement::Vertical(VerticalMovement::DocumentEnd),
-        )),
-        "moveToEndOfDocumentAndModifySelection:" => edit_lock.handle_action(
-            TextInputAction::MoveExtent(TextMovement::Vertical(VerticalMovement::DocumentEnd)),
-        ),
-        "moveToEndOfLine:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Line(
-            TextDirection::Downstream,
+        "moveToEndOfDocument:" => edit_lock.handle_action(Action::Move(Movement::Vertical(
+            VerticalMovement::DocumentEnd,
         ))),
-        "moveToEndOfLineAndModifySelection:" => edit_lock.handle_action(
-            TextInputAction::MoveExtent(TextMovement::Line(TextDirection::Downstream)),
-        ),
-        "moveToEndOfParagraph:" => {
-            edit_lock.handle_action(TextInputAction::Move(TextMovement::ParagraphEnd))
+        "moveToEndOfDocumentAndModifySelection:" => edit_lock.handle_action(Action::MoveExtent(
+            Movement::Vertical(VerticalMovement::DocumentEnd),
+        )),
+        "moveToEndOfLine:" => {
+            edit_lock.handle_action(Action::Move(Movement::Line(Direction::Downstream)))
         }
+        "moveToEndOfLineAndModifySelection:" => {
+            edit_lock.handle_action(Action::MoveExtent(Movement::Line(Direction::Downstream)))
+        }
+        "moveToEndOfParagraph:" => edit_lock.handle_action(Action::Move(Movement::ParagraphEnd)),
         "moveToEndOfParagraphAndModifySelection:" => {
-            edit_lock.handle_action(TextInputAction::MoveExtent(TextMovement::ParagraphEnd))
+            edit_lock.handle_action(Action::MoveExtent(Movement::ParagraphEnd))
         }
-        "moveToLeftEndOfLine:" => edit_lock.handle_action(TextInputAction::Move(
-            TextMovement::Line(TextDirection::Left),
-        )),
-        "moveToLeftEndOfLineAndModifySelection:" => edit_lock.handle_action(
-            TextInputAction::MoveExtent(TextMovement::Line(TextDirection::Left)),
-        ),
-        "moveToRightEndOfLine:" => edit_lock.handle_action(TextInputAction::Move(
-            TextMovement::Line(TextDirection::Right),
-        )),
-        "moveToRightEndOfLineAndModifySelection:" => edit_lock.handle_action(
-            TextInputAction::MoveExtent(TextMovement::Line(TextDirection::Right)),
-        ),
-        "moveUp:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Vertical(
-            VerticalMovement::LineUp,
-        ))),
-        "moveUpAndModifySelection:" => edit_lock.handle_action(TextInputAction::MoveExtent(
-            TextMovement::Vertical(VerticalMovement::LineUp),
-        )),
-        "moveWordBackward:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Word(
-            TextDirection::Upstream,
-        ))),
-        "moveWordBackwardAndModifySelection:" => edit_lock.handle_action(
-            TextInputAction::MoveExtent(TextMovement::Word(TextDirection::Upstream)),
-        ),
-        "moveWordForward:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Word(
-            TextDirection::Downstream,
-        ))),
-        "moveWordForwardAndModifySelection:" => edit_lock.handle_action(
-            TextInputAction::MoveExtent(TextMovement::Word(TextDirection::Downstream)),
-        ),
-        "moveWordLeft:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Word(
-            TextDirection::Left,
-        ))),
-        "moveWordLeftAndModifySelection:" => edit_lock.handle_action(TextInputAction::MoveExtent(
-            TextMovement::Word(TextDirection::Left),
-        )),
-        "moveWordRight:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Word(
-            TextDirection::Right,
-        ))),
-        "moveWordRightAndModifySelection:" => edit_lock.handle_action(TextInputAction::MoveExtent(
-            TextMovement::Word(TextDirection::Right),
-        )),
-        "pageDown:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Vertical(
-            VerticalMovement::PageDown,
-        ))),
-        "pageDownAndModifySelection:" => edit_lock.handle_action(TextInputAction::MoveExtent(
-            TextMovement::Vertical(VerticalMovement::PageDown),
-        )),
-        "pageUp:" => edit_lock.handle_action(TextInputAction::Move(TextMovement::Vertical(
-            VerticalMovement::PageUp,
-        ))),
-        "pageUpAndModifySelection:" => edit_lock.handle_action(TextInputAction::MoveExtent(
-            TextMovement::Vertical(VerticalMovement::PageUp),
-        )),
-        "scrollLineDown:" => {
-            edit_lock.handle_action(TextInputAction::Scroll(VerticalMovement::LineDown))
+        "moveToLeftEndOfLine:" => {
+            edit_lock.handle_action(Action::Move(Movement::Line(Direction::Left)))
         }
-        "scrollLineUp:" => {
-            edit_lock.handle_action(TextInputAction::Scroll(VerticalMovement::LineUp))
+        "moveToLeftEndOfLineAndModifySelection:" => {
+            edit_lock.handle_action(Action::MoveExtent(Movement::Line(Direction::Left)))
         }
-        "scrollPageDown:" => {
-            edit_lock.handle_action(TextInputAction::Scroll(VerticalMovement::PageDown))
+        "moveToRightEndOfLine:" => {
+            edit_lock.handle_action(Action::Move(Movement::Line(Direction::Right)))
         }
-        "scrollPageUp:" => {
-            edit_lock.handle_action(TextInputAction::Scroll(VerticalMovement::PageUp))
+        "moveToRightEndOfLineAndModifySelection:" => {
+            edit_lock.handle_action(Action::MoveExtent(Movement::Line(Direction::Right)))
         }
+        "moveUp:" => {
+            edit_lock.handle_action(Action::Move(Movement::Vertical(VerticalMovement::LineUp)))
+        }
+        "moveUpAndModifySelection:" => edit_lock.handle_action(Action::MoveExtent(
+            Movement::Vertical(VerticalMovement::LineUp),
+        )),
+        "moveWordBackward:" => {
+            edit_lock.handle_action(Action::Move(Movement::Word(Direction::Upstream)))
+        }
+        "moveWordBackwardAndModifySelection:" => {
+            edit_lock.handle_action(Action::MoveExtent(Movement::Word(Direction::Upstream)))
+        }
+        "moveWordForward:" => {
+            edit_lock.handle_action(Action::Move(Movement::Word(Direction::Downstream)))
+        }
+        "moveWordForwardAndModifySelection:" => {
+            edit_lock.handle_action(Action::MoveExtent(Movement::Word(Direction::Downstream)))
+        }
+        "moveWordLeft:" => edit_lock.handle_action(Action::Move(Movement::Word(Direction::Left))),
+        "moveWordLeftAndModifySelection:" => {
+            edit_lock.handle_action(Action::MoveExtent(Movement::Word(Direction::Left)))
+        }
+        "moveWordRight:" => edit_lock.handle_action(Action::Move(Movement::Word(Direction::Right))),
+        "moveWordRightAndModifySelection:" => {
+            edit_lock.handle_action(Action::MoveExtent(Movement::Word(Direction::Right)))
+        }
+        "pageDown:" => {
+            edit_lock.handle_action(Action::Move(Movement::Vertical(VerticalMovement::PageDown)))
+        }
+        "pageDownAndModifySelection:" => edit_lock.handle_action(Action::MoveExtent(
+            Movement::Vertical(VerticalMovement::PageDown),
+        )),
+        "pageUp:" => {
+            edit_lock.handle_action(Action::Move(Movement::Vertical(VerticalMovement::PageUp)))
+        }
+        "pageUpAndModifySelection:" => edit_lock.handle_action(Action::MoveExtent(
+            Movement::Vertical(VerticalMovement::PageUp),
+        )),
+        "scrollLineDown:" => edit_lock.handle_action(Action::Scroll(VerticalMovement::LineDown)),
+        "scrollLineUp:" => edit_lock.handle_action(Action::Scroll(VerticalMovement::LineUp)),
+        "scrollPageDown:" => edit_lock.handle_action(Action::Scroll(VerticalMovement::PageDown)),
+        "scrollPageUp:" => edit_lock.handle_action(Action::Scroll(VerticalMovement::PageUp)),
         "scrollToBeginningOfDocument:" => {
-            edit_lock.handle_action(TextInputAction::Scroll(VerticalMovement::DocumentStart))
+            edit_lock.handle_action(Action::Scroll(VerticalMovement::DocumentStart))
         }
         "scrollToEndOfDocument:" => {
-            edit_lock.handle_action(TextInputAction::Scroll(VerticalMovement::DocumentEnd))
+            edit_lock.handle_action(Action::Scroll(VerticalMovement::DocumentEnd))
         }
-        "selectAll:" => edit_lock.handle_action(TextInputAction::SelectAll),
-        "selectLine:" => edit_lock.handle_action(TextInputAction::SelectLine),
-        "selectParagraph:" => edit_lock.handle_action(TextInputAction::SelectParagraph),
-        "selectWord:" => edit_lock.handle_action(TextInputAction::SelectWord),
+        "selectAll:" => edit_lock.handle_action(Action::SelectAll),
+        "selectLine:" => edit_lock.handle_action(Action::SelectLine),
+        "selectParagraph:" => edit_lock.handle_action(Action::SelectParagraph),
+        "selectWord:" => edit_lock.handle_action(Action::SelectWord),
         "transpose:" => {
             // transpose is a tricky-to-implement-correctly mac-specific operation, and so we implement it using
             // edit_lock commands directly instead of allowing applications to implement it directly through an
@@ -550,8 +534,8 @@ pub extern "C" fn do_command_by_selector(this: &mut Object, _: Sel, cmd: Sel) {
             // move caret to the end of the transpose region
             {
                 let old_selection = edit_lock.selection();
-                edit_lock.handle_action(TextInputAction::MoveExtent(TextMovement::Grapheme(
-                    TextDirection::Downstream,
+                edit_lock.handle_action(Action::MoveExtent(Movement::Grapheme(
+                    Direction::Downstream,
                 )));
                 let new_selection = edit_lock.selection().to_range();
                 let next_grapheme = edit_lock.slice(new_selection.clone());
@@ -567,23 +551,17 @@ pub extern "C" fn do_command_by_selector(this: &mut Object, _: Sel, cmd: Sel) {
                     edit_lock.set_selection(old_selection);
                 } else {
                     // normally, end of transpose range will be next grapheme
-                    edit_lock.set_selection(TextSelection::new_caret(new_selection.end));
+                    edit_lock.set_selection(Selection::new_caret(new_selection.end));
                 }
             }
 
             // now find the previous two graphemes
-            edit_lock.handle_action(TextInputAction::MoveExtent(TextMovement::Grapheme(
-                TextDirection::Upstream,
-            )));
+            edit_lock.handle_action(Action::MoveExtent(Movement::Grapheme(Direction::Upstream)));
             let middle_idx = edit_lock.selection().extent;
-            edit_lock.handle_action(TextInputAction::MoveExtent(TextMovement::Grapheme(
-                TextDirection::Upstream,
-            )));
+            edit_lock.handle_action(Action::MoveExtent(Movement::Grapheme(Direction::Upstream)));
             let selection = edit_lock.selection();
-            let first_grapheme = edit_lock
-                .slice(selection.upstream_index()..middle_idx)
-                .into_owned();
-            let second_grapheme = edit_lock.slice(middle_idx..selection.downstream_index());
+            let first_grapheme = edit_lock.slice(selection.min()..middle_idx).into_owned();
+            let second_grapheme = edit_lock.slice(middle_idx..selection.max());
             let new_string = format!("{}{}", second_grapheme, first_grapheme);
             // replace_range should automatically set selection to end of inserted range
             edit_lock.replace_range(selection.to_range(), &new_string);
@@ -592,26 +570,26 @@ pub extern "C" fn do_command_by_selector(this: &mut Object, _: Sel, cmd: Sel) {
             // this command expands the selection to words, and then applies titlecase to that selection
             // not actually sure what keyboard shortcut corresponds to this or the other case changing commands,
             // but textedit seems to have this behavior when this action is simulated by editing DefaultKeyBinding.dict.
-            edit_lock.handle_action(TextInputAction::SelectWord);
-            edit_lock.handle_action(TextInputAction::TitlecaseSelection)
+            edit_lock.handle_action(Action::SelectWord);
+            edit_lock.handle_action(Action::TitlecaseSelection)
         }
         "lowercaseWord:" => {
             // this command expands the selection to words, and then applies uppercase to that selection
-            edit_lock.handle_action(TextInputAction::SelectWord);
-            edit_lock.handle_action(TextInputAction::LowercaseSelection);
+            edit_lock.handle_action(Action::SelectWord);
+            edit_lock.handle_action(Action::LowercaseSelection);
         }
         "uppercaseWord:" => {
             // this command expands the selection to words, and then applies uppercase to that selection
-            edit_lock.handle_action(TextInputAction::SelectWord);
-            edit_lock.handle_action(TextInputAction::UppercaseSelection);
+            edit_lock.handle_action(Action::SelectWord);
+            edit_lock.handle_action(Action::UppercaseSelection);
         }
         "insertDoubleQuoteIgnoringSubstitution:" => {
-            edit_lock.handle_action(TextInputAction::InsertDoubleQuoteIgnoringSmartQuotes)
+            edit_lock.handle_action(Action::InsertDoubleQuoteIgnoringSmartQuotes)
         }
         "insertSingleQuoteIgnoringSubstitution:" => {
-            edit_lock.handle_action(TextInputAction::InsertSingleQuoteIgnoringSmartQuotes)
+            edit_lock.handle_action(Action::InsertSingleQuoteIgnoringSmartQuotes)
         }
-        "cancelOperation:" => edit_lock.handle_action(TextInputAction::Cancel),
+        "cancelOperation:" => edit_lock.handle_action(Action::Cancel),
         // "deleteToMark:" => {}          // TODO(lord): selectToMark, then delete selection. also puts selection in yank buffer
         // "selectToMark:" => {}          // TODO(lord): extends the selection to include the mark
         // "setMark:" => {}               // TODO(lord): remembers index in document (but what about grapheme clusters??)
@@ -622,10 +600,12 @@ pub extern "C" fn do_command_by_selector(this: &mut Object, _: Sel, cmd: Sel) {
         "indent:" => {}         // textedit doesn't support, so neither will we
         "insertContainerBreak:" => {} // textedit and pages don't seem to support, so neither will we
         "quickLookPreviewItems:" => {} // don't seem to apply to text editing?? hopefully
-        "complete:" => {}             // intercepted by the IME; if it gets to us, noop
+        // TODO(lord): reply to cmyr comment
+        "complete:" => {} // intercepted by the IME; if it gets to us, noop
         "noop:" => {}
         e => {
             eprintln!("unknown text editing command from macos: {}", e);
+            {};
         }
     };
 }
@@ -635,7 +615,7 @@ pub extern "C" fn do_command_by_selector(this: &mut Object, _: Sel, cmd: Sel) {
 /// is absolute instead of relative.
 /// Returns `None` if `range` was invalid; macOS often uses this to indicate some special null value.
 fn decode_nsrange(
-    edit_lock: &mut Box<dyn TextInputHandler>,
+    edit_lock: &mut Box<dyn InputHandler>,
     range: &NSRange,
     start_offset: usize,
 ) -> Option<Range<usize>> {
@@ -652,7 +632,7 @@ fn decode_nsrange(
 }
 
 // Encodes the UTF-8 `Range<usize>` into a UTF-16 `NSRange`.
-fn encode_nsrange(edit_lock: &mut Box<dyn TextInputHandler>, mut range: Range<usize>) -> NSRange {
+fn encode_nsrange(edit_lock: &mut Box<dyn InputHandler>, mut range: Range<usize>) -> NSRange {
     while !edit_lock.is_char_boundary(range.start) {
         range.start -= 1;
     }

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -58,8 +58,10 @@ use crate::keyboard_types::KeyState;
 use crate::mouse::{Cursor, CursorDesc, MouseButton, MouseButtons, MouseEvent};
 use crate::region::Region;
 use crate::scale::Scale;
-use crate::text_input::{TextInputHandler, TextInputToken, TextInputUpdate};
-use crate::window::{FileDialogToken, IdleToken, TimerToken, WinHandler, WindowLevel, WindowState};
+use crate::text::{Event, InputHandler};
+use crate::window::{
+    FileDialogToken, IdleToken, TextInputToken, TimerToken, WinHandler, WindowLevel, WindowState,
+};
 use crate::Error;
 
 #[allow(non_upper_case_globals)]
@@ -476,7 +478,7 @@ lazy_static! {
 pub(super) fn get_edit_lock_from_window(
     this: &mut Object,
     mutable: bool,
-) -> Option<Box<dyn TextInputHandler>> {
+) -> Option<Box<dyn InputHandler>> {
     let view_state = unsafe {
         let view_state: *mut c_void = *this.get_ivar("viewState");
         let view_state = &mut *(view_state as *mut ViewState);
@@ -1030,22 +1032,22 @@ impl WindowHandle {
         }
     }
 
-    pub fn set_active_text_input(&self, active_field: Option<TextInputToken>) {
+    pub fn set_focused_text_input(&self, active_field: Option<TextInputToken>) {
         let mut state = unsafe {
             let view = self.nsview.load().as_ref().unwrap();
             let state: *mut c_void = *view.get_ivar("viewState");
             &mut (*(state as *mut ViewState))
         };
         if let Some(old_field) = state.active_text_input {
-            self.update_text_input(old_field, TextInputUpdate::Reset);
+            self.update_text_input(old_field, Event::Reset);
         }
         state.active_text_input = active_field;
         if let Some(new_field) = active_field {
-            self.update_text_input(new_field, TextInputUpdate::Reset);
+            self.update_text_input(new_field, Event::Reset);
         }
     }
 
-    pub fn update_text_input(&self, token: TextInputToken, update: TextInputUpdate) {
+    pub fn update_text_input(&self, token: TextInputToken, update: Event) {
         let state = unsafe {
             let view = self.nsview.load().as_ref().unwrap();
             let state: *mut c_void = *view.get_ivar("viewState");
@@ -1055,11 +1057,11 @@ impl WindowHandle {
             return;
         }
         match update {
-            TextInputUpdate::LayoutChanged => unsafe {
+            Event::LayoutChanged => unsafe {
                 let input_context: id = msg_send![*self.nsview.load(), inputContext];
                 let _: () = msg_send![input_context, invalidateCharacterCoordinates];
             },
-            TextInputUpdate::Reset | TextInputUpdate::SelectionChanged => unsafe {
+            Event::Reset | Event::SelectionChanged => unsafe {
                 let input_context: id = msg_send![*self.nsview.load(), inputContext];
                 let _: () = msg_send![input_context, discardMarkedText];
                 let mut edit_lock = state.handler.text_input(token, true);

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -60,7 +60,7 @@ use crate::region::Region;
 use crate::scale::Scale;
 use crate::text::{Event, InputHandler};
 use crate::window::{
-    FileDialogToken, IdleToken, TextInputToken, TimerToken, WinHandler, WindowLevel, WindowState,
+    FileDialogToken, IdleToken, TextFieldToken, TimerToken, WinHandler, WindowLevel, WindowState,
 };
 use crate::Error;
 
@@ -148,7 +148,7 @@ struct ViewState {
     mouse_left: bool,
     keyboard_state: KeyboardState,
     text: PietText,
-    active_text_input: Option<TextInputToken>,
+    active_text_input: Option<TextFieldToken>,
 }
 
 #[derive(Clone)]
@@ -1017,11 +1017,11 @@ impl WindowHandle {
         }
     }
 
-    pub fn add_text_input(&self) -> TextInputToken {
-        TextInputToken::next()
+    pub fn add_text_field(&self) -> TextFieldToken {
+        TextFieldToken::next()
     }
 
-    pub fn remove_text_input(&self, token: TextInputToken) {
+    pub fn remove_text_field(&self, token: TextFieldToken) {
         let mut state = unsafe {
             let view = self.nsview.load().as_ref().unwrap();
             let state: *mut c_void = *view.get_ivar("viewState");
@@ -1032,22 +1032,22 @@ impl WindowHandle {
         }
     }
 
-    pub fn set_focused_text_input(&self, active_field: Option<TextInputToken>) {
+    pub fn set_focused_text_field(&self, active_field: Option<TextFieldToken>) {
         let mut state = unsafe {
             let view = self.nsview.load().as_ref().unwrap();
             let state: *mut c_void = *view.get_ivar("viewState");
             &mut (*(state as *mut ViewState))
         };
         if let Some(old_field) = state.active_text_input {
-            self.update_text_input(old_field, Event::Reset);
+            self.update_text_field(old_field, Event::Reset);
         }
         state.active_text_input = active_field;
         if let Some(new_field) = active_field {
-            self.update_text_input(new_field, Event::Reset);
+            self.update_text_field(new_field, Event::Reset);
         }
     }
 
-    pub fn update_text_input(&self, token: TextInputToken, update: Event) {
+    pub fn update_text_field(&self, token: TextFieldToken, update: Event) {
         let state = unsafe {
             let view = self.nsview.load().as_ref().unwrap();
             let state: *mut c_void = *view.get_ivar("viewState");

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -29,7 +29,7 @@ use cocoa::appkit::{
 };
 use cocoa::base::{id, nil, BOOL, NO, YES};
 use cocoa::foundation::{
-    NSAutoreleasePool, NSInteger, NSPoint, NSRect, NSSize, NSString, NSUInteger,
+    NSArray, NSAutoreleasePool, NSInteger, NSPoint, NSRect, NSSize, NSString, NSUInteger,
 };
 use core_graphics::context::CGContextRef;
 use foreign_types::ForeignTypeRef;
@@ -37,7 +37,7 @@ use lazy_static::lazy_static;
 use log::{error, info};
 use objc::declare::ClassDecl;
 use objc::rc::WeakPtr;
-use objc::runtime::{Class, Object, Sel};
+use objc::runtime::{Class, Object, Protocol, Sel};
 use objc::{class, msg_send, sel, sel_impl};
 
 use crate::kurbo::{Point, Rect, Size, Vec2};
@@ -50,6 +50,7 @@ use super::application::Application;
 use super::dialog;
 use super::keyboard::{make_modifiers, KeyboardState};
 use super::menu::Menu;
+use super::text_input::NSRange;
 use super::util::{assert_main_thread, make_nsstring};
 use crate::common_util::IdleCallback;
 use crate::dialog::{FileDialogOptions, FileDialogType, FileInfo};
@@ -57,6 +58,7 @@ use crate::keyboard_types::KeyState;
 use crate::mouse::{Cursor, CursorDesc, MouseButton, MouseButtons, MouseEvent};
 use crate::region::Region;
 use crate::scale::Scale;
+use crate::text_input::{TextInputHandler, TextInputToken, TextInputUpdate};
 use crate::window::{FileDialogToken, IdleToken, TimerToken, WinHandler, WindowLevel, WindowState};
 use crate::Error;
 
@@ -144,6 +146,7 @@ struct ViewState {
     mouse_left: bool,
     keyboard_state: KeyboardState,
     text: PietText,
+    active_text_input: Option<TextInputToken>,
 }
 
 #[derive(Clone)]
@@ -423,8 +426,67 @@ lazy_static! {
             sel!(windowWillClose:),
             window_will_close as extern "C" fn(&mut Object, Sel, id),
         );
+
+        // methods for NSTextInputClient
+        decl.add_method(sel!(hasMarkedText), super::text_input::has_marked_text as extern fn(&mut Object, Sel) -> BOOL);
+        decl.add_method(
+            sel!(markedRange),
+            super::text_input::marked_range as extern fn(&mut Object, Sel) -> NSRange,
+        );
+        decl.add_method(sel!(selectedRange), super::text_input::selected_range as extern fn(&mut Object, Sel) -> NSRange);
+        decl.add_method(
+            sel!(setMarkedText:selectedRange:replacementRange:),
+            super::text_input::set_marked_text as extern fn(&mut Object, Sel, id, NSRange, NSRange),
+        );
+        decl.add_method(sel!(unmarkText), super::text_input::unmark_text as extern fn(&mut Object, Sel));
+        decl.add_method(
+            sel!(validAttributesForMarkedText),
+            super::text_input::valid_attributes_for_marked_text as extern fn(&mut Object, Sel) -> id,
+        );
+        decl.add_method(
+            sel!(attributedSubstringForProposedRange:actualRange:),
+            super::text_input::attributed_substring_for_proposed_range
+                as extern fn(&mut Object, Sel, NSRange, *mut c_void) -> id,
+        );
+        decl.add_method(
+            sel!(insertText:replacementRange:),
+            super::text_input::insert_text as extern fn(&mut Object, Sel, id, NSRange),
+        );
+        decl.add_method(
+            sel!(characterIndexForPoint:),
+            super::text_input::character_index_for_point as extern fn(&mut Object, Sel, NSPoint) -> NSUInteger,
+        );
+        decl.add_method(
+            sel!(firstRectForCharacterRange:actualRange:),
+            super::text_input::first_rect_for_character_range
+                as extern fn(&mut Object, Sel, NSRange, *mut c_void) -> NSRect,
+        );
+        decl.add_method(
+            sel!(doCommandBySelector:),
+            super::text_input::do_command_by_selector as extern fn(&mut Object, Sel, Sel),
+        );
+
+        let protocol = Protocol::get("NSTextInputClient").unwrap();
+        decl.add_protocol(&protocol);
+
         ViewClass(decl.register())
     };
+}
+
+pub(super) fn get_edit_lock_from_window(
+    this: &mut Object,
+    mutable: bool,
+) -> Option<Box<dyn TextInputHandler>> {
+    let view_state = unsafe {
+        let view_state: *mut c_void = *this.get_ivar("viewState");
+        let view_state = &mut *(view_state as *mut ViewState);
+        &mut (*view_state)
+    };
+    Some(
+        view_state
+            .handler
+            .text_input(view_state.active_text_input?, mutable),
+    )
 }
 
 fn make_view(handler: Box<dyn WinHandler>) -> (id, Weak<Mutex<Vec<IdleKind>>>) {
@@ -442,6 +504,7 @@ fn make_view(handler: Box<dyn WinHandler>) -> (id, Weak<Mutex<Vec<IdleKind>>>) {
             mouse_left: true,
             keyboard_state,
             text: PietText::new_with_unique_state(),
+            active_text_input: None,
         };
         let state_ptr = Box::into_raw(Box::new(state));
         (*view).set_ivar("viewState", state_ptr as *mut c_void);
@@ -687,7 +750,13 @@ extern "C" fn key_down(this: &mut Object, _: Sel, nsevent: id) {
         &mut *(view_state as *mut ViewState)
     };
     if let Some(event) = (*view_state).keyboard_state.process_native_event(nsevent) {
-        (*view_state).handler.key_down(event);
+        if !(*view_state).handler.key_down(event) {
+            // key down not handled; foward to text input system
+            unsafe {
+                let events = NSArray::arrayWithObjects(nil, &[nsevent]);
+                let _: () = msg_send![*(*view_state).nsview.load(), interpretKeyEvents: events];
+            }
+        }
     }
 }
 
@@ -943,6 +1012,59 @@ impl WindowHandle {
                 // this codepath should only happen during tests in druid, when view is nil
                 PietText::new_with_unique_state()
             }
+        }
+    }
+
+    pub fn add_text_input(&self) -> TextInputToken {
+        TextInputToken::next()
+    }
+
+    pub fn remove_text_input(&self, token: TextInputToken) {
+        let mut state = unsafe {
+            let view = self.nsview.load().as_ref().unwrap();
+            let state: *mut c_void = *view.get_ivar("viewState");
+            &mut (*(state as *mut ViewState))
+        };
+        if state.active_text_input == Some(token) {
+            state.active_text_input = None;
+        }
+    }
+
+    pub fn set_active_text_input(&self, active_field: Option<TextInputToken>) {
+        let mut state = unsafe {
+            let view = self.nsview.load().as_ref().unwrap();
+            let state: *mut c_void = *view.get_ivar("viewState");
+            &mut (*(state as *mut ViewState))
+        };
+        if let Some(old_field) = state.active_text_input {
+            self.update_text_input(old_field, TextInputUpdate::Reset);
+        }
+        state.active_text_input = active_field;
+        if let Some(new_field) = active_field {
+            self.update_text_input(new_field, TextInputUpdate::Reset);
+        }
+    }
+
+    pub fn update_text_input(&self, token: TextInputToken, update: TextInputUpdate) {
+        let state = unsafe {
+            let view = self.nsview.load().as_ref().unwrap();
+            let state: *mut c_void = *view.get_ivar("viewState");
+            &mut (*(state as *mut ViewState))
+        };
+        if state.active_text_input != Some(token) {
+            return;
+        }
+        match update {
+            TextInputUpdate::LayoutChanged => unsafe {
+                let input_context: id = msg_send![*self.nsview.load(), inputContext];
+                let _: () = msg_send![input_context, invalidateCharacterCoordinates];
+            },
+            TextInputUpdate::Reset | TextInputUpdate::SelectionChanged => unsafe {
+                let input_context: id = msg_send![*self.nsview.load(), inputContext];
+                let _: () = msg_send![input_context, discardMarkedText];
+                let mut edit_lock = state.handler.text_input(token, true);
+                edit_lock.set_composition_range(None);
+            },
         }
     }
 

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -44,7 +44,7 @@ use crate::region::Region;
 use crate::text::{simulate_input, Event};
 use crate::window;
 use crate::window::{
-    FileDialogToken, IdleToken, TextInputToken, TimerToken, WinHandler, WindowLevel,
+    FileDialogToken, IdleToken, TextFieldToken, TimerToken, WinHandler, WindowLevel,
 };
 
 // This is a macro instead of a function since KeyboardEvent and MouseEvent has identical functions
@@ -100,7 +100,7 @@ struct WindowState {
     canvas: web_sys::HtmlCanvasElement,
     context: web_sys::CanvasRenderingContext2d,
     invalid: RefCell<Region>,
-    active_text_input: Cell<Option<TextInputToken>>,
+    active_text_input: Cell<Option<TextFieldToken>>,
 }
 
 // TODO: support custom cursors
@@ -530,11 +530,11 @@ impl WindowHandle {
         PietText::new(s.context.clone())
     }
 
-    pub fn add_text_input(&self) -> TextInputToken {
-        TextInputToken::next()
+    pub fn add_text_field(&self) -> TextFieldToken {
+        TextFieldToken::next()
     }
 
-    pub fn remove_text_input(&self, token: TextInputToken) {
+    pub fn remove_text_field(&self, token: TextFieldToken) {
         if let Some(state) = self.0.upgrade() {
             if state.active_text_input.get() == Some(token) {
                 state.active_text_input.set(None);
@@ -542,13 +542,13 @@ impl WindowHandle {
         }
     }
 
-    pub fn set_focused_text_input(&self, active_field: Option<TextInputToken>) {
+    pub fn set_focused_text_field(&self, active_field: Option<TextFieldToken>) {
         if let Some(state) = self.0.upgrade() {
             state.active_text_input.set(active_field);
         }
     }
 
-    pub fn update_text_input(&self, _token: TextInputToken, _update: Event) {
+    pub fn update_text_field(&self, _token: TextFieldToken, _update: Event) {
         // no-op for now, until we get a properly implemented text input
     }
 

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -41,6 +41,7 @@ use crate::scale::{Scale, ScaledArea};
 use crate::keyboard::{KbKey, KeyState, Modifiers};
 use crate::mouse::{Cursor, CursorDesc, MouseButton, MouseButtons, MouseEvent};
 use crate::region::Region;
+use crate::text_input::{simulate_text_input, TextInputToken, TextInputUpdate};
 use crate::window;
 use crate::window::{FileDialogToken, IdleToken, TimerToken, WinHandler, WindowLevel};
 
@@ -97,6 +98,7 @@ struct WindowState {
     canvas: web_sys::HtmlCanvasElement,
     context: web_sys::CanvasRenderingContext2d,
     invalid: RefCell<Region>,
+    active_text_input: Cell<Option<TextInputToken>>,
 }
 
 // TODO: support custom cursors
@@ -280,7 +282,10 @@ fn setup_keydown_callback(ws: &Rc<WindowState>) {
             // Prevent the browser from going back a page by default.
             event.prevent_default();
         }
-        state.handler.borrow_mut().key_down(kb_event);
+        let mut handler = state.handler.borrow_mut();
+        if !handler.key_down(kb_event.clone()) {
+            simulate_text_input(&mut **handler, state.active_text_input.get(), kb_event);
+        }
     });
 }
 
@@ -416,6 +421,7 @@ impl WindowBuilder {
             canvas,
             context,
             invalid: RefCell::new(Region::EMPTY),
+            active_text_input: Cell::new(None),
         });
 
         setup_web_callbacks(&window);
@@ -520,6 +526,28 @@ impl WindowHandle {
             .unwrap_or_else(|| panic!("Failed to produce a text context"));
 
         PietText::new(s.context.clone())
+    }
+
+    pub fn add_text_input(&self) -> TextInputToken {
+        TextInputToken::next()
+    }
+
+    pub fn remove_text_input(&self, token: TextInputToken) {
+        if let Some(state) = self.0.upgrade() {
+            if state.active_text_input.get() == Some(token) {
+                state.active_text_input.set(None);
+            }
+        }
+    }
+
+    pub fn set_active_text_input(&self, active_field: Option<TextInputToken>) {
+        if let Some(state) = self.0.upgrade() {
+            state.active_text_input.set(active_field);
+        }
+    }
+
+    pub fn update_text_input(&self, _token: TextInputToken, _update: TextInputUpdate) {
+        // no-op for now, until we get a properly implemented text input
     }
 
     pub fn request_timer(&self, deadline: Instant) -> TimerToken {

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -41,9 +41,11 @@ use crate::scale::{Scale, ScaledArea};
 use crate::keyboard::{KbKey, KeyState, Modifiers};
 use crate::mouse::{Cursor, CursorDesc, MouseButton, MouseButtons, MouseEvent};
 use crate::region::Region;
-use crate::text_input::{simulate_text_input, TextInputToken, TextInputUpdate};
+use crate::text::{simulate_input, Event};
 use crate::window;
-use crate::window::{FileDialogToken, IdleToken, TimerToken, WinHandler, WindowLevel};
+use crate::window::{
+    FileDialogToken, IdleToken, TextInputToken, TimerToken, WinHandler, WindowLevel,
+};
 
 // This is a macro instead of a function since KeyboardEvent and MouseEvent has identical functions
 // to query modifier key states.
@@ -284,7 +286,7 @@ fn setup_keydown_callback(ws: &Rc<WindowState>) {
         }
         let mut handler = state.handler.borrow_mut();
         if !handler.key_down(kb_event.clone()) {
-            simulate_text_input(&mut **handler, state.active_text_input.get(), kb_event);
+            simulate_input(&mut **handler, state.active_text_input.get(), kb_event);
         }
     });
 }
@@ -540,13 +542,13 @@ impl WindowHandle {
         }
     }
 
-    pub fn set_active_text_input(&self, active_field: Option<TextInputToken>) {
+    pub fn set_focused_text_input(&self, active_field: Option<TextInputToken>) {
         if let Some(state) = self.0.upgrade() {
             state.active_text_input.set(active_field);
         }
     }
 
-    pub fn update_text_input(&self, _token: TextInputToken, _update: TextInputUpdate) {
+    pub fn update_text_input(&self, _token: TextInputToken, _update: Event) {
         // no-op for now, until we get a properly implemented text input
     }
 

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -69,7 +69,7 @@ use crate::scale::{Scalable, Scale, ScaledArea};
 use crate::text::{simulate_input, Event};
 use crate::window;
 use crate::window::{
-    FileDialogToken, IdleToken, TextInputToken, TimerToken, WinHandler, WindowLevel,
+    FileDialogToken, IdleToken, TextFieldToken, TimerToken, WinHandler, WindowLevel,
 };
 
 /// The platform target DPI.
@@ -191,7 +191,7 @@ struct WindowState {
     // For resizable borders, window can still be resized with code.
     is_resizable: Cell<bool>,
     handle_titlebar: Cell<bool>,
-    active_text_input: Cell<Option<TextInputToken>>,
+    active_text_input: Cell<Option<TextFieldToken>>,
 }
 
 /// Generic handler trait for the winapi window procedure entry point.
@@ -1736,11 +1736,11 @@ impl WindowHandle {
         PietText::new(self.dwrite_factory.clone())
     }
 
-    pub fn add_text_input(&self) -> TextInputToken {
-        TextInputToken::next()
+    pub fn add_text_field(&self) -> TextFieldToken {
+        TextFieldToken::next()
     }
 
-    pub fn remove_text_input(&self, token: TextInputToken) {
+    pub fn remove_text_field(&self, token: TextFieldToken) {
         if let Some(state) = self.state.upgrade() {
             if state.active_text_input.get() == Some(token) {
                 state.active_text_input.set(None);
@@ -1748,13 +1748,13 @@ impl WindowHandle {
         }
     }
 
-    pub fn set_focused_text_input(&self, active_field: Option<TextInputToken>) {
+    pub fn set_focused_text_field(&self, active_field: Option<TextFieldToken>) {
         if let Some(state) = self.state.upgrade() {
             state.active_text_input.set(active_field);
         }
     }
 
-    pub fn update_text_input(&self, _token: TextInputToken, _update: Event) {
+    pub fn update_text_field(&self, _token: TextFieldToken, _update: Event) {
         // noop until we get a real text input implementation
     }
 

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -66,6 +66,7 @@ use crate::keyboard::{KbKey, KeyState};
 use crate::mouse::{Cursor, CursorDesc, MouseButton, MouseButtons, MouseEvent};
 use crate::region::Region;
 use crate::scale::{Scalable, Scale, ScaledArea};
+use crate::text_input::{simulate_text_input, TextInputToken, TextInputUpdate};
 use crate::window;
 use crate::window::{FileDialogToken, IdleToken, TimerToken, WinHandler, WindowLevel};
 
@@ -188,6 +189,7 @@ struct WindowState {
     // For resizable borders, window can still be resized with code.
     is_resizable: Cell<bool>,
     handle_titlebar: Cell<bool>,
+    active_text_input: Cell<Option<TextInputToken>>,
 }
 
 /// Generic handler trait for the winapi window procedure entry point.
@@ -869,7 +871,15 @@ impl WndProc for MyWndProc {
                                 && (event.key == KbKey::Alt || event.key == KbKey::F10);
                             match event.state {
                                 KeyState::Down => {
-                                    if s.handler.key_down(event) || handle_menu {
+                                    let keydown_handled = s.handler.key_down(event.clone())
+                                        || self.with_window_state(|window_state| {
+                                            simulate_text_input(
+                                                &mut *s.handler,
+                                                window_state.active_text_input.get(),
+                                                event,
+                                            )
+                                        });
+                                    if keydown_handled || handle_menu {
                                         return true;
                                     }
                                 }
@@ -1237,6 +1247,7 @@ impl WindowBuilder {
                 has_titlebar: Cell::new(self.show_titlebar),
                 is_resizable: Cell::new(self.resizable),
                 handle_titlebar: Cell::new(false),
+                active_text_input: Cell::new(None),
             };
             let win = Rc::new(window);
             let handle = WindowHandle {
@@ -1721,6 +1732,28 @@ impl WindowHandle {
 
     pub fn text(&self) -> PietText {
         PietText::new(self.dwrite_factory.clone())
+    }
+
+    pub fn add_text_input(&self) -> TextInputToken {
+        TextInputToken::next()
+    }
+
+    pub fn remove_text_input(&self, token: TextInputToken) {
+        if let Some(state) = self.state.upgrade() {
+            if state.active_text_input.get() == Some(token) {
+                state.active_text_input.set(None);
+            }
+        }
+    }
+
+    pub fn set_active_text_input(&self, active_field: Option<TextInputToken>) {
+        if let Some(state) = self.state.upgrade() {
+            state.active_text_input.set(active_field);
+        }
+    }
+
+    pub fn update_text_input(&self, _token: TextInputToken, _update: TextInputUpdate) {
+        // noop until we get a real text input implementation
     }
 
     /// Request a timer event.

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -66,9 +66,11 @@ use crate::keyboard::{KbKey, KeyState};
 use crate::mouse::{Cursor, CursorDesc, MouseButton, MouseButtons, MouseEvent};
 use crate::region::Region;
 use crate::scale::{Scalable, Scale, ScaledArea};
-use crate::text_input::{simulate_text_input, TextInputToken, TextInputUpdate};
+use crate::text::{simulate_input, Event};
 use crate::window;
-use crate::window::{FileDialogToken, IdleToken, TimerToken, WinHandler, WindowLevel};
+use crate::window::{
+    FileDialogToken, IdleToken, TextInputToken, TimerToken, WinHandler, WindowLevel,
+};
 
 /// The platform target DPI.
 ///
@@ -873,7 +875,7 @@ impl WndProc for MyWndProc {
                                 KeyState::Down => {
                                     let keydown_handled = s.handler.key_down(event.clone())
                                         || self.with_window_state(|window_state| {
-                                            simulate_text_input(
+                                            simulate_input(
                                                 &mut *s.handler,
                                                 window_state.active_text_input.get(),
                                                 event,
@@ -1746,13 +1748,13 @@ impl WindowHandle {
         }
     }
 
-    pub fn set_active_text_input(&self, active_field: Option<TextInputToken>) {
+    pub fn set_focused_text_input(&self, active_field: Option<TextInputToken>) {
         if let Some(state) = self.state.upgrade() {
             state.active_text_input.set(active_field);
         }
     }
 
-    pub fn update_text_input(&self, _token: TextInputToken, _update: TextInputUpdate) {
+    pub fn update_text_input(&self, _token: TextInputToken, _update: Event) {
         // noop until we get a real text input implementation
     }
 

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -49,7 +49,7 @@ use crate::scale::Scale;
 use crate::text::{simulate_input, Event};
 use crate::window;
 use crate::window::{
-    FileDialogToken, IdleToken, TextInputToken, TimerToken, WinHandler, WindowLevel,
+    FileDialogToken, IdleToken, TextFieldToken, TimerToken, WinHandler, WindowLevel,
 };
 
 use super::application::Application;
@@ -322,7 +322,7 @@ impl WindowBuilder {
             idle_pipe: self.app.idle_pipe(),
             present_data: RefCell::new(present_data),
             buffers,
-            active_text_input: Cell::new(None),
+            active_text_field: Cell::new(None),
         });
         window.set_title(&self.title);
 
@@ -426,7 +426,7 @@ pub(crate) struct Window {
     /// actually been presented.
     present_data: RefCell<Option<PresentData>>,
     buffers: RefCell<Buffers>,
-    active_text_input: Cell<Option<TextInputToken>>,
+    active_text_field: Cell<Option<TextFieldToken>>,
 }
 
 // This creates a `struct WindowAtoms` containing the specified atoms as members (along with some
@@ -879,7 +879,7 @@ impl Window {
         };
         self.with_handler(|h| {
             if !h.key_down(key_event.clone()) {
-                simulate_input(h, self.active_text_input.get(), key_event);
+                simulate_input(h, self.active_text_field.get(), key_event);
             }
         });
     }
@@ -1487,25 +1487,25 @@ impl WindowHandle {
         PietText::new()
     }
 
-    pub fn add_text_input(&self) -> TextInputToken {
-        TextInputToken::next()
+    pub fn add_text_field(&self) -> TextFieldToken {
+        TextFieldToken::next()
     }
 
-    pub fn remove_text_input(&self, token: TextInputToken) {
+    pub fn remove_text_field(&self, token: TextFieldToken) {
         if let Some(window) = self.window.upgrade() {
-            if window.active_text_input.get() == Some(token) {
-                window.active_text_input.set(None)
+            if window.active_text_field.get() == Some(token) {
+                window.active_text_field.set(None)
             }
         }
     }
 
-    pub fn set_focused_text_input(&self, active_field: Option<TextInputToken>) {
+    pub fn set_focused_text_field(&self, active_field: Option<TextFieldToken>) {
         if let Some(window) = self.window.upgrade() {
-            window.active_text_input.set(active_field);
+            window.active_text_field.set(active_field);
         }
     }
 
-    pub fn update_text_input(&self, _token: TextInputToken, _update: Event) {
+    pub fn update_text_field(&self, _token: TextFieldToken, _update: Event) {
         // noop until we get a real text input implementation
     }
 

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -15,7 +15,7 @@
 //! X11 window creation and window management.
 
 use std::any::Any;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::BinaryHeap;
 use std::convert::{TryFrom, TryInto};
 use std::os::unix::io::RawFd;
@@ -46,6 +46,7 @@ use crate::mouse::{Cursor, CursorDesc, MouseButton, MouseButtons, MouseEvent};
 use crate::piet::{Piet, PietText, RenderContext};
 use crate::region::Region;
 use crate::scale::Scale;
+use crate::text_input::{simulate_text_input, TextInputToken, TextInputUpdate};
 use crate::window;
 use crate::window::{FileDialogToken, IdleToken, TimerToken, WinHandler, WindowLevel};
 
@@ -319,6 +320,7 @@ impl WindowBuilder {
             idle_pipe: self.app.idle_pipe(),
             present_data: RefCell::new(present_data),
             buffers,
+            active_text_input: Cell::new(None),
         });
         window.set_title(&self.title);
 
@@ -422,6 +424,7 @@ pub(crate) struct Window {
     /// actually been presented.
     present_data: RefCell<Option<PresentData>>,
     buffers: RefCell<Buffers>,
+    active_text_input: Cell<Option<TextInputToken>>,
 }
 
 // This creates a `struct WindowAtoms` containing the specified atoms as members (along with some
@@ -872,7 +875,11 @@ impl Window {
             repeat: false,
             is_composing: false,
         };
-        self.with_handler(|h| h.key_down(key_event));
+        self.with_handler(|h| {
+            if !h.key_down(key_event.clone()) {
+                simulate_text_input(h, self.active_text_input.get(), key_event);
+            }
+        });
     }
 
     pub fn handle_button_press(&self, button_press: &xproto::ButtonPressEvent) {
@@ -1476,6 +1483,28 @@ impl WindowHandle {
 
     pub fn text(&self) -> PietText {
         PietText::new()
+    }
+
+    pub fn add_text_input(&self) -> TextInputToken {
+        TextInputToken::next()
+    }
+
+    pub fn remove_text_input(&self, token: TextInputToken) {
+        if let Some(window) = self.window.upgrade() {
+            if window.active_text_input.get() == Some(token) {
+                window.active_text_input.set(None)
+            }
+        }
+    }
+
+    pub fn set_active_text_input(&self, active_field: Option<TextInputToken>) {
+        if let Some(window) = self.window.upgrade() {
+            window.active_text_input.set(active_field);
+        }
+    }
+
+    pub fn update_text_input(&self, _token: TextInputToken, _update: TextInputUpdate) {
+        // noop until we get a real text input implementation
     }
 
     pub fn request_timer(&self, deadline: Instant) -> TimerToken {

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -46,9 +46,11 @@ use crate::mouse::{Cursor, CursorDesc, MouseButton, MouseButtons, MouseEvent};
 use crate::piet::{Piet, PietText, RenderContext};
 use crate::region::Region;
 use crate::scale::Scale;
-use crate::text_input::{simulate_text_input, TextInputToken, TextInputUpdate};
+use crate::text::{simulate_input, Event};
 use crate::window;
-use crate::window::{FileDialogToken, IdleToken, TimerToken, WinHandler, WindowLevel};
+use crate::window::{
+    FileDialogToken, IdleToken, TextInputToken, TimerToken, WinHandler, WindowLevel,
+};
 
 use super::application::Application;
 use super::keycodes;
@@ -877,7 +879,7 @@ impl Window {
         };
         self.with_handler(|h| {
             if !h.key_down(key_event.clone()) {
-                simulate_text_input(h, self.active_text_input.get(), key_event);
+                simulate_input(h, self.active_text_input.get(), key_event);
             }
         });
     }
@@ -1497,13 +1499,13 @@ impl WindowHandle {
         }
     }
 
-    pub fn set_active_text_input(&self, active_field: Option<TextInputToken>) {
+    pub fn set_focused_text_input(&self, active_field: Option<TextInputToken>) {
         if let Some(window) = self.window.upgrade() {
             window.active_text_input.set(active_field);
         }
     }
 
-    pub fn update_text_input(&self, _token: TextInputToken, _update: TextInputUpdate) {
+    pub fn update_text_input(&self, _token: TextInputToken, _update: Event) {
         // noop until we get a real text input implementation
     }
 

--- a/druid-shell/src/text.rs
+++ b/druid-shell/src/text.rs
@@ -12,98 +12,147 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::common_util::Counter;
+//! Types and functions for cross-platform text input.
+//!
+//! Text input is a notoriously difficult problem.
+//! Unlike many other aspects of user interfaces, text input can not be correctly modeled
+//! using discrete events passed from the platform to the application. For example, many mobile phones
+//! implement autocorrect: when the user presses the spacebar, the platform peeks at the word directly
+//! behind the caret, and potentially replaces it if it's mispelled. This means the platform needs to
+//! know the contents of a text field. On other devices, the platform may need to draw an emoji window
+//! under the caret, or look up the on-screen locations of letters for crossing out with a stylus, both
+//! of which require fetching on-screen coordinates from the application.
+//!
+//! This is all to say: text editing is a bidirectional conversation between the application and the
+//! platform. The application, when the platform asks for it, serves up text field coordinates and content.
+//! The platform looks at this information and combines it with input from keyboards (physical or onscreen),
+//! voice, styluses, the user's language settings, and then sends edit commands to the application.
+//!
+//! Many platforms have an additional complication: this input fusion often happens in a different process
+//! from your application. If we don't specifically account for this fact, we might get race conditions!
+//! In the autocorrect example, if I sloppily type "meoow" and press space, the platform might issue edits
+//! to "delete backwords one word and insert meow". However, if I concurrently click somewhere else in the
+//! document to move the caret, this will replace some *other* word with "meow", and leave the "meoow"
+//! disappointingly present. To mitigate this problem, we use locks, represented by the `InputHandler` trait.
+//!
+//! ## Lifecycle of a Text Input
+//!
+//! 1. The user clicks a link or switches tabs, and the window content now contains a new text field.
+//!    The application registers this new field by calling `WindowHandle::add_text_input`, and gets a
+//!    `TextFieldToken` that represents this new field.
+//! 2. The user clicks on that text field, focusing it. The application lets the platform know by calling
+//!    `WindowHandle::set_focused_text_input` with that field's `TextFieldToken`.
+//! 3. The user presses a key on the keyboard. The platform first calls `WinHandler::key_down`. If this
+//!    method returns `true`, the application has indicated the keypress was captured, and we skip the
+//!    remaining steps.
+//! 4. If `key_down` returned `false`, druid-shell forwards the key event to the platform's text input
+//!    system.
+//! 5. The platform, in response to either this key event or some other user action, determines it's time
+//!    for some text input. It calls `WinHandler::text_input` to acquire a lock on the text field's state.
+//!    The application returns an `InputHandler` object corresponding to the requested text field. To prevent
+//!    race conditions, your application may not make any changes to the text field's state until the platform
+//!    drops the `InputHandler`.
+//! 6. The platform calls various `InputHandler` methods to inspect and edit the text field's state. Later,
+//!    usually within a few milliseconds, the platform drops the `InputHandler`, allowing the application to
+//!    once again make changes to the text field's state. These commands might be "insert `q`" for a smartphone
+//!    user tapping on their virtual keyboard, or "move the caret one word left" for a user pressing the left
+//!    arrow key while holding control.
+//! 7. Eventually, after many keypresses cause steps 3–6 to repeat, the user unfocuses the text field. The
+//!    application indicates this to the platform by calling `set_focused_text_input`. Note that
+//!    even though focus has shifted away from our text field, the platform may still send edits to it by calling
+//!    `WinHandler::text_input`.
+//! 8. At some point, the user clicks a link or switches a tab, and the text field is no longer present in the window.
+//!    The application calls `WindowHandle::remove_text_input`, and the platform may no longer call `WinHandler::text_input`
+//!    to make changes to it.
+//!
+//! The application also has a series of steps it follows if it wants to make its own changes to the text field's state:
+//!
+//! 1. The application determines it would like to make a change to the text field; perhaps the user has scrolled and
+//!    and the text field has changed its visible location on screen, or perhaps the user has clicked to move the caret
+//!    to a new location.
+//! 2. The application first checks to see if there's an outstanding `InputHandler` lock for this text field; if so, it waits
+//!    until the last `InputHandler` is dropped before continuing.
+//! 3. The application then makes the change to the text input. If the change would affect state visible from an `InputHandler`,
+//!    the application must notify the platform via `WinHandler::update_text_input`.
+//!
+//! ## Supported Platforms
+//!
+//! Currently, `druid-shell` text input is fully implemented on macOS. Our goal is to have full support for all druid-shell
+//! targets, but for now, `InputHandler` calls are simulated from keypresses on other platforms, which doesn't allow for IME
+//! input, dead keys, etc.
+
 use crate::keyboard::{KbKey, KeyEvent};
 use crate::kurbo::{Point, Rect};
 use crate::piet::HitTestPoint;
-use crate::window::WinHandler;
+use crate::window::{TextInputToken, WinHandler};
 use std::borrow::Cow;
 use std::ops::Range;
 
-/// Uniquely identifies a text input field inside a window.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
-pub struct TextInputToken(u64);
-
-impl TextInputToken {
-    /// A token that does not correspond to any text input.
-    pub const INVALID: TextInputToken = TextInputToken(0);
-
-    /// Create a new token; this should for the most part be called only by platform code.
-    pub fn next() -> TextInputToken {
-        static TEXT_FIELD_COUNTER: Counter = Counter::new();
-        TextInputToken(TEXT_FIELD_COUNTER.next())
-    }
-
-    /// Create a new token from a raw value.
-    pub const fn from_raw(id: u64) -> TextInputToken {
-        TextInputToken(id)
-    }
-
-    /// Get the raw value for a token.
-    pub const fn into_raw(self) -> u64 {
-        self.0
-    }
-}
-
-/// An event that indicates to the platform that some aspect of a text field may have changed.
+/// An event sent from the application to the platform, indicating that some state previously retrieved from an `InputHandler`
+/// has changed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
-pub enum TextInputUpdate {
-    /// Indicates the value returned by `TextInputHandler::selection` may have changed.
+pub enum Event {
+    /// Indicates the value returned by `InputHandler::selection` may have changed.
     SelectionChanged,
 
     /// Indicates the values returned by one or more of these methods may have changed:
-    /// - `TextInputHandler::hit_test_point`
-    /// - `TextInputHandler::line_range`
-    /// - `TextInputHandler::bounding_box`
-    /// - `TextInputHandler::slice_bounding_box`
+    /// - `InputHandler::hit_test_point`
+    /// - `InputHandler::line_range`
+    /// - `InputHandler::bounding_box`
+    /// - `InputHandler::slice_bounding_box`
     LayoutChanged,
 
-    /// Indicates any value returned from any of the TextInputHandler methods may have changed.
+    /// Indicates any value returned from any of the InputHandler methods may have changed.
     Reset,
 }
 
-/// Corresponds to a selection of some text. This also can represent a text input caret — the blinking vertical
-/// bar where text is to be inserted. A caret is a selection with zero length, where `anchor == extent`.
+/// A range of selected text, or a caret.
+///
+/// A caret is the blinking vertical bar where text is to be inserted. We represent it as a selection with zero length,
+/// where `anchor == extent`.
 /// Indices are always expressed in UTF-8 bytes, and must be between 0 and the document length, inclusive.
 ///
 /// As an example, if the input caret is at the start of the document `hello world`, we would expect both `anchor`
 /// and `extent` to be `0`. If the user holds shift and presses the right arrow key five times, we would expect the
 /// word `hello` to be selected, the `anchor` to still be `0`, and the `extent` to now be `5`.
 #[derive(Clone, Default, PartialEq, Eq, Hash)]
-pub struct TextSelection {
+pub struct Selection {
     /// This is the end of the selection that stays unchanged while holding shift and pressing the arrow keys.
     pub anchor: usize,
     /// This is the end of the selection that moves while holding shift and pressing the arrow keys.
+    // TODO(lord): active instead of extent?
     pub extent: usize,
 }
 
 #[allow(clippy::len_without_is_empty)]
-impl TextSelection {
+impl Selection {
     /// Creates a new caret (the blinking vertical bar where text is to be inserted) at UTF-8 byte index `index`.
     /// `index` must be a grapheme cluster boundary.
-    pub fn new_caret(index: usize) -> TextSelection {
-        TextSelection {
+    pub fn new_caret(index: usize) -> Selection {
+        Selection {
             anchor: index,
             extent: index,
         }
     }
 
-    /// Corresponds to the end of the selection — either the `anchor` or `extent` — that has a lesser byte index.
+    /// Corresponds to the upstream end of the selection — the one with a lesser byte index.
+    ///
     /// Because of bidirectional text, this is not necessarily "left".
-    pub fn upstream_index(&self) -> usize {
+    pub fn min(&self) -> usize {
         usize::min(self.anchor, self.extent)
     }
 
-    /// Corresponds to the end of the selection — either the `anchor` or `extent` — that has a greater byte index.
+    /// Corresponds to the downstream end of the selection — the one with a greater byte index.
+    ///
     /// Because of bidirectional text, this is not necessarily "right".
-    pub fn downstream_index(&self) -> usize {
+    pub fn max(&self) -> usize {
         usize::max(self.anchor, self.extent)
     }
 
     /// The sorted range of the document that would be replaced if text were inserted at this selection.
     pub fn to_range(&self) -> Range<usize> {
-        self.upstream_index()..self.downstream_index()
+        self.min()..self.max()
     }
 
     /// The number of characters in the selection. If the selection is a caret, this is `0`.
@@ -121,41 +170,43 @@ impl TextSelection {
     }
 }
 
-/// A lock on a text document, such as a text box or text editor document.
+/// A lock on a text field that allows the platform to retrieve state and make edits.
+///
+/// This trait is implemented by the application or UI framework.
 /// The platform acquires this lock temporarily to apply edits corresponding to some user input.
-/// So long as the `TextInputHandler` has not been dropped,
-/// the only changes to the document state must come from calls to `TextInputHandler`.
+/// So long as the `InputHandler` has not been dropped,
+/// the only changes to the document state must come from calls to `InputHandler`.
 ///
 /// Some methods require a mutable lock, as indicated when acquiring the lock with `WinHandler::text_input`.
-/// If a mutable method is called on a immutable lock, `TextInputHandler` may panic.
+/// If a mutable method is called on a immutable lock, `InputHandler` may panic.
 ///
 /// All ranges, lengths, and indices are specified in UTF-8 code units, unless specified otherwise.
-pub trait TextInputHandler {
+pub trait InputHandler {
     /// Gets the range of the document that is currently selected.
     /// If the selection is a vertical caret bar, then `range.start == range.end`.
     /// Both `selection.anchor` and `selection.extent` must be less than or equal to the value returned
-    /// from `TextInputHandler::len()`, and must land on a extended grapheme cluster boundary in the document.
-    fn selection(&mut self) -> TextSelection;
+    /// from `InputHandler::len()`, and must land on a extended grapheme cluster boundary in the document.
+    fn selection(&mut self) -> Selection;
 
     /// Sets the range of the document that is currently selected.
     /// If the selection is a vertical caret bar, then `range.start == range.end`.
     /// Both `selection.anchor` and `selection.extent` must be less than or equal to the value returned
-    /// from `TextInputHandler::len()`.
+    /// from `InputHandler::len()`.
     ///
     /// The `set_selection` implementation should round up (downstream) both `selection.anchor` and `selection.extent`
     /// to the nearest extended grapheme cluster boundary.
     ///
     /// Requries a mutable lock.
-    fn set_selection(&mut self, selection: TextSelection);
+    fn set_selection(&mut self, selection: Selection);
 
     /// Gets the range of the document that is the input method's composition region.
     /// Both `range.start` and `range.end` must be less than or equal to the value returned
-    /// from `TextInputHandler::len()`, and must land on a extended grapheme cluster boundary in the document.
+    /// from `InputHandler::len()`, and must land on a extended grapheme cluster boundary in the document.
     fn composition_range(&mut self) -> Option<Range<usize>>;
 
     /// Sets the range of the document that is the input method's composition region.
     /// Both `range.start` and `range.end` must be less than or equal to the value returned
-    /// from `TextInputHandler::len()`.
+    /// from `InputHandler::len()`.
     ///
     /// The `set_selection` implementation should round up (downstream) both `range.start` and `range.end`
     /// to the nearest extended grapheme cluster boundary.
@@ -163,8 +214,8 @@ pub trait TextInputHandler {
     /// Requries a mutable lock.
     fn set_composition_range(&mut self, range: Option<Range<usize>>);
 
-    /// Returns true if `i==0`, `i==TextInputHandler::len()`, or `i` is the first byte of a UTF-8 code point sequence.
-    /// Returns false otherwise, including if `i>TextInputHandler::len()`.
+    /// Returns true if `i==0`, `i==InputHandler::len()`, or `i` is the first byte of a UTF-8 code point sequence.
+    /// Returns false otherwise, including if `i>InputHandler::len()`.
     /// Equivalent in functionality to `String::is_char_boundary`.
     fn is_char_boundary(&mut self, i: usize) -> bool;
 
@@ -234,22 +285,24 @@ pub trait TextInputHandler {
     fn bounding_box(&mut self) -> Option<Rect>;
 
     /// Returns the bounding box, in window coordinates, of the range of text specified by `range`.
-    /// Ranges will always be equal to or a subrange of some line range returned by `TextInputHandler::line_range`.
+    /// Ranges will always be equal to or a subrange of some line range returned by `InputHandler::line_range`.
     /// If a range spans multiple lines, `slice_bounding_box` may panic.
     fn slice_bounding_box(&mut self, range: Range<usize>) -> Option<Rect>;
 
     /// Applies some special action to the text field.
     ///
     /// Requries a mutable lock.
-    fn handle_action(&mut self, action: TextInputAction);
+    fn handle_action(&mut self, action: Action);
 }
 
 #[allow(dead_code)]
-/// Simulates `TextInputHandler` calls on `handler` for a given keypress `event`. This circumvents the platform, and so can't
+/// Simulates `InputHandler` calls on `handler` for a given keypress `event`.
+///
+/// This circumvents the platform, and so can't
 /// work with important features like input method editors! However, it's necessary while we build up our input support on
-/// various platforms, which takes a lot of time, and allows applications to start building on the new `TextInputHandler`
-/// interface immediately on all platforms, with a hopefully seamless upgrade process as we implement IME input on more platforms.
-pub fn simulate_text_input<H: WinHandler + ?Sized>(
+/// various platforms, which takes a lot of time. We want applications to start building on the new `InputHandler`
+/// interface immediately, with a hopefully seamless upgrade process as we implement IME input on more platforms.
+pub fn simulate_input<H: WinHandler + ?Sized>(
     handler: &mut H,
     token: Option<TextInputToken>,
     event: KeyEvent,
@@ -267,39 +320,39 @@ pub fn simulate_text_input<H: WinHandler + ?Sized>(
         KbKey::Character(c) if !event.mods.ctrl() && !event.mods.meta() && !event.mods.alt() => {
             let selection = input_handler.selection();
             input_handler.replace_range(selection.to_range(), &c);
-            let new_caret_index = selection.upstream_index() + c.len();
-            input_handler.set_selection(TextSelection::new_caret(new_caret_index));
+            let new_caret_index = selection.min() + c.len();
+            input_handler.set_selection(Selection::new_caret(new_caret_index));
         }
         KbKey::ArrowLeft => {
-            let movement = TextMovement::Grapheme(TextDirection::Left);
+            let movement = Movement::Grapheme(Direction::Left);
             if event.mods.shift() {
-                input_handler.handle_action(TextInputAction::MoveExtent(movement));
+                input_handler.handle_action(Action::MoveExtent(movement));
             } else {
-                input_handler.handle_action(TextInputAction::Move(movement));
+                input_handler.handle_action(Action::Move(movement));
             }
         }
         KbKey::ArrowRight => {
-            let movement = TextMovement::Grapheme(TextDirection::Right);
+            let movement = Movement::Grapheme(Direction::Right);
             if event.mods.shift() {
-                input_handler.handle_action(TextInputAction::MoveExtent(movement));
+                input_handler.handle_action(Action::MoveExtent(movement));
             } else {
-                input_handler.handle_action(TextInputAction::Move(movement));
+                input_handler.handle_action(Action::Move(movement));
             }
         }
         KbKey::ArrowUp => {
-            let movement = TextMovement::Vertical(VerticalMovement::LineUp);
+            let movement = Movement::Vertical(VerticalMovement::LineUp);
             if event.mods.shift() {
-                input_handler.handle_action(TextInputAction::MoveExtent(movement));
+                input_handler.handle_action(Action::MoveExtent(movement));
             } else {
-                input_handler.handle_action(TextInputAction::Move(movement));
+                input_handler.handle_action(Action::Move(movement));
             }
         }
         KbKey::ArrowDown => {
-            let movement = TextMovement::Vertical(VerticalMovement::LineDown);
+            let movement = Movement::Vertical(VerticalMovement::LineDown);
             if event.mods.shift() {
-                input_handler.handle_action(TextInputAction::MoveExtent(movement));
+                input_handler.handle_action(Action::MoveExtent(movement));
             } else {
-                input_handler.handle_action(TextInputAction::Move(movement));
+                input_handler.handle_action(Action::Move(movement));
             }
         }
         _ => return false,
@@ -313,22 +366,22 @@ pub fn simulate_text_input<H: WinHandler + ?Sized>(
 /// You'll note that a lot of these operations are idempotent, but you can get around this by first
 /// sending a `Grapheme` movement.
 /// If for instance, you want a `ParagraphStart` that is not idempotent, you can first send
-/// `TextMovement::Grapheme(TextDirection::Upstream)`, and then follow it with `ParagraphStart`.
+/// `Movement::Grapheme(Direction::Upstream)`, and then follow it with `ParagraphStart`.
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum TextMovement {
+pub enum Movement {
     /// A movement that stops when it reaches an extended grapheme cluster boundary.
     ///
     /// This movement is achieved on most systems by pressing the left and right arrow keys.
     /// For more information on grapheme clusters, see
     /// [Unicode Text Segmentation](https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries).
-    Grapheme(TextDirection),
+    Grapheme(Direction),
     /// A movement that stops when it reaches a word boundary.
     ///
     /// This movement is achieved on most systems by pressing the left and right arrow keys while holding control.
     /// For more information on words, see
     /// [Unicode Text Segmentation](https://unicode.org/reports/tr29/#Word_Boundaries).
-    Word(TextDirection),
+    Word(Direction),
     /// A movement that stops when it reaches a soft line break.
     ///
     /// This movement is achieved on macOS by pressing the left and right arrow keys while holding command.
@@ -336,7 +389,7 @@ pub enum TextMovement {
     /// this movement should never push it onto another soft-wrapped line.
     ///
     /// In order to implement this properly, your text positions should remember their affinity.
-    Line(TextDirection),
+    Line(Direction),
     /// An upstream movement that stops when it reaches a hard line break.
     ///
     /// `ParagraphStart` should be idempotent: if the position is already at the start of a hard-wrapped line,
@@ -353,7 +406,7 @@ pub enum TextMovement {
 
 /// Indicates a horizontal direction in the text.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum TextDirection {
+pub enum Direction {
     /// Indicates the direction visually to the left. This may be byte-wise forwards or backwards in the document,
     /// depending on the text direction around the position being moved.
     Left,
@@ -366,6 +419,8 @@ pub enum TextDirection {
     Downstream,
 }
 
+/// Distinguishes between two visually distinct locations with the same byte index.
+///
 /// Sometimes, a byte location in a document has two visual locations. For example, the end of a soft-wrapped line
 /// and the start of the subsequent line have different visual locations (and we want to be able to place an input caret
 /// in either place!) but the same byte-wise location. This also shows up in bidirectional text contexts. Affinity
@@ -396,26 +451,27 @@ pub enum VerticalMovement {
     DocumentEnd,
 }
 
+/// A special text editing command sent from the platform to the application.
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum TextInputAction {
+pub enum Action {
     /// Moves the selection.
     ///
     /// Before moving, if the extent and the anchor of the selection are not at the same
     /// position (it's a non-caret selection), then:
     ///
     /// 1. First set both extent and anchor to the same position: the selection's
-    /// upstream index if `TextMovement` is an upstream movement, or the downstream index if
-    /// `TextMovement` is a downstream movement.
+    /// upstream index if `Movement` is an upstream movement, or the downstream index if
+    /// `Movement` is a downstream movement.
     ///
-    /// 2. If `TextMovement` is `Grapheme`, then stop. Otherwise, apply the `TextMovement` as
+    /// 2. If `Movement` is `Grapheme`, then stop. Otherwise, apply the `Movement` as
     /// per the usual rules.
-    Move(TextMovement),
+    Move(Movement),
 
     /// Moves just the selection's extent.
     ///
     /// Equivalent to holding shift while performing movements or clicks on most operating systems.
-    MoveExtent(TextMovement),
+    MoveExtent(Movement),
 
     /// Select the entire document.
     SelectAll,
@@ -449,10 +505,10 @@ pub enum TextInputAction {
 
     /// Deletes some text.
     ///
-    /// If some text is already selected, `TextMovement` is ignored, and the selection is deleted.
-    /// If the selection's anchor is the same as the extent, then first apply `MoveExtent(TextMovement)`
+    /// If some text is already selected, `Movement` is ignored, and the selection is deleted.
+    /// If the selection's anchor is the same as the extent, then first apply `MoveExtent(Movement)`
     /// and then delete the resulting selection.
-    Delete(TextMovement),
+    Delete(Movement),
 
     /// A special kind of backspace that, instead of deleting the entire grapheme upstream of the caret,
     /// may in some cases and character sets delete a subset of that grapheme's code points.

--- a/druid-shell/src/text.rs
+++ b/druid-shell/src/text.rs
@@ -38,10 +38,10 @@
 //! ## Lifecycle of a Text Input
 //!
 //! 1. The user clicks a link or switches tabs, and the window content now contains a new text field.
-//!    The application registers this new field by calling `WindowHandle::add_text_input`, and gets a
+//!    The application registers this new field by calling `WindowHandle::add_text_field`, and gets a
 //!    `TextFieldToken` that represents this new field.
 //! 2. The user clicks on that text field, focusing it. The application lets the platform know by calling
-//!    `WindowHandle::set_focused_text_input` with that field's `TextFieldToken`.
+//!    `WindowHandle::set_focused_text_field` with that field's `TextFieldToken`.
 //! 3. The user presses a key on the keyboard. The platform first calls `WinHandler::key_down`. If this
 //!    method returns `true`, the application has indicated the keypress was captured, and we skip the
 //!    remaining steps.
@@ -58,11 +58,11 @@
 //!    user tapping on their virtual keyboard, or "move the caret one word left" for a user pressing the left
 //!    arrow key while holding control.
 //! 7. Eventually, after many keypresses cause steps 3–6 to repeat, the user unfocuses the text field. The
-//!    application indicates this to the platform by calling `set_focused_text_input`. Note that
+//!    application indicates this to the platform by calling `set_focused_text_field`. Note that
 //!    even though focus has shifted away from our text field, the platform may still send edits to it by calling
 //!    `WinHandler::text_input`.
 //! 8. At some point, the user clicks a link or switches a tab, and the text field is no longer present in the window.
-//!    The application calls `WindowHandle::remove_text_input`, and the platform may no longer call `WinHandler::text_input`
+//!    The application calls `WindowHandle::remove_text_field`, and the platform may no longer call `WinHandler::text_input`
 //!    to make changes to it.
 //!
 //! The application also has a series of steps it follows if it wants to make its own changes to the text field's state:
@@ -73,7 +73,7 @@
 //! 2. The application first checks to see if there's an outstanding `InputHandler` lock for this text field; if so, it waits
 //!    until the last `InputHandler` is dropped before continuing.
 //! 3. The application then makes the change to the text input. If the change would affect state visible from an `InputHandler`,
-//!    the application must notify the platform via `WinHandler::update_text_input`.
+//!    the application must notify the platform via `WinHandler::update_text_field`.
 //!
 //! ## Supported Platforms
 //!
@@ -84,7 +84,7 @@
 use crate::keyboard::{KbKey, KeyEvent};
 use crate::kurbo::{Point, Rect};
 use crate::piet::HitTestPoint;
-use crate::window::{TextInputToken, WinHandler};
+use crate::window::{TextFieldToken, WinHandler};
 use std::borrow::Cow;
 use std::ops::Range;
 
@@ -303,7 +303,7 @@ pub trait InputHandler {
 /// interface immediately, with a hopefully seamless upgrade process as we implement IME input on more platforms.
 pub fn simulate_input<H: WinHandler + ?Sized>(
     handler: &mut H,
-    token: Option<TextInputToken>,
+    token: Option<TextFieldToken>,
     event: KeyEvent,
 ) -> bool {
     if handler.key_down(event.clone()) {

--- a/druid-shell/src/text_input.rs
+++ b/druid-shell/src/text_input.rs
@@ -384,7 +384,7 @@ pub enum WritingDirection {
     Natural,
 }
 
-/// Indicates a vertial movement in a text document.
+/// Indicates a vertical movement in a text document.
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum VerticalMovement {

--- a/druid-shell/src/text_input.rs
+++ b/druid-shell/src/text_input.rs
@@ -1,0 +1,516 @@
+// Copyright 2020 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::common_util::Counter;
+use crate::keyboard::{KbKey, KeyEvent};
+use crate::kurbo::{Point, Rect};
+use crate::piet::HitTestPoint;
+use crate::window::WinHandler;
+use std::borrow::Cow;
+use std::ops::Range;
+
+/// Uniquely identifies a text input field inside a window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
+pub struct TextInputToken(u64);
+
+impl TextInputToken {
+    /// A token that does not correspond to any text input.
+    pub const INVALID: TextInputToken = TextInputToken(0);
+
+    /// Create a new token; this should for the most part be called only by platform code.
+    pub fn next() -> TextInputToken {
+        static TEXT_FIELD_COUNTER: Counter = Counter::new();
+        TextInputToken(TEXT_FIELD_COUNTER.next())
+    }
+
+    /// Create a new token from a raw value.
+    pub const fn from_raw(id: u64) -> TextInputToken {
+        TextInputToken(id)
+    }
+
+    /// Get the raw value for a token.
+    pub const fn into_raw(self) -> u64 {
+        self.0
+    }
+}
+
+/// An event that indicates to the platform that some aspect of a text field may have changed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum TextInputUpdate {
+    /// Indicates the value returned by `TextInputHandler::selection` may have changed.
+    SelectionChanged,
+
+    /// Indicates the values returned by one or more of these methods may have changed:
+    /// - `TextInputHandler::hit_test_point`
+    /// - `TextInputHandler::line_range`
+    /// - `TextInputHandler::bounding_box`
+    /// - `TextInputHandler::slice_bounding_box`
+    LayoutChanged,
+
+    /// Indicates any value returned from any of the TextInputHandler methods may have changed.
+    Reset,
+}
+
+/// Corresponds to a selection of some text. This also can represent a text input caret — the blinking vertical
+/// bar where text is to be inserted. A caret is a selection with zero length, where `anchor == extent`.
+/// Indices are always expressed in UTF-8 bytes, and must be between 0 and the document length, inclusive.
+///
+/// As an example, if the input caret is at the start of the document `hello world`, we would expect both `anchor`
+/// and `extent` to be `0`. If the user holds shift and presses the right arrow key five times, we would expect the
+/// word `hello` to be selected, the `anchor` to still be `0`, and the `extent` to now be `5`.
+#[derive(Clone, Default, PartialEq, Eq, Hash)]
+pub struct TextSelection {
+    /// This is the end of the selection that stays unchanged while holding shift and pressing the arrow keys.
+    pub anchor: usize,
+    /// This is the end of the selection that moves while holding shift and pressing the arrow keys.
+    pub extent: usize,
+}
+
+#[allow(clippy::len_without_is_empty)]
+impl TextSelection {
+    /// Creates a new caret (the blinking vertical bar where text is to be inserted) at UTF-8 byte index `index`.
+    /// `index` must be a grapheme cluster boundary.
+    pub fn new_caret(index: usize) -> TextSelection {
+        TextSelection {
+            anchor: index,
+            extent: index,
+        }
+    }
+
+    /// Corresponds to the end of the selection — either the `anchor` or `extent` — that has a lesser byte index.
+    /// Because of bidirectional text, this is not necessarily "left".
+    pub fn upstream_index(&self) -> usize {
+        usize::min(self.anchor, self.extent)
+    }
+
+    /// Corresponds to the end of the selection — either the `anchor` or `extent` — that has a greater byte index.
+    /// Because of bidirectional text, this is not necessarily "right".
+    pub fn downstream_index(&self) -> usize {
+        usize::max(self.anchor, self.extent)
+    }
+
+    /// The sorted range of the document that would be replaced if text were inserted at this selection.
+    pub fn to_range(&self) -> Range<usize> {
+        self.upstream_index()..self.downstream_index()
+    }
+
+    /// The number of characters in the selection. If the selection is a caret, this is `0`.
+    pub fn len(&self) -> usize {
+        if self.anchor > self.extent {
+            self.anchor - self.extent
+        } else {
+            self.extent - self.anchor
+        }
+    }
+
+    /// Returns true if the selection's length is `0`.
+    pub fn is_caret(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// A lock on a text document, such as a text box or text editor document.
+/// The platform acquires this lock temporarily to apply edits corresponding to some user input.
+/// So long as the `TextInputHandler` has not been dropped,
+/// the only changes to the document state must come from calls to `TextInputHandler`.
+///
+/// Some methods require a mutable lock, as indicated when acquiring the lock with `WinHandler::text_input`.
+/// If a mutable method is called on a immutable lock, `TextInputHandler` may panic.
+///
+/// All ranges, lengths, and indices are specified in UTF-8 code units, unless specified otherwise.
+pub trait TextInputHandler {
+    /// Gets the range of the document that is currently selected.
+    /// If the selection is a vertical caret bar, then `range.start == range.end`.
+    /// Both `selection.anchor` and `selection.extent` must be less than or equal to the value returned
+    /// from `TextInputHandler::len()`, and must land on a extended grapheme cluster boundary in the document.
+    fn selection(&mut self) -> TextSelection;
+
+    /// Sets the range of the document that is currently selected.
+    /// If the selection is a vertical caret bar, then `range.start == range.end`.
+    /// Both `selection.anchor` and `selection.extent` must be less than or equal to the value returned
+    /// from `TextInputHandler::len()`.
+    ///
+    /// The `set_selection` implementation should round up (downstream) both `selection.anchor` and `selection.extent`
+    /// to the nearest extended grapheme cluster boundary.
+    ///
+    /// Requries a mutable lock.
+    fn set_selection(&mut self, selection: TextSelection);
+
+    /// Gets the range of the document that is the input method's composition region.
+    /// Both `range.start` and `range.end` must be less than or equal to the value returned
+    /// from `TextInputHandler::len()`, and must land on a extended grapheme cluster boundary in the document.
+    fn composition_range(&mut self) -> Option<Range<usize>>;
+
+    /// Sets the range of the document that is the input method's composition region.
+    /// Both `range.start` and `range.end` must be less than or equal to the value returned
+    /// from `TextInputHandler::len()`.
+    ///
+    /// The `set_selection` implementation should round up (downstream) both `range.start` and `range.end`
+    /// to the nearest extended grapheme cluster boundary.
+    ///
+    /// Requries a mutable lock.
+    fn set_composition_range(&mut self, range: Option<Range<usize>>);
+
+    /// Returns true if `i==0`, `i==TextInputHandler::len()`, or `i` is the first byte of a UTF-8 code point sequence.
+    /// Returns false otherwise, including if `i>TextInputHandler::len()`.
+    /// Equivalent in functionality to `String::is_char_boundary`.
+    fn is_char_boundary(&mut self, i: usize) -> bool;
+
+    /// Returns the length of the document in UTF-8 code units. Equivalent to `String::len`.
+    fn len(&mut self) -> usize;
+
+    /// Returns whether the length of the document is `0`.
+    fn is_empty(&mut self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the contents of some range of the document.
+    /// If `range.start` or `range.end` do not fall on a code point sequence boundary, this method may panic.
+    fn slice<'a>(&'a mut self, range: Range<usize>) -> Cow<'a, str>;
+
+    /// Converts the document into UTF-8, looks up the range specified by `utf8_range` (in UTF-8 code units), reencodes
+    /// that substring into UTF-16, and then returns the number of UTF-16 code units in that substring.
+    ///
+    /// This is automatically implemented, but you can override this if you have some faster system to determine string length.
+    fn utf8_to_utf16(&mut self, utf8_range: Range<usize>) -> usize {
+        self.slice(utf8_range).encode_utf16().count()
+    }
+
+    /// Converts the document into UTF-16, looks up the range specified by `utf16_range` (in UTF-16 code units), reencodes
+    /// that substring into UTF-8, and then returns the number of UTF-8 code units in that substring.
+    ///
+    /// This is automatically implemented, but you can override this if you have some faster system to determine string length.
+    fn utf16_to_utf8(&mut self, utf16_range: Range<usize>) -> usize {
+        if utf16_range.is_empty() {
+            return 0;
+        }
+        let doc_range = 0..self.len();
+        let text = self.slice(doc_range);
+        let utf16: Vec<u16> = text
+            .encode_utf16()
+            .skip(utf16_range.start)
+            .take(utf16_range.end)
+            .collect();
+        String::from_utf16_lossy(&utf16).len()
+    }
+
+    /// Replaces a range of the text document with `text`.
+    /// If `range.start` or `range.end` do not fall on a code point sequence boundary, this method may panic.
+    /// Equivalent to `String::replace_range`.
+    ///
+    /// This method also sets the composition range to `None`, and updates the selection:
+    ///
+    /// - If both the selection's anchor and extent are `< range.start`, then nothing is updated.
+    /// - If both the selection's anchor and extent are `> range.end`, then subtract `range.len()` from both, and add `text.len()`.
+    /// - If neither of the previous two conditions are true, then set both anchor and extent to `range.start + text.len()`.
+    ///
+    /// After the above update, if we increase each end of the selection if necessary to put it on a grapheme cluster boundary.
+    ///
+    /// Requries a mutable lock.
+    fn replace_range(&mut self, range: Range<usize>, text: &str);
+
+    /// Given a `Point`, determine the corresponding text position.
+    fn hit_test_point(&mut self, point: Point) -> HitTestPoint;
+
+    /// Returns the character range of the line (soft- or hard-wrapped) containing the character
+    /// specified by `char_index`.
+    fn line_range(&mut self, char_index: usize, affinity: Affinity) -> Range<usize>;
+
+    /// Returns the bounding box, in window coordinates, of the visible text document. For instance,
+    /// a text box's bounding box would be the rectangle of the border surrounding it, even if the text box is empty.
+    /// If the text document is completely offscreen, return `None`.
+    fn bounding_box(&mut self) -> Option<Rect>;
+
+    /// Returns the bounding box, in window coordinates, of the range of text specified by `range`.
+    /// Ranges will always be equal to or a subrange of some line range returned by `TextInputHandler::line_range`.
+    /// If a range spans multiple lines, `slice_bounding_box` may panic.
+    fn slice_bounding_box(&mut self, range: Range<usize>) -> Option<Rect>;
+
+    /// Applies some special action to the text field.
+    ///
+    /// Requries a mutable lock.
+    fn handle_action(&mut self, action: TextInputAction);
+}
+
+#[allow(dead_code)]
+/// Simulates `TextInputHandler` calls on `handler` for a given keypress `event`. This circumvents the platform, and so can't
+/// work with important features like input method editors! However, it's necessary while we build up our input support on
+/// various platforms, which takes a lot of time, and allows applications to start building on the new `TextInputHandler`
+/// interface immediately on all platforms, with a hopefully seamless upgrade process as we implement IME input on more platforms.
+pub fn simulate_text_input<H: WinHandler + ?Sized>(
+    handler: &mut H,
+    token: Option<TextInputToken>,
+    event: KeyEvent,
+) -> bool {
+    if handler.key_down(event.clone()) {
+        return true;
+    }
+
+    let token = match token {
+        Some(v) => v,
+        None => return false,
+    };
+    let mut input_handler = handler.text_input(token, true);
+    match event.key {
+        KbKey::Character(c) if !event.mods.ctrl() && !event.mods.meta() && !event.mods.alt() => {
+            let selection = input_handler.selection();
+            input_handler.replace_range(selection.to_range(), &c);
+            let new_caret_index = selection.upstream_index() + c.len();
+            input_handler.set_selection(TextSelection::new_caret(new_caret_index));
+        }
+        KbKey::ArrowLeft => {
+            let movement = TextMovement::Grapheme(TextDirection::Left);
+            if event.mods.shift() {
+                input_handler.handle_action(TextInputAction::MoveExtent(movement));
+            } else {
+                input_handler.handle_action(TextInputAction::Move(movement));
+            }
+        }
+        KbKey::ArrowRight => {
+            let movement = TextMovement::Grapheme(TextDirection::Right);
+            if event.mods.shift() {
+                input_handler.handle_action(TextInputAction::MoveExtent(movement));
+            } else {
+                input_handler.handle_action(TextInputAction::Move(movement));
+            }
+        }
+        KbKey::ArrowUp => {
+            let movement = TextMovement::Vertical(VerticalMovement::LineUp);
+            if event.mods.shift() {
+                input_handler.handle_action(TextInputAction::MoveExtent(movement));
+            } else {
+                input_handler.handle_action(TextInputAction::Move(movement));
+            }
+        }
+        KbKey::ArrowDown => {
+            let movement = TextMovement::Vertical(VerticalMovement::LineDown);
+            if event.mods.shift() {
+                input_handler.handle_action(TextInputAction::MoveExtent(movement));
+            } else {
+                input_handler.handle_action(TextInputAction::Move(movement));
+            }
+        }
+        _ => return false,
+    };
+    true
+}
+
+/// Indicates a movement that transforms a particular text position in a document.
+/// These movements transform only single indices — not selections.
+///
+/// You'll note that a lot of these operations are idempotent, but you can get around this by first
+/// sending a `Grapheme` movement.
+/// If for instance, you want a `ParagraphStart` that is not idempotent, you can first send
+/// `TextMovement::Grapheme(TextDirection::Upstream)`, and then follow it with `ParagraphStart`.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum TextMovement {
+    /// A movement that stops when it reaches an extended grapheme cluster boundary.
+    ///
+    /// This movement is achieved on most systems by pressing the left and right arrow keys.
+    /// For more information on grapheme clusters, see
+    /// [Unicode Text Segmentation](https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries).
+    Grapheme(TextDirection),
+    /// A movement that stops when it reaches a word boundary.
+    ///
+    /// This movement is achieved on most systems by pressing the left and right arrow keys while holding control.
+    /// For more information on words, see
+    /// [Unicode Text Segmentation](https://unicode.org/reports/tr29/#Word_Boundaries).
+    Word(TextDirection),
+    /// A movement that stops when it reaches a soft line break.
+    ///
+    /// This movement is achieved on macOS by pressing the left and right arrow keys while holding command.
+    /// `Line` should be idempotent: if the position is already at the end of a soft-wrapped line,
+    /// this movement should never push it onto another soft-wrapped line.
+    ///
+    /// In order to implement this properly, your text positions should remember their affinity.
+    Line(TextDirection),
+    /// An upstream movement that stops when it reaches a hard line break.
+    ///
+    /// `ParagraphStart` should be idempotent: if the position is already at the start of a hard-wrapped line,
+    /// this movement should never push it onto the previous line.
+    ParagraphStart,
+    /// A downstream movement that stops when it reaches a hard line break.
+    ///
+    /// `ParagraphEnd` should be idempotent: if the position is already at the end of a hard-wrapped line,
+    /// this movement should never push it onto the next line.
+    ParagraphEnd,
+    /// A vertical movement, see `VerticalMovement` for more details.
+    Vertical(VerticalMovement),
+}
+
+/// Indicates a horizontal direction in the text.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum TextDirection {
+    /// Indicates the direction visually to the left. This may be byte-wise forwards or backwards in the document,
+    /// depending on the text direction around the position being moved.
+    Left,
+    /// Indicates the direction visually to the right. This may be byte-wise forwards or backwards in the document,
+    /// depending on the text direction around the position being moved.
+    Right,
+    /// Byte-wise backwards in the document. In a left-to-right context, this value is the same as `Left`.
+    Upstream,
+    /// Byte-wise forwards in the document. In a left-to-right context, this value is the same as `Right`.
+    Downstream,
+}
+
+/// Sometimes, a byte location in a document has two visual locations. For example, the end of a soft-wrapped line
+/// and the start of the subsequent line have different visual locations (and we want to be able to place an input caret
+/// in either place!) but the same byte-wise location. This also shows up in bidirectional text contexts. Affinity
+/// allows us to disambiguate between these two visual locations.
+pub enum Affinity {
+    Upstream,
+    Downstream,
+}
+
+/// Indicates a horizontal direction for writing text.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum WritingDirection {
+    LeftToRight,
+    RightToLeft,
+    /// Indicates writing direction should be automatically detected based on the text contents.
+    Natural,
+}
+
+/// Indicates a vertial movement in a text document.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum VerticalMovement {
+    LineUp,
+    LineDown,
+    PageUp,
+    PageDown,
+    DocumentStart,
+    DocumentEnd,
+}
+
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum TextInputAction {
+    /// Moves the selection.
+    ///
+    /// Before moving, if the extent and the anchor of the selection are not at the same
+    /// position (it's a non-caret selection), then:
+    ///
+    /// 1. First set both extent and anchor to the same position: the selection's
+    /// upstream index if `TextMovement` is an upstream movement, or the downstream index if
+    /// `TextMovement` is a downstream movement.
+    ///
+    /// 2. If `TextMovement` is `Grapheme`, then stop. Otherwise, apply the `TextMovement` as
+    /// per the usual rules.
+    Move(TextMovement),
+
+    /// Moves just the selection's extent.
+    ///
+    /// Equivalent to holding shift while performing movements or clicks on most operating systems.
+    MoveExtent(TextMovement),
+
+    /// Select the entire document.
+    SelectAll,
+
+    /// Expands the selection to the entire soft-wrapped line.
+    ///
+    /// If multiple lines are already selected, expands the selection to encompass all soft-wrapped lines
+    /// that intersected with the prior selection.
+    /// If the selection is a caret is on a soft line break, uses the affinity of the caret to determine
+    /// which of the two lines to select.
+    /// `SelectLine` should be idempotent: it should never expand onto adjacent lines.
+    SelectLine,
+
+    /// Expands the selection to the entire hard-wrapped line.
+    ///
+    /// If multiple lines are already selected, expands the selection to encompass all hard-wrapped lines
+    /// that intersected with the prior selection.
+    /// `SelectParagraph` should be idempotent: it should never expand onto adjacent lines.
+    SelectParagraph,
+
+    /// Expands the selection to the entire word.
+    ///
+    /// If multiple words are already selected, expands the selection to encompass all words
+    /// that intersected with the prior selection.
+    /// If the selection is a caret is on a word boundary, selects the word downstream of the caret.
+    /// `SelectWord` should be idempotent: it should never expand onto adjacent words.
+    ///
+    /// For more information on what these so-called "words" are, see
+    /// [Unicode Text Segmentation](https://unicode.org/reports/tr29/#Word_Boundaries).
+    SelectWord,
+
+    /// Deletes some text.
+    ///
+    /// If some text is already selected, `TextMovement` is ignored, and the selection is deleted.
+    /// If the selection's anchor is the same as the extent, then first apply `MoveExtent(TextMovement)`
+    /// and then delete the resulting selection.
+    Delete(TextMovement),
+
+    /// A special kind of backspace that, instead of deleting the entire grapheme upstream of the caret,
+    /// may in some cases and character sets delete a subset of that grapheme's code points.
+    DecomposingBackspace,
+
+    /// Maps the characters in the selection to uppercase.
+    ///
+    /// For more information on case mapping, see the [Unicode Case Mapping FAQ](https://unicode.org/faq/casemap_charprop.html#7)
+    UppercaseSelection,
+
+    /// Maps the characters in the selection to lowercase.
+    ///
+    /// For more information on case mapping, see the [Unicode Case Mapping FAQ](https://unicode.org/faq/casemap_charprop.html#7)
+    LowercaseSelection,
+
+    /// Maps the characters in the selection to titlecase. When calculating whether a character is at the beginning of a word, you
+    /// may have to peek outside the selection to other characters in the document.
+    ///
+    /// For more information on case mapping, see the [Unicode Case Mapping FAQ](https://unicode.org/faq/casemap_charprop.html#7)
+    TitlecaseSelection,
+
+    /// Inserts a newline character into the document.
+    InsertNewLine {
+        /// If `true`, then actually insert a newline, even if normally you would run a keyboard shortcut attached
+        /// to the return key, like sending a message or activating autocomplete. On macOS, this is triggered by pressing option-return.
+        ignore_hotkey: bool,
+        /// Either `U+000A`, `U+2029`, or `U+2028`. For instance, on macOS, control-enter inserts `U+2028`.
+        newline_type: char,
+    },
+
+    /// Inserts a tab character into the document.
+    InsertTab {
+        /// If `true`, then actually insert a tab, even if normally you would run a keyboard shortcut attached
+        /// to the return key, like indenting a line or activating autocomplete. On macOS, this is triggered by pressing option-tab.
+        ignore_hotkey: bool,
+    },
+
+    /// Indicates the reverse of inserting tab; corresponds to shift-tab on most operating systems.
+    InsertBacktab,
+
+    InsertSingleQuoteIgnoringSmartQuotes,
+    InsertDoubleQuoteIgnoringSmartQuotes,
+
+    /// Scrolls the text field without modifying the selection.
+    Scroll(VerticalMovement),
+
+    /// Centers the selection vertically in the text field. The average of the anchor's y and the extent's y should be
+    /// exactly halfway down the field.
+    /// If the selection is taller than the text field's visible height, then instead
+    /// scrolls the minimum distance such that the text field is completely vertically filled by the selection.
+    ScrollToSelection,
+
+    /// Sets the writing direction of the selected text or caret.
+    SetSelectionWritingDirection(WritingDirection),
+
+    /// Sets the writing direction of all paragraphs that partially or fully intersect with the selection or caret.
+    SetParagraphWritingDirection(WritingDirection),
+
+    /// Cancels the current window or operation. Triggered on most operating systems with escape.
+    Cancel,
+}

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -28,6 +28,7 @@ use crate::mouse::{Cursor, CursorDesc, MouseEvent};
 use crate::platform::window as platform;
 use crate::region::Region;
 use crate::scale::Scale;
+use crate::text_input::{TextInputHandler, TextInputToken, TextInputUpdate};
 use piet_common::PietText;
 
 /// A token that uniquely identifies a running timer.
@@ -268,6 +269,31 @@ impl WindowHandle {
         self.0.text()
     }
 
+    /// Indicates there's a new editable text input in the window.
+    /// Returns the `TextInputToken` associated with this new text input.
+    /// `WinHandler::text_input` should be able to serve edit locks for the returned token
+    /// at any point in time until the application passes the token to `remove_text_input`.
+    pub fn add_text_input(&self) -> TextInputToken {
+        self.0.add_text_input()
+    }
+
+    /// Indicates a text input has been removed from the window.
+    pub fn remove_text_input(&self, token: TextInputToken) {
+        self.0.remove_text_input(token)
+    }
+
+    /// Sets the currently focused text input.
+    pub fn set_active_text_input(&self, active_field: Option<TextInputToken>) {
+        self.0.set_active_text_input(active_field)
+    }
+
+    /// Indicates some aspect of the text input has updated; the selection, contents, etc.
+    /// This method should *never* be called in response to edits from a `TextInputHandler`;
+    /// only in response to changes from the application: scrolling, remote edits, etc.
+    pub fn update_text_input(&self, token: TextInputToken, update: TextInputUpdate) {
+        self.0.update_text_input(token, update)
+    }
+
     /// Schedule a timer.
     ///
     /// This causes a [`WinHandler::timer`] call at the deadline. The
@@ -490,6 +516,23 @@ pub trait WinHandler {
     /// on Windows, or keyUp(withEvent:) on macOS.
     #[allow(unused_variables)]
     fn key_up(&mut self, event: KeyEvent) {}
+
+    /// Grabs a lock for the text document specified by `token`.
+    ///
+    /// If `mutable` is true, the lock should be a write lock, and allow calling mutating methods on TextInputHandler.
+    /// This method is called from the top level of the event loop and expects to acquire a lock successfully.
+    ///
+    /// Why does text input acquire a lock, instead of sending text input events? It turns out many input methods need
+    /// to know the context around the selection in order to make edits — think about how autocomplete works on most phones,
+    /// for example. If the input method is on a different process, as is the case on many platforms, not using a lock
+    /// will cause race conditions. As an example, imagine an input method detects that the caret is at the end of the
+    /// word "helo", and wants to autocorrect it to "hello", so it issues commands to delete backwards one grapheme and
+    /// insert "lo". If we allow concurrent edits without locks, the user might have simultaneously moved the caret to a
+    /// different part of the document, and we'll get "lo" inserted in some random place!
+    #[allow(unused_variables)]
+    fn text_input(&mut self, token: TextInputToken, mutable: bool) -> Box<dyn TextInputHandler> {
+        panic!("text_input was called on a WinHandler that did not expect text input.")
+    }
 
     /// Called on a mouse wheel event.
     ///

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -58,21 +58,21 @@ impl TimerToken {
 
 /// Uniquely identifies a text input field inside a window.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
-pub struct TextInputToken(u64);
+pub struct TextFieldToken(u64);
 
-impl TextInputToken {
+impl TextFieldToken {
     /// A token that does not correspond to any text input.
-    pub const INVALID: TextInputToken = TextInputToken(0);
+    pub const INVALID: TextFieldToken = TextFieldToken(0);
 
     /// Create a new token; this should for the most part be called only by platform code.
-    pub fn next() -> TextInputToken {
+    pub fn next() -> TextFieldToken {
         static TEXT_FIELD_COUNTER: Counter = Counter::new();
-        TextInputToken(TEXT_FIELD_COUNTER.next())
+        TextFieldToken(TEXT_FIELD_COUNTER.next())
     }
 
     /// Create a new token from a raw value.
-    pub const fn from_raw(id: u64) -> TextInputToken {
-        TextInputToken(id)
+    pub const fn from_raw(id: u64) -> TextFieldToken {
+        TextFieldToken(id)
     }
 
     /// Get the raw value for a token.
@@ -297,37 +297,37 @@ impl WindowHandle {
     /// Indicates to the platform that there's a new editable text input in the window.
     ///
     /// This method should be called any time a new editable text field is created inside a window.
-    /// Any text field with a `TextInputToken` that has not yet been destroyed with `remove_text_input`
+    /// Any text field with a `TextFieldToken` that has not yet been destroyed with `remove_text_field`
     /// *must* be ready to accept input from the platform via `WinHandler::text_input` at any time, even if
     /// it is not currently focused.
     ///
-    /// Returns the `TextInputToken` associated with this new text input.
+    /// Returns the `TextFieldToken` associated with this new text input.
     // TODO(lord): would `add_text_field` be more clear?
-    pub fn add_text_input(&self) -> TextInputToken {
-        self.0.add_text_input()
+    pub fn add_text_field(&self) -> TextFieldToken {
+        self.0.add_text_field()
     }
 
     /// Indicates to the platform that a text input field has been destroyed.
     ///
     /// If `token` is the text field currently focused, the platform automatically
     /// sets the focused field to `None`.
-    pub fn remove_text_input(&self, token: TextInputToken) {
-        self.0.remove_text_input(token)
+    pub fn remove_text_field(&self, token: TextFieldToken) {
+        self.0.remove_text_field(token)
     }
 
     /// Indicates to the platform that the focused text input has changed.
     ///
     /// This must be called any time focus changes to a different text input, or
     /// when focus switches away from a text input.
-    pub fn set_focused_text_input(&self, active_field: Option<TextInputToken>) {
-        self.0.set_focused_text_input(active_field)
+    pub fn set_focused_text_field(&self, active_field: Option<TextFieldToken>) {
+        self.0.set_focused_text_field(active_field)
     }
 
     /// Indicates some aspect of the text input has updated; the selection, contents, etc.
     /// This method should *never* be called in response to edits from a `InputHandler`;
     /// only in response to changes from the application: scrolling, remote edits, etc.
-    pub fn update_text_input(&self, token: TextInputToken, update: Event) {
-        self.0.update_text_input(token, update)
+    pub fn update_text_field(&self, token: TextFieldToken, update: Event) {
+        self.0.update_text_field(token, update)
     }
 
     /// Schedule a timer.
@@ -559,7 +559,7 @@ pub trait WinHandler {
     /// This method is called from the top level of the event loop and expects to acquire a lock successfully. For
     /// more information, see [the text input documentation](crate::text).
     #[allow(unused_variables)]
-    fn text_input(&mut self, token: TextInputToken, mutable: bool) -> Box<dyn InputHandler> {
+    fn text_input(&mut self, token: TextFieldToken, mutable: bool) -> Box<dyn InputHandler> {
         panic!("text_input was called on a WinHandler that did not expect text input.")
     }
 

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -28,7 +28,7 @@ use crate::mouse::{Cursor, CursorDesc, MouseEvent};
 use crate::platform::window as platform;
 use crate::region::Region;
 use crate::scale::Scale;
-use crate::text_input::{TextInputHandler, TextInputToken, TextInputUpdate};
+use crate::text::{Event, InputHandler};
 use piet_common::PietText;
 
 /// A token that uniquely identifies a running timer.
@@ -48,6 +48,31 @@ impl TimerToken {
     /// Create a new token from a raw value.
     pub const fn from_raw(id: u64) -> TimerToken {
         TimerToken(id)
+    }
+
+    /// Get the raw value for a token.
+    pub const fn into_raw(self) -> u64 {
+        self.0
+    }
+}
+
+/// Uniquely identifies a text input field inside a window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
+pub struct TextInputToken(u64);
+
+impl TextInputToken {
+    /// A token that does not correspond to any text input.
+    pub const INVALID: TextInputToken = TextInputToken(0);
+
+    /// Create a new token; this should for the most part be called only by platform code.
+    pub fn next() -> TextInputToken {
+        static TEXT_FIELD_COUNTER: Counter = Counter::new();
+        TextInputToken(TEXT_FIELD_COUNTER.next())
+    }
+
+    /// Create a new token from a raw value.
+    pub const fn from_raw(id: u64) -> TextInputToken {
+        TextInputToken(id)
     }
 
     /// Get the raw value for a token.
@@ -269,28 +294,39 @@ impl WindowHandle {
         self.0.text()
     }
 
-    /// Indicates there's a new editable text input in the window.
+    /// Indicates to the platform that there's a new editable text input in the window.
+    ///
+    /// This method should be called any time a new editable text field is created inside a window.
+    /// Any text field with a `TextInputToken` that has not yet been destroyed with `remove_text_input`
+    /// *must* be ready to accept input from the platform via `WinHandler::text_input` at any time, even if
+    /// it is not currently focused.
+    ///
     /// Returns the `TextInputToken` associated with this new text input.
-    /// `WinHandler::text_input` should be able to serve edit locks for the returned token
-    /// at any point in time until the application passes the token to `remove_text_input`.
+    // TODO(lord): would `add_text_field` be more clear?
     pub fn add_text_input(&self) -> TextInputToken {
         self.0.add_text_input()
     }
 
-    /// Indicates a text input has been removed from the window.
+    /// Indicates to the platform that a text input field has been destroyed.
+    ///
+    /// If `token` is the text field currently focused, the platform automatically
+    /// sets the focused field to `None`.
     pub fn remove_text_input(&self, token: TextInputToken) {
         self.0.remove_text_input(token)
     }
 
-    /// Sets the currently focused text input.
-    pub fn set_active_text_input(&self, active_field: Option<TextInputToken>) {
-        self.0.set_active_text_input(active_field)
+    /// Indicates to the platform that the focused text input has changed.
+    ///
+    /// This must be called any time focus changes to a different text input, or
+    /// when focus switches away from a text input.
+    pub fn set_focused_text_input(&self, active_field: Option<TextInputToken>) {
+        self.0.set_focused_text_input(active_field)
     }
 
     /// Indicates some aspect of the text input has updated; the selection, contents, etc.
-    /// This method should *never* be called in response to edits from a `TextInputHandler`;
+    /// This method should *never* be called in response to edits from a `InputHandler`;
     /// only in response to changes from the application: scrolling, remote edits, etc.
-    pub fn update_text_input(&self, token: TextInputToken, update: TextInputUpdate) {
+    pub fn update_text_input(&self, token: TextInputToken, update: Event) {
         self.0.update_text_input(token, update)
     }
 
@@ -519,18 +555,11 @@ pub trait WinHandler {
 
     /// Grabs a lock for the text document specified by `token`.
     ///
-    /// If `mutable` is true, the lock should be a write lock, and allow calling mutating methods on TextInputHandler.
-    /// This method is called from the top level of the event loop and expects to acquire a lock successfully.
-    ///
-    /// Why does text input acquire a lock, instead of sending text input events? It turns out many input methods need
-    /// to know the context around the selection in order to make edits — think about how autocomplete works on most phones,
-    /// for example. If the input method is on a different process, as is the case on many platforms, not using a lock
-    /// will cause race conditions. As an example, imagine an input method detects that the caret is at the end of the
-    /// word "helo", and wants to autocorrect it to "hello", so it issues commands to delete backwards one grapheme and
-    /// insert "lo". If we allow concurrent edits without locks, the user might have simultaneously moved the caret to a
-    /// different part of the document, and we'll get "lo" inserted in some random place!
+    /// If `mutable` is true, the lock should be a write lock, and allow calling mutating methods on InputHandler.
+    /// This method is called from the top level of the event loop and expects to acquire a lock successfully. For
+    /// more information, see [the text input documentation](crate::text).
     #[allow(unused_variables)]
-    fn text_input(&mut self, token: TextInputToken, mutable: bool) -> Box<dyn TextInputHandler> {
+    fn text_input(&mut self, token: TextInputToken, mutable: bool) -> Box<dyn InputHandler> {
         panic!("text_input was called on a WinHandler that did not expect text input.")
     }
 


### PR DESCRIPTION
This change proposes a new set of APIs for text input, as well as fully implements proper text input using those APIs on macOS. Other platforms have text input commands simulated from key down events — this won't handle IME input on those platforms, but will hopefully work as a temporary solution for those platforms until we can add IME support to them.

To test it out: `cd druid-shell; cargo run --example edit_text`

Sorry for the really long commit!! Let me know if I should split it up. Most of the changes should hopefully be boilerplate and comments, but there's still a fair amount of logic.

I have a few things I'm still unsure about, although I'm sure there's plenty more I've missed:

- this i think will allow for RTL/LTR, but do we ever want specially handled vertical text? i guess the macOS APIs don't really seem to handle it specifically, so maybe OK to ignore for now
- have not spent too much time considering whether this design works with async functions on android. i've also only barely looked into non-mac platforms for this, but the similarity between this design and tcw3's design makes me feel confident that it'll work on at least gtk and windows, which I think tcw3 has a full text input implementation for.
- this is a pretty complex interface! if folks have ideas for how it could be simplified, could be a good idea to try?
- are we happy with the taxonomy of `TextInputAction`s I've created? it seems maybe better to me than a completely flat list of commands in a single `enum`, but perhaps I've over-combined commands, like how vertical movement is shared between selection movements and scrolling. these actions are also a little macOS specific, although I've tried my best to directly implement some of the more esoteric commands like "transpose". tcw3 handles this by having a bunch of post-ime keybindings on other platforms that trigger the appropriate `TextInputAction`.
- not too happy with all the `TextInput` prefixes everywhere on basic types, but was necessary given how druid-shell puts everything in a single top-level namespace. if we think it's ok to have a `text_input_types` prefix or something like that, could make types like `TextSelection` and `TextInputUpdate` look a little prettier?
- this does not yet implement killing and yanking, triggered by control-k and control-y on macOS. hopefully this is ok to defer for now?
- there are no tests right now. is this ok? i do think in the long term, would be nice to have a standard test suite that's run on all `TextInputHandler` implementations to ensure they correctly manipulate the text state, deal with graphemes correctly, etc

See also the IME tracking issue: #1308