### PR TITLE
Account for viewport_offset in children's LayoutCtx::mouse_pos

### DIFF
--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -537,7 +537,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         self.state.is_expecting_set_origin_call = true;
 
         let child_mouse_pos = match ctx.mouse_pos {
-            Some(pos) => Some(pos - self.layout_rect().origin().to_vec2()),
+            Some(pos) => Some(pos - self.layout_rect().origin().to_vec2() + self.viewport_offset()),
             None => None,
         };
         let prev_size = self.state.size;


### PR DESCRIPTION
`viewport_offset` needs to be included into the mouse position also in `WidgetPod::layout`. Fixes glitches, i.e. when some widgets inside `Scroll` are hot, with mouse hovering, and then an external layout pass switches them to cold because `WidgetPod::set_origin` thinks they have moved.