### PR TITLE
Ensure TextBox editor is up to date after event

### DIFF
--- a/druid/src/text/editor.rs
+++ b/druid/src/text/editor.rs
@@ -173,7 +173,12 @@ impl<T: TextStorage + EditableText> Editor<T> {
         self.layout.rebuild_if_needed(factory, env);
     }
 
-    /// Perform an [`EditAction`](enum.EditAction.html).
+    /// Perform an [`EditAction`].
+    ///
+    /// After editing, the inner layout is not valid until [`rebuild_if_needed`]
+    /// is called.
+    ///
+    /// [`rebuild_if_needed`]: Editor::rebuild_if_needed
     pub fn do_edit(&mut self, edit: EditAction, data: &mut T) {
         if self.data_is_stale(data) {
             log::warn!("editor data changed externally, skipping event {:?}", &edit);
@@ -208,6 +213,8 @@ impl<T: TextStorage + EditableText> Editor<T> {
             EditAction::Drag(action) => self.selection.end = action.column,
             EditAction::SelectAll => self.selection = Selection::new(0, data.len()),
         }
+        // layout checks that this has changed before actually invalidating
+        self.layout.set_text(data.to_owned());
     }
 
     /// Draw this editor at the provided point.

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -298,7 +298,10 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
                 ctx.request_paint();
             }
             _ => (),
-        }
+        };
+        // if an edit occurred, rebuild the editor so that things like cursor
+        // positions are up to date,
+        self.editor.rebuild_if_needed(ctx.text(), env);
     }
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {


### PR DESCRIPTION
Previously the editor's inner layout would be stale between
when an edit occured, and when update happened; this meant that
things like text measurement and cursor positions would be incorrect
unless the caller manually rebuilt the layout.

Since rebuilding is already lazy, and avoids doing work unless state
has changed, this should not be much more expensive and removes
a significant potential source of confusion.

This was motivated by my experiments with notifications.