### PR TITLE
Add source data type as param of LensWrap

### DIFF
--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -211,10 +211,6 @@ pub use window::{Window, WindowId};
 #[cfg(test)]
 pub(crate) use event::{StateCell, StateCheckFn};
 
-#[deprecated(since = "0.7.0", note = "use druid::widget::LensWrap instead")]
-#[allow(missing_docs)]
-pub type LensWrap<A, B, C> = widget::LensWrap<A, B, C>;
-
 /// The meaning (mapped value) of a keypress.
 ///
 /// Note that in previous versions, the `KeyCode` field referred to the

--- a/druid/src/widget/lens_wrap.rs
+++ b/druid/src/widget/lens_wrap.rs
@@ -43,28 +43,32 @@ use crate::{Data, Lens};
 /// of a struct field, or some other way of narrowing the scope.
 ///
 /// [`Lens`]: trait.Lens.html
-pub struct LensWrap<U, L, W> {
+pub struct LensWrap<T, U, L, W> {
     inner: W,
     lens: L,
     // The following is a workaround for otherwise getting E0207.
-    phantom: PhantomData<U>,
+    // the 'in' data type of the lens
+    phantom_u: PhantomData<U>,
+    // the 'out' data type of the lens
+    phantom_t: PhantomData<T>,
 }
 
-impl<U, L, W> LensWrap<U, L, W> {
+impl<T, U, L, W> LensWrap<T, U, L, W> {
     /// Wrap a widget with a lens.
     ///
     /// When the lens has type `Lens<T, U>`, the inner widget has data
     /// of type `U`, and the wrapped widget has data of type `T`.
-    pub fn new(inner: W, lens: L) -> LensWrap<U, L, W> {
+    pub fn new(inner: W, lens: L) -> LensWrap<T, U, L, W> {
         LensWrap {
             inner,
             lens,
-            phantom: Default::default(),
+            phantom_u: Default::default(),
+            phantom_t: Default::default(),
         }
     }
 }
 
-impl<T, U, L, W> Widget<T> for LensWrap<U, L, W>
+impl<T, U, L, W> Widget<T> for LensWrap<T, U, L, W>
 where
     T: Data,
     U: Data,

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -215,7 +215,7 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     ///
     /// [`LensWrap`]: struct.LensWrap.html
     /// [`Lens`]: trait.Lens.html
-    fn lens<S: Data, L: Lens<S, T>>(self, lens: L) -> LensWrap<T, L, Self> {
+    fn lens<S: Data, L: Lens<S, T>>(self, lens: L) -> LensWrap<S, T, L, Self> {
         LensWrap::new(self, lens)
     }
 
@@ -316,5 +316,25 @@ mod tests {
         // this should be SizedBox<Slider>
         let widget = Slider::new().fix_height(10.0).fix_width(1.0);
         assert_eq!(widget.width_and_height(), (Some(1.0), Some(10.0)));
+    }
+
+    /// we only care that this will compile; see
+    /// https://github.com/linebender/druid/pull/1414/
+    #[test]
+    fn lens_with_generic_param() {
+        use crate::widget::{Checkbox, Flex, Slider};
+
+        #[derive(Debug, Clone, Data, Lens)]
+        struct MyData<T> {
+            data: T,
+            floatl: f64,
+        }
+
+        #[allow(dead_code)]
+        fn make_widget() -> impl Widget<MyData<bool>> {
+            Flex::row()
+                .with_child(Slider::new().lens(MyData::<bool>::floatl))
+                .with_child(Checkbox::new("checkbox").lens(MyData::<bool>::data))
+        }
     }
 }


### PR DESCRIPTION
This resolves an issue with WidgetExt being unable to appropriately
infer this parameter in certain circumstances. This is illustrated
with the included test case, which fails to compile without this
change.