### PR TITLE
Add widget wrapper and implementation macros.

### DIFF
--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -207,16 +207,6 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
         self.state.is_hot
     }
 
-    /// Return a reference to the inner widget.
-    pub fn widget(&self) -> &W {
-        &self.inner
-    }
-
-    /// Return a mutable reference to the inner widget.
-    pub fn widget_mut(&mut self) -> &mut W {
-        &mut self.inner
-    }
-
     /// Get the identity of the widget.
     pub fn id(&self) -> WidgetId {
         self.state.id
@@ -1017,6 +1007,18 @@ impl<T, W: Widget<T> + 'static> WidgetPod<T, W> {
     /// into a dynamically boxed widget.
     pub fn boxed(self) -> WidgetPod<T, Box<dyn Widget<T>>> {
         WidgetPod::new(Box::new(self.inner))
+    }
+}
+
+impl<T, W> WidgetPod<T, W> {
+    /// Return a reference to the inner widget.
+    pub fn widget(&self) -> &W {
+        &self.inner
+    }
+
+    /// Return a mutable reference to the inner widget.
+    pub fn widget_mut(&mut self) -> &mut W {
+        &mut self.inner
     }
 }
 

--- a/druid/src/widget/controller.rs
+++ b/druid/src/widget/controller.rs
@@ -15,6 +15,7 @@
 //! A widget-controlling widget.
 
 use crate::widget::prelude::*;
+use crate::widget::WidgetWrapper;
 
 /// A trait for types that modify behaviour of a child widget.
 ///
@@ -132,4 +133,8 @@ impl<T, W: Widget<T>, C: Controller<T, W>> Widget<T> for ControllerHost<W, C> {
     fn id(&self) -> Option<WidgetId> {
         self.widget.id()
     }
+}
+
+impl<W, C> WidgetWrapper for ControllerHost<W, C> {
+    widget_wrapper_body!(W, widget);
 }

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -15,6 +15,7 @@
 //! A widget that accepts a closure to update the environment for its child.
 
 use crate::widget::prelude::*;
+use crate::widget::WidgetWrapper;
 use crate::{Data, Point, WidgetPod};
 
 /// A widget that accepts a closure to update the environment for its child.
@@ -93,4 +94,8 @@ impl<T: Data, W: Widget<T>> Widget<T> for EnvScope<T, W> {
 
         self.child.paint(ctx, data, &new_env);
     }
+}
+
+impl<T, W: Widget<T>> WidgetWrapper for EnvScope<T, W> {
+    widget_wrapper_pod_body!(W, child);
 }

--- a/druid/src/widget/identity_wrapper.rs
+++ b/druid/src/widget/identity_wrapper.rs
@@ -14,7 +14,9 @@
 
 //! A widget that provides an explicit identity to a child.
 
+use crate::kurbo::Size;
 use crate::widget::prelude::*;
+use crate::widget::WidgetWrapper;
 use crate::Data;
 
 /// A wrapper that adds an identity to an otherwise anonymous widget.
@@ -54,4 +56,8 @@ impl<T: Data, W: Widget<T>> Widget<T> for IdentityWrapper<W> {
     fn id(&self) -> Option<WidgetId> {
         Some(self.id)
     }
+}
+
+impl<W> WidgetWrapper for IdentityWrapper<W> {
+    widget_wrapper_body!(W, inner);
 }

--- a/druid/src/widget/lens_wrap.rs
+++ b/druid/src/widget/lens_wrap.rs
@@ -21,6 +21,7 @@
 use std::marker::PhantomData;
 
 use crate::widget::prelude::*;
+use crate::widget::WidgetWrapper;
 use crate::{Data, Lens};
 
 /// A wrapper for its widget subtree to have access to a part
@@ -113,4 +114,8 @@ where
     fn id(&self) -> Option<WidgetId> {
         self.inner.id()
     }
+}
+
+impl<T, U, L, W> WidgetWrapper for LensWrap<T, U, L, W> {
+    widget_wrapper_body!(W, inner);
 }

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -14,6 +14,10 @@
 
 //! Common widgets.
 
