### PR TITLE
Made 'set_level' available from WindowDesc

### DIFF
--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -428,6 +428,14 @@ impl<T: Data> WindowDesc<T> {
         self
     }
 
+    /// Sets the [`WindowLevel`] of the window
+    ///
+    /// [`WindowLevel`]: enum.WindowLevel.html
+    pub fn set_level(mut self, level: WindowLevel) -> Self {
+        self.config = self.config.set_level(level);
+        self
+    }
+
     /// Set initial state for the window.
     pub fn set_window_state(mut self, state: WindowState) -> Self {
         self.config = self.config.set_window_state(state);


### PR DESCRIPTION
There is no simple way of setting the WindowLevel prior to creation for a window.
This would allows tiling window managers like i3 to see the _NET_WM_WINDOW_TYPE_DIALOG flag on window creation
and mark the window as floating.
Since all other options of WindowConfig are exposed in WindowDesc, this seems like an oversight. :)