### PR TITLE
Use set_origin instead of set_layout_rect in built-in widgets

### DIFF
--- a/druid/examples/timer.rs
+++ b/druid/examples/timer.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 
 use druid::widget::prelude::*;
 use druid::widget::BackgroundBrush;
-use druid::{AppLauncher, Color, LocalizedString, Point, Rect, TimerToken, WidgetPod, WindowDesc};
+use druid::{AppLauncher, Color, LocalizedString, Point, TimerToken, WidgetPod, WindowDesc};
 
 static TIMER_INTERVAL: Duration = Duration::from_millis(10);
 
@@ -72,9 +72,8 @@ impl Widget<u32> for TimerWidget {
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &u32, env: &Env) -> Size {
-        let size = self.simple_box.layout(ctx, &bc.loosen(), data, env);
-        let rect = Rect::from_origin_size(self.pos, size);
-        self.simple_box.set_layout_rect(ctx, data, env, rect);
+        self.simple_box.layout(ctx, &bc.loosen(), data, env);
+        self.simple_box.set_origin(ctx, data, env, self.pos);
         bc.constrain((500.0, 500.0))
     }
 

--- a/druid/examples/widget_gallery.rs
+++ b/druid/examples/widget_gallery.rs
@@ -14,7 +14,7 @@
 
 use druid::{
     im,
-    kurbo::{Affine, BezPath, Circle},
+    kurbo::{Affine, BezPath, Circle, Point},
     piet::{FixedLinearGradient, GradientStop, InterpolationMode},
     widget::{
         prelude::*, Button, Checkbox, FillStrat, Flex, Image, Label, List, Painter, ProgressBar,
@@ -355,19 +355,13 @@ impl<T: Data> Widget<T> for SquaresGrid<T> {
             .take(self.drawable_widgets)
             .enumerate()
         {
-            let rect = Rect::new(
-                x_position,
-                y_position,
-                x_position + self.cell_size.width,
-                y_position + self.cell_size.height,
-            );
             widget.layout(
                 ctx,
                 &BoxConstraints::new(self.cell_size, self.cell_size),
                 data,
                 env,
             );
-            widget.set_layout_rect(ctx, data, env, rect);
+            widget.set_origin(ctx, data, env, Point::new(x_position, y_position));
             // Increment position for the next cell
             x_position += self.cell_size.width + self.spacing;
             // If we can't fit in another cell in this row ...

--- a/druid/src/widget/align.rs
+++ b/druid/src/widget/align.rs
@@ -118,8 +118,7 @@ impl<T: Data> Widget<T> for Align<T> {
             .align
             .resolve(Rect::new(0., 0., extra_width, extra_height))
             .expand();
-        self.child
-            .set_layout_rect(ctx, data, env, Rect::from_origin_size(origin, size));
+        self.child.set_origin(ctx, data, env, origin);
 
         let my_insets = self.child.compute_parent_paint_insets(my_size);
         ctx.set_paint_insets(my_insets);

--- a/druid/src/widget/clip_box.rs
+++ b/druid/src/widget/clip_box.rs
@@ -299,8 +299,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for ClipBox<T, W> {
 
         let content_size = self.child.layout(ctx, &child_bc, data, env);
         self.port.content_size = content_size;
-        self.child
-            .set_layout_rect(ctx, data, env, content_size.to_rect());
+        self.child.set_origin(ctx, data, env, Point::ORIGIN);
 
         self.port.rect = self.port.rect.with_size(bc.constrain(content_size));
         let new_offset = self.port.clamp_view_origin(self.viewport_origin());

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -15,9 +15,8 @@
 //! A widget that provides simple visual styling options to a child.
 
 use super::BackgroundBrush;
-use crate::kurbo::Point;
 use crate::widget::prelude::*;
-use crate::{Color, Data, KeyOrValue, Rect, WidgetPod};
+use crate::{Color, Data, KeyOrValue, Point, WidgetPod};
 
 struct BorderStyle {
     width: KeyOrValue<f64>,
@@ -156,8 +155,7 @@ impl<T: Data> Widget<T> for Container<T> {
         let child_bc = bc.shrink((2.0 * border_width, 2.0 * border_width));
         let size = self.inner.layout(ctx, &child_bc, data, env);
         let origin = Point::new(border_width, border_width);
-        self.inner
-            .set_layout_rect(ctx, data, env, Rect::from_origin_size(origin, size));
+        self.inner.set_origin(ctx, data, env, origin);
 
         let my_size = Size::new(
             size.width + 2.0 * border_width,

--- a/druid/src/widget/either.rs
+++ b/druid/src/widget/either.rs
@@ -15,7 +15,7 @@
 //! A widget that switches dynamically between two child views.
 
 use crate::widget::prelude::*;
-use crate::{Data, WidgetPod};
+use crate::{Data, Point, WidgetPod};
 
 /// A widget that switches between two possible child views.
 pub struct Either<T> {
@@ -79,7 +79,7 @@ impl<T: Data> Widget<T> for Either<T> {
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         let current_widget = self.current_widget();
         let size = current_widget.layout(ctx, bc, data, env);
-        current_widget.set_layout_rect(ctx, data, env, size.to_rect());
+        current_widget.set_origin(ctx, data, env, Point::ORIGIN);
         ctx.set_paint_insets(current_widget.paint_insets());
         size
     }

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -15,7 +15,7 @@
 //! A widget that accepts a closure to update the environment for its child.
 
 use crate::widget::prelude::*;
-use crate::{Data, WidgetPod};
+use crate::{Data, Point, WidgetPod};
 
 /// A widget that accepts a closure to update the environment for its child.
 pub struct EnvScope<T, W> {
@@ -83,7 +83,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for EnvScope<T, W> {
         (self.f)(&mut new_env, &data);
 
         let size = self.child.layout(ctx, &bc, data, &new_env);
-        self.child.set_layout_rect(ctx, data, env, size.to_rect());
+        self.child.set_origin(ctx, data, env, Point::ORIGIN);
         size
     }
 

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -650,9 +650,6 @@ impl<T: Data> Widget<T> for Flex<T> {
                 minor = minor.max(self.direction.minor(child_size).expand());
                 max_above_baseline = max_above_baseline.max(child_size.height - baseline_offset);
                 max_below_baseline = max_below_baseline.max(baseline_offset);
-                // Stash size.
-                let rect = child_size.to_rect();
-                child.widget.set_layout_rect(ctx, data, env, rect);
             }
         }
 
@@ -680,9 +677,6 @@ impl<T: Data> Widget<T> for Flex<T> {
                 minor = minor.max(self.direction.minor(child_size).expand());
                 max_above_baseline = max_above_baseline.max(child_size.height - baseline_offset);
                 max_below_baseline = max_below_baseline.max(baseline_offset);
-                // Stash size.
-                let rect = child_size.to_rect();
-                child.widget.set_layout_rect(ctx, data, env, rect);
             }
         }
 
@@ -725,8 +719,7 @@ impl<T: Data> Widget<T> for Flex<T> {
             };
 
             let child_pos: Point = self.direction.pack(major, child_minor_offset).into();
-            let child_frame = Rect::from_origin_size(child_pos, child_size);
-            child.widget.set_layout_rect(ctx, data, env, child_frame);
+            child.widget.set_origin(ctx, data, env, child_pos);
             child_paint_rect = child_paint_rect.union(child.widget.paint_rect());
             major += self.direction.major(child_size).expand();
             major += spacing.next().unwrap_or(0.);

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -273,8 +273,8 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
                 }
             };
             let child_size = child.layout(ctx, &child_bc, child_data, env);
-            let rect = Rect::from_origin_size(Point::from(axis.pack(major_pos, 0.)), child_size);
-            child.set_layout_rect(ctx, child_data, env, rect);
+            let child_pos: Point = axis.pack(major_pos, 0.).into();
+            child.set_origin(ctx, child_data, env, child_pos);
             paint_rect = paint_rect.union(child.paint_rect());
             minor = minor.max(axis.minor(child_size));
             major_pos += axis.major(child_size) + spacing;
@@ -284,7 +284,7 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
         major_pos -= spacing;
 
         let my_size = bc.constrain(Size::from(axis.pack(major_pos, minor)));
-        let insets = paint_rect - Rect::ZERO.with_size(my_size);
+        let insets = paint_rect - my_size.to_rect();
         ctx.set_paint_insets(insets);
         my_size
     }

--- a/druid/src/widget/padding.rs
+++ b/druid/src/widget/padding.rs
@@ -15,7 +15,7 @@
 //! A widget that just adds padding during layout.
 
 use crate::widget::prelude::*;
-use crate::{Data, Insets, Point, Rect, WidgetPod};
+use crate::{Data, Insets, Point, WidgetPod};
 
 /// A widget that just adds padding around its child.
 pub struct Padding<T> {
@@ -91,8 +91,7 @@ impl<T: Data> Widget<T> for Padding<T> {
         let child_bc = bc.shrink((hpad, vpad));
         let size = self.child.layout(ctx, &child_bc, data, env);
         let origin = Point::new(self.left, self.top);
-        self.child
-            .set_layout_rect(ctx, data, env, Rect::from_origin_size(origin, size));
+        self.child.set_origin(ctx, data, env, origin);
 
         let my_size = Size::new(size.width + hpad, size.height + vpad);
         let my_insets = self.child.compute_parent_paint_insets(my_size);

--- a/druid/src/widget/scope.rs
+++ b/druid/src/widget/scope.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::widget::prelude::*;
-use crate::{Data, Lens, WidgetPod};
+use crate::{Data, Lens, Point, WidgetPod};
 
 /// A policy that controls how a [`Scope`] will interact with its surrounding
 /// application data. Specifically, how to create an initial State from the
@@ -292,7 +292,7 @@ impl<SP: ScopePolicy, W: Widget<SP::State>> Widget<SP::In> for Scope<SP, W> {
     ) -> Size {
         self.with_state(data, |state, inner| {
             let size = inner.layout(ctx, bc, state, env);
-            inner.set_layout_rect(ctx, state, env, size.to_rect());
+            inner.set_origin(ctx, state, env, Point::ORIGIN);
             size
         })
     }

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -404,33 +404,22 @@ impl<T: Data> Widget<T> for Split<T> {
 
         // Top-left align for both children, out of laziness.
         // Reduce our unsplit direction to the larger of the two widgets
-        let (child1_rect, child2_rect) = match self.split_axis {
+        let child1_pos = Point::ORIGIN;
+        let child2_pos = match self.split_axis {
             Axis::Horizontal => {
                 my_size.height = child1_size.height.max(child2_size.height);
-                (
-                    Rect::from_origin_size(Point::ORIGIN, child1_size),
-                    Rect::from_origin_size(
-                        Point::new(child1_size.width + bar_area, 0.0),
-                        child2_size,
-                    ),
-                )
+                Point::new(child1_size.width + bar_area, 0.0)
             }
             Axis::Vertical => {
                 my_size.width = child1_size.width.max(child2_size.width);
-                (
-                    Rect::from_origin_size(Point::ORIGIN, child1_size),
-                    Rect::from_origin_size(
-                        Point::new(0.0, child1_size.height + bar_area),
-                        child2_size,
-                    ),
-                )
+                Point::new(0.0, child1_size.height + bar_area)
             }
         };
-        self.child1.set_layout_rect(ctx, data, env, child1_rect);
-        self.child2.set_layout_rect(ctx, data, env, child2_rect);
+        self.child1.set_origin(ctx, data, env, child1_pos);
+        self.child2.set_origin(ctx, data, env, child2_pos);
 
         let paint_rect = self.child1.paint_rect().union(self.child2.paint_rect());
-        let insets = paint_rect - Rect::ZERO.with_size(my_size);
+        let insets = paint_rect - my_size.to_rect();
         ctx.set_paint_insets(insets);
 
         my_size

--- a/druid/src/widget/view_switcher.rs
+++ b/druid/src/widget/view_switcher.rs
@@ -15,7 +15,7 @@
 //! A widget that can dynamically switch between one of many views.
 
 use crate::widget::prelude::*;
-use crate::{Data, WidgetPod};
+use crate::{Data, Point, WidgetPod};
 
 /// A widget that can switch dynamically between one of many views depending
 /// on application state.
@@ -89,7 +89,7 @@ impl<T: Data, U: Data> Widget<T> for ViewSwitcher<T, U> {
         match self.active_child {
             Some(ref mut child) => {
                 let size = child.layout(ctx, bc, data, env);
-                child.set_layout_rect(ctx, data, env, size.to_rect());
+                child.set_origin(ctx, data, env, Point::ORIGIN);
                 size
             }
             None => bc.max(),

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -371,9 +371,9 @@ impl<T: Data> Window<T> {
             mouse_pos: self.last_mouse_pos,
         };
         let bc = BoxConstraints::tight(self.size);
-        let size = self.root.layout(&mut layout_ctx, &bc, data, env);
+        self.root.layout(&mut layout_ctx, &bc, data, env);
         self.root
-            .set_layout_rect(&mut layout_ctx, data, env, size.to_rect());
+            .set_origin(&mut layout_ctx, data, env, Point::ORIGIN);
         self.post_event_processing(&mut widget_state, queue, data, env, true);
     }
 


### PR DESCRIPTION
This replaces usages of `WidgetPod::set_layout_rect` by `WidgetPod::set_origin` in all built-in widgets. This means that the layout rect is always left to be determined solely by the child's `layout` method. Only widget not obeying this was `tabs::TabBar`, expanding the minor axis of tab labels to the maximum (so i.e. in the vertical alignment they have the same width). This was replaced by keeping the layout as returned from the child, and expanding the minor axis later in `paint`.