+// First as it defines macros
+#[macro_use]
+mod widget_wrapper;
+
 mod align;
 mod button;
 mod checkbox;
@@ -92,6 +96,7 @@ pub use view_switcher::ViewSwitcher;
 pub use widget::{Widget, WidgetId};
 #[doc(hidden)]
 pub use widget_ext::WidgetExt;
+pub use widget_wrapper::WidgetWrapper;
 
 /// The types required to implement a `Widget`.
 ///

--- a/druid/src/widget/scope.rs
+++ b/druid/src/widget/scope.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::widget::prelude::*;
+use crate::widget::WidgetWrapper;
 use crate::{Data, Lens, Point, WidgetPod};
 
 /// A policy that controls how a [`Scope`] will interact with its surrounding
@@ -300,4 +301,8 @@ impl<SP: ScopePolicy, W: Widget<SP::State>> Widget<SP::In> for Scope<SP, W> {
     fn paint(&mut self, ctx: &mut PaintCtx, data: &SP::In, env: &Env) {
         self.with_state(data, |state, inner| inner.paint_raw(ctx, state, env));
     }
+}
+
+impl<SP: ScopePolicy, W: Widget<SP::State>> WidgetWrapper for Scope<SP, W> {
+    widget_wrapper_pod_body!(W, inner);
 }

--- a/druid/src/widget/widget_wrapper.rs
+++ b/druid/src/widget/widget_wrapper.rs
@@ -1,0 +1,47 @@
+/// A trait for widgets that wrap a single child to expose that child for access and mutation
+pub trait WidgetWrapper {
+    /// The type of the wrapped widget.
+    /// Maybe we would like to constrain this to Widget<impl Data> (if existential bounds were supported).
+    /// Any other scheme leads to T being unconstrained in unification at some point
+    type Wrapped;
+    /// Get immutable access to the wrapped child
+    fn wrapped(&self) -> &Self::Wrapped;
+    /// Get mutable access to the wrapped child
+    fn wrapped_mut(&mut self) -> &mut Self::Wrapped;
+}
+
+/// A macro to help implementation of WidgetWrapper for a direct wrapper.
+/// Use it in the body of the impl.
+///
+#[macro_export]
+macro_rules! widget_wrapper_body {
+    ($wrapped:ty, $field:ident) => {
+        type Wrapped = $wrapped;
+
+        fn wrapped(&self) -> &Self::Wrapped {
+            &self.$field
+        }
+
+        fn wrapped_mut(&mut self) -> &mut Self::Wrapped {
+            &mut self.$field
+        }
+    };
+}
+
+/// A macro to help implementation of WidgetWrapper for a wrapper of a typed pod.
+/// Use it in the body of the impl.
+///
+#[macro_export]
+macro_rules! widget_wrapper_pod_body {
+    ($wrapped:ty, $field:ident) => {
+        type Wrapped = $wrapped;
+
+        fn wrapped(&self) -> &Self::Wrapped {
+            self.$field.widget()
+        }
+
+        fn wrapped_mut(&mut self) -> &mut Self::Wrapped {
+            self.$field.widget_mut()
+        }
+    };
+}


### PR DESCRIPTION
To support bindings and other cases where access and mutation of existing widgets is desired.

Note (can be ignored): 

It is quite involved to actually make use of this access and mutation in the way you would expect (e.g changing a font of a label by clicking a button - the font not being in the data argument but rather a member variable of the label).
 
This is because of the ownership of widgets in druid. Widgets that are in scope during construction can't be directly fiddled with (e.g in onclick) because they will have moved by the time any events are processed. Effectively you need to send a command up to some parent, and it needs to navigate down to the thing it needs to change. This is not particularly succinct and theres no obvious mapping between the lexical name of the widget as you've constructed it, and the navigation you need to do. 
 
That is what BindingHost in druid_bindings does - decouples this by pushing changes up into app data, and then down from app data into member variables. 