### PR TITLE
[ci] Reenable clippy for wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,31 +179,30 @@ jobs:
           override: true
 
       # Clippy wasm32 relevant packages in deeper-to-higher dependency order
-      # FIXME: reenable clippy when rustc >= 1.47.1
-      #- name: cargo clippy druid-shell (wasm)
-        #uses: actions-rs/cargo@v1
-        #with:
-          #command: clippy
-          #args: --manifest-path=druid-shell/Cargo.toml --all-targets --target wasm32-unknown-unknown -- -D warnings
+      - name: cargo clippy druid-shell (wasm)
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path=druid-shell/Cargo.toml --all-targets --target wasm32-unknown-unknown -- -D warnings
 
-      #- name: cargo clippy druid (wasm)
-        #uses: actions-rs/cargo@v1
-        #with:
-          #command: clippy
-          ## TODO: Add svg feature when it's no longer broken with wasm
-          #args: --manifest-path=druid/Cargo.toml --all-targets --features=image,im --target wasm32-unknown-unknown -- -D warnings
+      - name: cargo clippy druid (wasm)
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          # TODO: Add svg feature when it's no longer broken with wasm
+          args: --manifest-path=druid/Cargo.toml --all-targets --features=image,im --target wasm32-unknown-unknown -- -D warnings
 
-      #- name: cargo clippy druid-derive (wasm)
-        #uses: actions-rs/cargo@v1
-        #with:
-          #command: clippy
-          #args: --manifest-path=druid-derive/Cargo.toml --all-targets --target wasm32-unknown-unknown -- -D warnings
+      - name: cargo clippy druid-derive (wasm)
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path=druid-derive/Cargo.toml --all-targets --target wasm32-unknown-unknown -- -D warnings
 
-      #- name: cargo clippy book examples (wasm)
-        #uses: actions-rs/cargo@v1
-        #with:
-          #command: clippy
-          #args: --manifest-path=docs/book_examples/Cargo.toml --all-targets --target wasm32-unknown-unknown -- -D warnings
+      - name: cargo clippy book examples (wasm)
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path=docs/book_examples/Cargo.toml --all-targets --target wasm32-unknown-unknown -- -D warnings
 
       # Test wasm32 relevant packages in deeper-to-higher dependency order
       # TODO: Find a way to make tests work. Until then the tests are merely compiled.
@@ -233,21 +232,21 @@ jobs:
           args: --manifest-path=docs/book_examples/Cargo.toml --no-run --target wasm32-unknown-unknown
 
       ## Clippy and build the special druid-web-examples package.
-      #- name: cargo clippy druid-web-examples
-        #uses: actions-rs/cargo@v1
-        #with:
-          #command: clippy
-          #args: --manifest-path=druid/examples/web/Cargo.toml --target wasm32-unknown-unknown -- -D warnings
+      - name: cargo clippy druid-web-examples
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path=druid/examples/web/Cargo.toml --target wasm32-unknown-unknown -- -D warnings
 
       - name: wasm-pack build examples
         run: wasm-pack build --dev --target web druid/examples/web
 
       ## Clippy and build the hello_web example
-      #- name: cargo clippy hello_web example
-        #uses: actions-rs/cargo@v1
-        #with:
-          #command: clippy
-          #args: --manifest-path=druid/examples/hello_web/Cargo.toml --target wasm32-unknown-unknown -- -D warnings
+      - name: cargo clippy hello_web example
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path=druid/examples/hello_web/Cargo.toml --target wasm32-unknown-unknown -- -D warnings
 
       - name: wasm-pack build hello_web example
         run: wasm-pack build --dev --target web druid/examples/hello_web

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -374,7 +374,7 @@ impl WindowBuilder {
     }
 
     pub fn build(self) -> Result<WindowHandle, Error> {
-        let window = web_sys::window().ok_or_else(|| Error::NoWindow)?;
+        let window = web_sys::window().ok_or(Error::NoWindow)?;
         let canvas = window
             .document()
             .ok_or(Error::NoDocument)?

--- a/druid/examples/web/build.rs
+++ b/druid/examples/web/build.rs
@@ -187,7 +187,7 @@ mod examples {
         }
     }
 
-    examples_in.push_str("}");
+    examples_in.push('}');
 
     index_html.push_str("</ul></body></html>");
 

--- a/druid/examples/web/src/lib.rs
+++ b/druid/examples/web/src/lib.rs
@@ -59,6 +59,7 @@ impl_example!(calc);
 impl_example!(cursor);
 impl_example!(custom_widget);
 impl_example!(either);
+impl_example!(event_viewer);
 impl_example!(flex.unwrap());
 impl_example!(game_of_life);
 impl_example!(hello);

--- a/druid/examples/widget_gallery.rs
+++ b/druid/examples/widget_gallery.rs
@@ -20,7 +20,7 @@ use druid::{
         prelude::*, Button, Checkbox, FillStrat, Flex, Image, Label, List, Painter, ProgressBar,
         RadioGroup, Scroll, Slider, Spinner, Stepper, Switch, TextBox,
     },
-    AppLauncher, Color, Data, ImageBuf, Lens, Rect, Widget, WidgetExt, WidgetPod, WindowDesc,
+    AppLauncher, Color, Data, ImageBuf, Lens, Widget, WidgetExt, WidgetPod, WindowDesc,
 };
 
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
This was disabled due to an issue with the previous clippy release
(d367e648).

This also fixes a new clippy lint in the wasm backend.