### PR TITLE
Add `Sync + Send` bounds to `dyn Error` from image.

### DIFF
--- a/druid-shell/src/image.rs
+++ b/druid-shell/src/image.rs
@@ -202,7 +202,7 @@ impl ImageBuf {
     }
 
     /// Attempt to load an image from the file at the provided path.
-    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<ImageBuf, Box<dyn Error>> {
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<ImageBuf, Box<dyn Error + Send + Sync>> {
         let image_data = image::open(path).map_err(|e| e)?;
         Ok(ImageBuf::from_dynamic_image(image_data))
     }


### PR DESCRIPTION
Follow on from https://github.com/linebender/druid/pull/1481.

Very sorry, I missed one of the functions. This PR makes sure all type-erased errors from `image` are annotated `Send + Sync`.