### PR TITLE
Request multiline textbox layout on update

### DIFF
--- a/druid/src/text/editor.rs
+++ b/druid/src/text/editor.rs
@@ -161,9 +161,9 @@ impl<T: TextStorage + EditableText> Editor<T> {
         if self.data_is_stale(new_data) {
             self.layout.set_text(new_data.clone());
             self.selection = self.selection.constrained(new_data);
-            ctx.request_paint();
+            ctx.request_layout();
         } else if self.layout.needs_rebuild_after_update(ctx) {
-            ctx.request_paint();
+            ctx.request_layout();
         }
         self.rebuild_if_needed(ctx.text(), env);
     }


### PR DESCRIPTION
Currently when you add/remove a newline in a multiline textbox the textbox does not resize until you do something like resize the window. This results in your cursor going off the screen when adding a newline at the end of the textbox.

This causes the textbox to request a layout on every update, which fixes the problem.

I'm not sure this is the right fix. For one it might be possible to be more conservative here and only update when newlines are added. Alternatively I notice an issue (#1134) which suggests accents should change text height, and it's possible for reason like that we should be rerunning layout on every change regardless of whether or not the textbox is multiline. Or something inbetween the two that I'm not aware of.