### PR TITLE
Add Scroll::scroll_to and ClipBox::pan_to_visible

### DIFF
--- a/druid/src/scroll_component.rs
+++ b/druid/src/scroll_component.rs
@@ -90,6 +90,7 @@ pub enum BarHeldState {
 /// [`ClipBox`]: ../widget/struct.ClipBox.html
 /// [`event`]: struct.ScrollComponent.html#method.event
 /// [`handle_scroll`]: struct.ScrollComponent.html#method.handle_scroll
+/// [`draw_bars`]: #method.draw_bars
 /// [`lifecycle`]: struct.ScrollComponent.html#method.lifecycle
 #[derive(Debug, Copy, Clone)]
 pub struct ScrollComponent {

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -16,7 +16,7 @@
 
 use crate::widget::prelude::*;
 use crate::widget::ClipBox;
-use crate::{scroll_component::*, Data, Vec2};
+use crate::{scroll_component::*, Data, Rect, Vec2};
 
 /// A container that scrolls its contents.
 ///
@@ -87,6 +87,14 @@ impl<T, W: Widget<T>> Scroll<T, W> {
     /// Returns `true` if the scroll offset has changed.
     pub fn scroll_by(&mut self, delta: Vec2) -> bool {
         self.clip.pan_by(delta)
+    }
+
+    /// Scroll the minimal distance to show the target rect.
+    ///
+    /// If the target region is larger than the viewport, we will display the
+    /// portion that fits, prioritizing the portion closest to the origin.
+    pub fn scroll_to(&mut self, region: Rect) -> bool {
+        self.clip.pan_to_visible(region)
     }
 }
 


### PR DESCRIPTION
Often when manipulating a scroll view you care less
about relative movement and more about just ensuring
some portion of the content is visible; this API
supports that case.

@jneem does this make sense to you?