### PR TITLE
Cursor setting fixups

### DIFF
--- a/druid-shell/src/mouse.rs
+++ b/druid-shell/src/mouse.rs
@@ -279,3 +279,18 @@ impl CursorDesc {
         }
     }
 }
+
+impl std::fmt::Debug for Cursor {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Cursor::Arrow => write!(f, "Cursor::Arrow"),
+            Cursor::IBeam => write!(f, "Cursor::IBeam"),
+            Cursor::Crosshair => write!(f, "Cursor::Crosshair"),
+            Cursor::OpenHand => write!(f, "Cursor::OpenHand"),
+            Cursor::NotAllowed => write!(f, "Cursor::NotAllowed"),
+            Cursor::ResizeLeftRight => write!(f, "Cursor::ResizeLeftRight"),
+            Cursor::ResizeUpDown => write!(f, "Cursor::ResizeUpDown"),
+            Cursor::Custom(_) => write!(f, "Cursor::Custom"),
+        }
+    }
+}

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -248,7 +248,10 @@ impl<T: Data> Window<T> {
 
         if let Some(cursor) = &widget_state.cursor {
             self.handle.set_cursor(&cursor);
-        } else if matches!(event, Event::MouseMove(..)) {
+        } else if matches!(
+            event,
+            Event::MouseMove(..) | Event::Internal(InternalEvent::MouseLeave)
+        ) {
             self.handle.set_cursor(&Cursor::Arrow);
         }
 


### PR DESCRIPTION
This fixes two small issues:

The first is that cursors set in leaf widgets were not being
handled correctly, due to the logic in `merge_up` not being called
on leaves.

The second is that on macOS we were not receiving a MouseMoved
event when we first left the window; we fix this by also explicitly
handling MouseLeave.

cc @jneem 