### PR TITLE
Fix scaling on GTK & X11

### DIFF
--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -375,6 +375,7 @@ impl WindowBuilder {
                         // Clip to the invalid region, in order that our surface doesn't get
                         // messed up if there's any painting outside them.
                         for rect in invalid.rects() {
+                            let rect = rect.to_px(scale);
                             surface_context.rectangle(rect.x0, rect.y0, rect.width(), rect.height());
                         }
                         surface_context.clip();

--- a/druid-shell/src/scale.rs
+++ b/druid-shell/src/scale.rs
@@ -100,6 +100,8 @@ impl Default for Scale {
 
 impl Scale {
     /// Create a new `Scale` based on the specified axis factors.
+    ///
+    /// Units: none (scale relative to "standard" scale)
     pub fn new(x: f64, y: f64) -> Scale {
         Scale { x, y }
     }


### PR DESCRIPTION
WIP: fixes #939 

The first commit fixes scaling on the GTK backend, per my testing.

The second commit attempts to get the scaling factor when using the X11 backend. Unfortunately it doesn't work:
```
     Running `/home/dhardy/.cache/cargo/debug/examples/calc`
INFO  [druid_shell::platform::x11::application] X server supports Present version 1.0
INFO  [druid_shell::platform::x11::application] X server supports XFIXES version 5.0
WARN  [druid_shell::platform::x11::application] Application::get_locale is currently unimplemented for X11 platforms. (defaulting to en-US)
DEBUG [druid::localization] available locales [en-US, fr-CA, de-DE], current en-US
DEBUG [druid::localization] resolved: [en-US]
WARN  [druid_shell::platform::x11::window] WindowBuilder::resizable is currently unimplemented for X11 platforms.
[druid-shell/src/platform/x11/window.rs:233] scale = Scale {
    x: 1.0004923682914821,
    y: 1.0,
}
```
(Scale factor is actually 1.1667.) Any idea what's wrong here? @crsaracco 