### PR TITLE
Expose `request_focus` on `WidgetPod`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - `WidgetPod::is_initialized` to check if a widget has received `WidgetAdded`. ([#1259] by [@finnerale])
 - `TextBox::with_text_alignment` and `TextBox::set_text_alignment` ([#1371] by [@cmyr])
 - Add default minimum size to `WindowConfig`. ([#1438] by [@colinfruit])
+- Expose `request_focus` on `WidgetPod`. ([#????] by [@ForLoveOfCats])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - `WidgetPod::is_initialized` to check if a widget has received `WidgetAdded`. ([#1259] by [@finnerale])
 - `TextBox::with_text_alignment` and `TextBox::set_text_alignment` ([#1371] by [@cmyr])
 - Add default minimum size to `WindowConfig`. ([#1438] by [@colinfruit])
-- Expose `request_focus` on `WidgetPod`. ([#????] by [@ForLoveOfCats])
+- Expose `request_focus` on `WidgetPod`. ([#1445] by [@ForLoveOfCats])
 
 ### Changed
 
@@ -84,6 +84,7 @@ You can find its changes [documented below](#060---2020-06-01).
 - `TextBox` selects all contents when tabbed to on macOS ([#1283] by [@cmyr])
 - All Image formats are now optional, reducing compile time and binary size by default ([#1340] by [@JAicewizard])
 - The `Cursor` API has changed to a stateful one ([#1433] by [@jneem])
+- Handle focus request after sending `WidgetAdded` for changed children. ([#1445] by [@ForLoveOfCats])
 
 ### Deprecated
 
@@ -547,6 +548,7 @@ Last release without a changelog :(
 [#1433]: https://github.com/linebender/druid/pull/1433
 [#1438]: https://github.com/linebender/druid/pull/1438
 [#1441]: https://github.com/linebender/druid/pull/1441
+[#1445]: https://github.com/linebender/druid/pull/1445
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master
 [0.6.0]: https://github.com/linebender/druid/compare/v0.5.0...v0.6.0

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -207,6 +207,17 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
         self.state.is_hot
     }
 
+    /// Request keyboard focus for the contained widget.
+    ///
+    /// See [`EventCtx::is_focused`] for more information about focus.
+    ///
+    /// [`EventCtx::is_focused`]: struct.EventCtx.html#method.is_focused
+    pub fn request_focus(&mut self, ctx: &mut EventCtx) {
+        let id = self.state.id;
+        self.state.request_focus = Some(FocusChange::Focus(id));
+        ctx.widget_state.merge_up(&mut self.state);
+    }
+
     /// Return a reference to the inner widget.
     pub fn widget(&self) -> &W {
         &self.inner


### PR DESCRIPTION
It can be extremely useful to give a widget focus when instancing it. This patch allows that by exposing `request_focus` on `WidgetPod`. It was required to change `Window`'s behavior to handle focus requests after dispatching `WidgetAdded` if prompted to do so by a `children_changed` call otherwise the subject widget would be marked as focused according to `ctx.is_focused()` but would not get keyboard events (in addition to the logged warning).