### PR TITLE
Add theme::UI_FONT_BOLD and theme::UI_FONT_ITALIC

### DIFF
--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -18,7 +18,7 @@
 
 use crate::piet::Color;
 
-use crate::{Env, FontDescriptor, FontFamily, Insets, Key};
+use crate::{Env, FontDescriptor, FontFamily, FontStyle, FontWeight, Insets, Key};
 
 pub const WINDOW_BACKGROUND_COLOR: Key<Color> =
     Key::new("org.linebender.druid.theme.window_background_color");
@@ -53,6 +53,13 @@ pub const BASIC_WIDGET_HEIGHT: Key<f64> =
 
 /// The default font for labels, buttons, text boxes, and other UI elements.
 pub const UI_FONT: Key<FontDescriptor> = Key::new("org.linebender.druid.theme.ui-font");
+
+/// A bold version of the default UI font.
+pub const UI_FONT_BOLD: Key<FontDescriptor> = Key::new("org.linebender.druid.theme.ui-font-bold");
+
+/// An Italic version of the default UI font.
+pub const UI_FONT_ITALIC: Key<FontDescriptor> =
+    Key::new("org.linebender.druid.theme.ui-font-italic");
 
 /// The default minimum width for a 'wide' widget; a textbox, slider, progress bar, etc.
 pub const WIDE_WIDGET_WIDTH: Key<f64> = Key::new("org.linebender.druid.theme.long-widget-width");
@@ -132,6 +139,18 @@ pub(crate) fn add_to_env(env: Env) -> Env {
         .adding(
             UI_FONT,
             FontDescriptor::new(FontFamily::SYSTEM_UI).with_size(15.0),
+        )
+        .adding(
+            UI_FONT_BOLD,
+            FontDescriptor::new(FontFamily::SYSTEM_UI)
+                .with_weight(FontWeight::BOLD)
+                .with_size(15.0),
+        )
+        .adding(
+            UI_FONT_ITALIC,
+            FontDescriptor::new(FontFamily::SYSTEM_UI)
+                .with_style(FontStyle::Italic)
+                .with_size(15.0),
         )
 }
 


### PR DESCRIPTION
had resisted these but it's nice to be able to create a bold/italic font descriptor with the same size as the normal `UI_FONT`.