### PR TITLE
Fix cursor jumping when moving in whitespace at EOL

### DIFF
--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -227,7 +227,10 @@ impl<T: TextStorage + EditableText> TextBox<T> {
     /// Calculate a stateful scroll offset
     fn update_hscroll(&mut self, self_width: f64, env: &Env) {
         let cursor_x = self.editor.cursor_line().p0.x;
-        let overall_text_width = self.editor.layout().size().width;
+        // if the text ends in trailing whitespace, that space is not included
+        // in its reported width, but we need to include it for these calculations.
+        // see https://github.com/linebender/druid/issues/1430
+        let overall_text_width = self.editor.layout().size().width.max(cursor_x);
         let text_insets = env.get(theme::TEXTBOX_INSETS);
 
         //// when advancing the cursor, we want some additional padding


### PR DESCRIPTION
This fixes the issue with the cursor jumping, but does not fix
the underlying problem, which is related to us not providing a
good API for including the whitespace in text width calculations.

see #1430


------

This still has the following weird behaviour, where if you have whitespace at the end of the line and you move the cursor, the line will shrink as if you had deleted text; but I think this is the best current compromise.

![2020-11-26 13 54 28](https://user-images.githubusercontent.com/3330916/100384771-f7bcce80-2fee-11eb-835c-4b1f5360157e.gif)
