### PR TITLE
Notification sketch

### DIFF
--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -81,6 +81,30 @@ pub struct Command {
     target: Target,
 }
 
+/// A message passed up the tree from a [`Widget`] to its ancestors.
+///
+/// In the course of handling an event, a [`Widget`] may change some internal
+/// state that is of interest to one of its ancestors. In this case, the widget
+/// may submit a [`Notification`].
+///
+/// In practice, a [`Notification`] is very similar to a [`Command`]; the
+/// main distinction relates to delivery. [`Command`]s are delivered from the
+/// root of the tree down towards the target, and this delivery occurs after
+/// the originating event call has returned. [`Notification`]s are delivered *up*
+/// the tree, and this occurs *during* event handling; immediately after the
+/// child widget's [`event`] method returns, the notification will be delivered
+/// to the child's parent, and then the parent's parent, until the notification
+/// is handled.
+///
+/// [`Widget`]: crate::Widget
+/// [`event`]: crate::Widget::event
+#[derive(Clone)]
+pub struct Notification {
+    symbol: SelectorSymbol,
+    payload: Arc<dyn Any>,
+    source: WidgetId,
+}
+
 /// A wrapper type for [`Command`] payloads that should only be used once.
 ///
 /// This is useful if you have some resource that cannot be
@@ -337,6 +361,19 @@ impl Command {
         .default_to(Target::Global)
     }
 
+    /// A helper method for creating a `Notification` from a `Command`.
+    ///
+    /// This is slightly icky; it lets us do `SOME_SELECTOR.with(SOME_PAYLOAD)`
+    /// (which generates a command) and then privately convert it to a
+    /// notification.
+    pub(crate) fn into_notification(self, source: WidgetId) -> Notification {
+        Notification {
+            symbol: self.symbol,
+            payload: self.payload,
+            source,
+        }
+    }
+
     /// Set the `Command`'s [`Target`].
     ///
     /// [`Command::target`] can be used to get the current [`Target`].
@@ -420,6 +457,43 @@ impl Command {
     }
 }
 
+impl Notification {
+    /// Returns `true` if `self` matches this [`Selector`].
+    pub fn is<T>(&self, selector: Selector<T>) -> bool {
+        self.symbol == selector.symbol()
+    }
+
+    /// Returns the payload for this [`Selector`], if the selector matches.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the payload has a different type, than what the selector
+    /// is supposed to carry. This can happen when two selectors with different
+    /// types but the same key are used.
+    ///
+    /// [`is`]: #method.is
+    pub fn get<T: Any>(&self, selector: Selector<T>) -> Option<&T> {
+        if self.symbol == selector.symbol() {
+            Some(self.payload.downcast_ref().unwrap_or_else(|| {
+                panic!(
+                    "The selector \"{}\" exists twice with different types. \
+                    See druid::Command::get for more information",
+                    selector.symbol()
+                );
+            }))
+        } else {
+            None
+        }
+    }
+
+    /// The [`WidgetId`] of the [`Widget`] that sent this [`Notification`].
+    ///
+    /// [`Widget`]: crate::Widget
+    pub fn source(&self) -> WidgetId {
+        self.source
+    }
+}
+
 impl<T: Any> SingleUse<T> {
     /// Create a new single-use payload.
     pub fn new(data: T) -> Self {
@@ -487,6 +561,16 @@ impl Into<Option<Target>> for WindowId {
 impl Into<Option<Target>> for WidgetId {
     fn into(self) -> Option<Target> {
         Some(Target::Widget(self))
+    }
+}
+
+impl std::fmt::Debug for Notification {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "Notification: Selector {} from {:?}",
+            self.symbol, self.source
+        )
     }
 }
 

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -19,7 +19,7 @@ use crate::kurbo::{Rect, Shape, Size, Vec2};
 use druid_shell::{Clipboard, KeyEvent, TimerToken};
 
 use crate::mouse::MouseEvent;
-use crate::{Command, WidgetId};
+use crate::{Command, Notification, WidgetId};
 
 /// An event, propagated downwards during event flow.
 ///
@@ -130,6 +130,24 @@ pub enum Event {
     /// [`Widget`]: trait.Widget.html
     /// [`EventCtx::submit_command`]: struct.EventCtx.html#method.submit_command
     Command(Command),
+    /// A [`Notification`] from one of this widget's descendants.
+    ///
+    /// While handling events, widgets can submit notifications to be
+    /// delivered to their ancestors immdiately after they return.
+    ///
+    /// If you handle a [`Notification`], you should call [`EventCtx::set_handled`]
+    /// to stop the notification from being delivered to further ancestors.
+    ///
+    /// ## Special considerations
+    ///
+    /// Notifications are slightly different from other events; they originate
+    /// inside Druid, and they are delivered as part of the handling of another
+    /// event. In this sense, they can sort of be thought of as an augmentation
+    /// of an event; they are a way for multiple widgets to coordinate the
+    /// handling of an event.
+    ///
+    /// [`EventCtx::set_handled`]: crate::EventCtx::set_handled
+    Notification(Notification),
     /// Internal druid event.
     ///
     /// This should always be passed down to descendant [`WidgetPod`]s.
@@ -310,6 +328,7 @@ impl Event {
             | Event::Timer(_)
             | Event::AnimFrame(_)
             | Event::Command(_)
+            | Event::Notification(_)
             | Event::Internal(_) => true,
             Event::MouseDown(_)
             | Event::MouseUp(_)

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -191,7 +191,7 @@ pub use crate::core::WidgetPod;
 pub use app::{AppLauncher, WindowConfig, WindowDesc};
 pub use app_delegate::{AppDelegate, DelegateCtx};
 pub use box_constraints::BoxConstraints;
-pub use command::{sys as commands, Command, Selector, SingleUse, Target};
+pub use command::{sys as commands, Command, Notification, Selector, SingleUse, Target};
 pub use contexts::{EventCtx, LayoutCtx, LifeCycleCtx, PaintCtx, UpdateCtx};
 pub use data::Data;
 pub use env::{Env, Key, KeyOrValue, Value, ValueType};


### PR DESCRIPTION
This implements the notification proposal described in #1388.
The implementation is minimal and relatively non-invasive;
my inclination is to merge this and then experiment on top
of that, with the understanding that it will be fairly easy
to remove this if it isn't pulling its weight.

~This is a quick and dirty implementation of the notifications mechanism described in #1388.~

~This adds notifications (which act like an event, and can only be sent via the `EventCtx`, although I suspect they should ultimately be a `LifeCycle`) and also adds support for a 'scroll to' notification in the `Scroll` widget, that lets children modify the scroll position; it uses this in the `TextBox` so that we always display the cursor position when the cursor moves. This can be tested in the `styled_text` example.~

~Overall I'm quite happy with how little code this is, and my inclination is to push this forward, merging some version of the notification mechanism; this would be tentative but make it possible to explore various ways of using this without having to maintain a fork.~

~(this is based on #1392)~
