### PR TITLE
Add a couple of missing with_/set_ methods.

### DIFF
--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -149,6 +149,11 @@ impl<T> TextBox<T> {
         self
     }
 
+    /// Set the `TextBox`'s placeholder text.
+    pub fn set_placeholder(&mut self, placeholder: impl Into<String>) {
+        self.placeholder.set_text(placeholder.into());
+    }
+
     /// Set the text size.
     ///
     /// The argument can be either an `f64` or a [`Key<f64>`].


### PR DESCRIPTION
Most Druid widgets have builder-style with_* methods alongside setter-style set_* methods. I noticed a couple of cases where one or the other was missing and added them.