### PR TITLE
Fix TextBox problems

### DIFF
--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -117,7 +117,7 @@ pub(crate) fn add_to_env(env: Env) -> Env {
         .adding(BORDERED_WIDGET_HEIGHT, 24.0)
         .adding(TEXTBOX_BORDER_RADIUS, 2.)
         .adding(TEXTBOX_BORDER_WIDTH, 1.)
-        .adding(TEXTBOX_INSETS, Insets::new(4.0, 2.0, 0.0, 2.0))
+        .adding(TEXTBOX_INSETS, Insets::new(4.0, 2.0, 4.0, 2.0))
         .adding(SCROLLBAR_COLOR, Color::rgb8(0xff, 0xff, 0xff))
         .adding(SCROLLBAR_BORDER_COLOR, Color::rgb8(0x77, 0x77, 0x77))
         .adding(SCROLLBAR_MAX_OPACITY, 0.7)

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -193,7 +193,7 @@ impl<T: TextStorage + EditableText> TextBox<T> {
             // **[I****]****
             //   ^
             self.hscroll_offset = cursor_x;
-        } else {
+        } else if self.hscroll_offset > overall_text_width - self_width + text_insets.x_value() {
             // If the text is getting shorter, keep as small offset as possible
             //        <-
             // **[****I]


### PR DESCRIPTION
Fixes two issues introduced in #1381.

- Cursor disappearing behind the right edge:
 Adds `x1` offset to the default insets. Previously, the inset value was calculated as `x0 * 2.0`, now as `x0 + x1`.
- Miscalculating the scroll offset:
 Clamp the offset value only in case it's bigger than needed.