### PR TITLE
Add serde feature, and enable `im/serde` when active.

### DIFF
--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -26,6 +26,7 @@ image = ["druid-shell/image"]
 svg = ["usvg", "harfbuzz-sys"]
 x11 = ["druid-shell/x11"]
 crochet = []
+serde = ["im/serde"]
 
 # passing on all the image features. AVIF is not supported because it does not
 # support decoding, and that's all we use `Image` for.


### PR DESCRIPTION
This means that a user can (de)serialize im data structures using serde.

Closes #1476.