### PR TITLE
Various image improvements

### DIFF
--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -38,7 +38,7 @@ hdr = ["piet-common/hdr"]
 [dependencies]
 # NOTE: When changing the piet or kurbo versions, ensure that
 #       the kurbo version included in piet is compatible with the kurbo version specified here.
-piet-common = "=0.3.1"
+piet-common = "=0.3.2"
 kurbo = "0.7.1"
 
 log = "0.4.11"
@@ -96,6 +96,6 @@ version = "0.3.44"
 features = ["Window", "MouseEvent", "CssStyleDeclaration", "WheelEvent", "KeyEvent", "KeyboardEvent"]
 
 [dev-dependencies]
-piet-common = { version = "=0.3.1", features = ["png"] }
+piet-common = { version = "=0.3.2", features = ["png"] }
 simple_logger = { version = "1.9.0", default-features = false }
 static_assertions = "1.1.0"

--- a/druid-shell/src/dialog.rs
+++ b/druid-shell/src/dialog.rs
@@ -290,6 +290,7 @@ impl FileSpec {
     pub const TEXT: FileSpec = FileSpec::new("Text", &["txt"]);
     pub const JPG: FileSpec = FileSpec::new("Jpeg", &["jpg", "jpeg"]);
     pub const GIF: FileSpec = FileSpec::new("Gif", &["gif"]);
+    pub const PNG: FileSpec = FileSpec::new("Portable network graphics (png)", &["png"]);
     pub const PDF: FileSpec = FileSpec::new("PDF", &["pdf"]);
     pub const HTML: FileSpec = FileSpec::new("Web Page", &["htm", "html"]);
 

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -36,6 +36,10 @@
 #[cfg(all(target_os = "linux", feature = "gtk"))]
 extern crate gtk_rs as gtk;
 
+// Reexport the version of `image` we are using.
+#[cfg(feature = "image")]
+pub use image;
+
 pub use kurbo;
 pub use piet_common as piet;
 

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -763,7 +763,7 @@ impl WndProc for MyWndProc {
                 Some(0)
             },
             WM_NCCALCSIZE => unsafe {
-                if wparam != 0 as usize && !self.has_titlebar() {
+                if wparam != 0 && !self.has_titlebar() {
                     if let Ok(handle) = self.handle.try_borrow() {
                         if handle.get_window_state() == window::WindowState::MAXIMIZED {
                             // When maximized, windows still adds offsets for the frame

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -76,7 +76,7 @@ console_log = "0.2.0"
 [dev-dependencies]
 float-cmp = { version = "0.8.0", features = ["std"], default-features = false }
 tempfile = "3.1.0"
-piet-common = { version = "=0.3.1", features = ["png"] }
+piet-common = { version = "=0.3.2", features = ["png"] }
 
 [[example]]
 name = "cursor"

--- a/druid/examples/game_of_life.rs
+++ b/druid/examples/game_of_life.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 const GRID_SIZE: usize = 40;
 const POOL_SIZE: usize = GRID_SIZE * GRID_SIZE;
 
-const BG: Color = Color::grey8(23 as u8);
+const BG: Color = Color::grey8(23);
 const C0: Color = Color::from_rgba32_u32(0xEBF1F7);
 const C1: Color = Color::from_rgba32_u32(0xA3FCF7);
 const C2: Color = Color::from_rgba32_u32(0xA2E3D8);
@@ -145,7 +145,7 @@ impl Grid {
                 let n_lives_around = self.n_neighbors(pos);
                 let life = self[pos];
                 // death by loneliness or overcrowding
-                if life && (n_lives_around < 2 || n_lives_around > 3) {
+                if life && !(2..=3).contains(&n_lives_around) {
                     indices_to_mutate.push(pos);
                     continue;
                 }

--- a/druid/src/env.rs
+++ b/druid/src/env.rs
@@ -400,19 +400,19 @@ impl Value {
 
     fn is_same_type(&self, other: &Value) -> bool {
         use Value::*;
-        match (self, other) {
-            (Point(_), Point(_)) => true,
-            (Size(_), Size(_)) => true,
-            (Rect(_), Rect(_)) => true,
-            (Insets(_), Insets(_)) => true,
-            (Color(_), Color(_)) => true,
-            (Float(_), Float(_)) => true,
-            (Bool(_), Bool(_)) => true,
-            (UnsignedInt(_), UnsignedInt(_)) => true,
-            (String(_), String(_)) => true,
-            (Font(_), Font(_)) => true,
-            _ => false,
-        }
+        matches!(
+            (self, other),
+            (Point(_) , Point(_))
+                | (Size(_), Size(_))
+                | (Rect(_), Rect(_))
+                | (Insets(_), Insets(_))
+                | (Color(_), Color(_))
+                | (Float(_), Float(_))
+                | (Bool(_), Bool(_))
+                | (UnsignedInt(_), UnsignedInt(_))
+                | (String(_), String(_))
+                | (Font(_), Font(_))
+        )
     }
 }
 

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -180,6 +180,8 @@ pub use piet::{
     RenderContext, TextAlignment, UnitPoint,
 };
 // these are the types from shell that we expose; others we only use internally.
+#[cfg(feature = "image")]
+pub use shell::image;
 pub use shell::keyboard_types;
 pub use shell::{
     Application, Clipboard, ClipboardFormat, Code, Cursor, CursorDesc, Error as PlatformError,

--- a/druid/src/tests/helpers.rs
+++ b/druid/src/tests/helpers.rs
@@ -272,11 +272,10 @@ impl<T: Data, W: Widget<T>> Widget<T> for Recorder<W> {
     }
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
-        let should_record = match event {
-            LifeCycle::Internal(InternalLifeCycle::DebugRequestState { .. }) => false,
-            LifeCycle::Internal(InternalLifeCycle::DebugInspectState(_)) => false,
-            _ => true,
-        };
+        let should_record = !matches!(event,
+            LifeCycle::Internal(InternalLifeCycle::DebugRequestState { .. }) |
+            LifeCycle::Internal(InternalLifeCycle::DebugInspectState(_))
+        );
 
         if should_record {
             self.recording.push(Record::L(event.clone()));

--- a/druid/src/widget/image.rs
+++ b/druid/src/widget/image.rs
@@ -17,7 +17,7 @@
 
 use crate::{
     kurbo::Rect,
-    piet::{ImageBuf, InterpolationMode, PietImage},
+    piet::{Image as _, ImageBuf, InterpolationMode, PietImage},
     widget::common::FillStrat,
     widget::prelude::*,
     Data,
@@ -205,7 +205,17 @@ impl<T: Data> Widget<T> for Image {
             ctx.clip(clip_rect);
         }
 
+        let piet_image = {
+            let image_data = &self.image_data;
+            self.paint_data
+                .get_or_insert_with(|| image_data.to_image(ctx.render_ctx))
+        };
+        if piet_image.size().is_empty() {
+            // zero-sized image = nothing to draw
+            return;
+        }
         ctx.with_save(|ctx| {
+            // we have to re-do this because the whole struct is moved into the closure.
             let piet_image = {
                 let image_data = &self.image_data;
                 self.paint_data

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -75,7 +75,7 @@ impl<T> Split<T> {
     /// The default split point is `0.5`.
     pub fn split_point(mut self, split_point: f64) -> Self {
         assert!(
-            split_point >= 0.0 && split_point <= 1.0,
+            (0.0..=1.0).contains(&split_point),
             "split_point must be in the range [0.0-1.0]!"
         );
         self.split_point_chosen = split_point;


### PR DESCRIPTION
Currently blocked on a new release of piet.

This patch adds 3 features:

 1. Allow the user to specify a subrectangle of an image to display.
 2. Add a `Send + Sync` bound to `dyn Error`s from `image`. This means that, for example, you can load an image on a dedicated IO thread, and pass the error back to the UI thread.
 3. Improve support for rendering svg images in the `Svg` widget.

This allows, for example, a sprite sheet to be shared between multiple `Image` widgets. It also allows my motivating use case, which is an image viewer where the user can zoom in on part of the image.

I've made the changes so they are backwards compatible.

Update: this patch is growing a bit, but each commit is completely disjoint and can be reviewed/accepted separately.

Note: edited heavily.