### PR TITLE
[ci] Pin tempfile to 0.3.1

### DIFF
--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -75,7 +75,8 @@ console_log = "0.2.0"
 
 [dev-dependencies]
 float-cmp = { version = "0.8.0", features = ["std"], default-features = false }
-tempfile = "3.1.0"
+# tempfile 3.2.0 broke wasm; I assume it will be yanked (Jan 12, 2021)
+tempfile = "=3.1.0"
 piet-common = { version = "=0.3.2", features = ["png"] }
 pulldown-cmark = { version = "0.8", default-features = false }
 


### PR DESCRIPTION
0.3.2 was breaking our wasm build in CI; this is a temporary fix.