### PR TITLE
Subwindow updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ You can find its changes [documented below](#070---2021-01-01).
 - RichTextBuilder ([#1520] by [@Maan2003])
 - `get_external_handle` on `DelegateCtx` ([#1526] by [@Maan2003])
 - `AppLauncher::localization_resources` to use custom l10n resources. ([#1528] by [@edwin0cheng])
+- Shell: get_content_insets and mac implementation ([#XXXX] by [@rjwittams])
+- Contexts: to_window and to_screen (useful for relatively positioning sub windows) ([#XXXX] by [@rjwittams])
+- WindowSizePolicy: allow windows to be sized by their content ([#XXXX] by [@rjwittams])
 
 ### Changed
 

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -818,8 +818,8 @@ impl WindowHandle {
         }
     }
 
-    pub fn get_content_insets(&self) -> Insets {
-        log::warn!("WindowHandle::get_content_insets unimplemented for GTK platforms.");
+    pub fn content_insets(&self) -> Insets {
+        log::warn!("WindowHandle::content_insets unimplemented for GTK platforms.");
         Insets::ZERO
     }
 

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -32,7 +32,7 @@ use gio::ApplicationExt;
 use gtk::prelude::*;
 use gtk::{AccelGroup, ApplicationWindow, DrawingArea, SettingsExt};
 
-use crate::kurbo::{Point, Rect, Size, Vec2};
+use crate::kurbo::{Insets, Point, Rect, Size, Vec2};
 use crate::piet::{Piet, PietText, RenderContext};
 
 use crate::common_util::{ClickCounter, IdleCallback};
@@ -816,6 +816,11 @@ impl WindowHandle {
         } else {
             Point::new(0.0, 0.0)
         }
+    }
+
+    pub fn get_content_insets(&self) -> Insets {
+        log::warn!("WindowHandle::get_content_insets unimplemented for GTK platforms.");
+        Insets::ZERO
     }
 
     pub fn set_level(&self, level: WindowLevel) {

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -785,8 +785,6 @@ fn set_size_deferred(this: &mut Object, _view_state: &mut ViewState, size: Size)
 
 fn set_position_deferred(this: &mut Object, _view_state: &mut ViewState, position: Point) {
     unsafe {
-
-
         let window: id = msg_send![this, window];
         let frame: NSRect = msg_send![window, frame];
 
@@ -1071,7 +1069,7 @@ impl WindowHandle {
         }
     }
 
-    pub fn get_content_insets(&self) -> Insets {
+    pub fn content_insets(&self) -> Insets {
         unsafe {
             let screen_height = crate::Screen::get_display_rect().height();
 

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -40,7 +40,7 @@ use objc::rc::WeakPtr;
 use objc::runtime::{Class, Object, Sel};
 use objc::{class, msg_send, sel, sel_impl};
 
-use crate::kurbo::{Point, Rect, Size, Vec2};
+use crate::kurbo::{Insets, Point, Rect, Size, Vec2};
 use crate::piet::{Piet, PietText, RenderContext};
 
 use super::appkit::{
@@ -127,10 +127,17 @@ pub(crate) struct IdleHandle {
     idle_queue: Weak<Mutex<Vec<IdleKind>>>,
 }
 
+#[derive(Debug)]
+enum DeferredOp {
+    SetSize(Size),
+    SetPosition(Point),
+}
+
 /// This represents different Idle Callback Mechanism
 enum IdleKind {
     Callback(Box<dyn IdleCallback>),
     Token(IdleToken),
+    DeferredOp(DeferredOp),
 }
 
 /// This is the state associated with our custom NSView.
@@ -156,7 +163,7 @@ impl WindowBuilder {
             handler: None,
             title: String::new(),
             menu: None,
-            size: Size::new(500.0, 400.0),
+            size: Size::new(0., 0.),
             min_size: None,
             position: None,
             level: None,
@@ -220,10 +227,11 @@ impl WindowBuilder {
                 style_mask |= NSWindowStyleMask::NSResizableWindowMask;
             }
 
-            let rect = NSRect::new(
-                NSPoint::new(0., 0.),
-                NSSize::new(self.size.width, self.size.height),
-            );
+            let screen_height = crate::Screen::get_display_rect().height();
+            let position = self.position.unwrap_or_else(|| Point::new(20., 20.));
+            let origin = NSPoint::new(position.x, screen_height - position.y - self.size.height); // Flip back
+
+            let rect = NSRect::new(origin, NSSize::new(self.size.width, self.size.height));
 
             let window: id = msg_send![WINDOW_CLASS.0, alloc];
             let window = window.initWithContentRect_styleMask_backing_defer_(
@@ -238,7 +246,6 @@ impl WindowBuilder {
                 window.setContentMinSize_(size);
             }
 
-            window.cascadeTopLeftFromPoint_(NSPoint::new(20.0, 20.0));
             window.setTitle_(make_nsstring(&self.title));
 
             let (view, idle_queue) = make_view(self.handler.expect("view"));
@@ -260,9 +267,6 @@ impl WindowBuilder {
                 idle_queue,
             };
 
-            if let Some(pos) = self.position {
-                handle.set_position(pos);
-            }
             if let Some(window_state) = self.window_state {
                 handle.set_window_state(window_state);
             }
@@ -758,6 +762,43 @@ extern "C" fn draw_rect(this: &mut Object, _: Sel, dirtyRect: NSRect) {
     }
 }
 
+fn run_deferred(this: &mut Object, view_state: &mut ViewState, op: DeferredOp) {
+    match op {
+        DeferredOp::SetSize(size) => set_size_deferred(this, view_state, size),
+        DeferredOp::SetPosition(pos) => set_position_deferred(this, view_state, pos),
+    }
+}
+
+fn set_size_deferred(this: &mut Object, _view_state: &mut ViewState, size: Size) {
+    unsafe {
+        let window: id = msg_send![this, window];
+        let current_frame: NSRect = msg_send![window, frame];
+        let mut new_frame = current_frame;
+
+        // TODO: maintain druid origin (as mac origin is bottom left)
+        new_frame.origin.y -= size.height - current_frame.size.height;
+        new_frame.size.width = size.width;
+        new_frame.size.height = size.height;
+        let () = msg_send![window, setFrame: new_frame display: YES];
+    }
+}
+
+fn set_position_deferred(this: &mut Object, _view_state: &mut ViewState, position: Point) {
+    unsafe {
+        // TODO this should be the max y in orig mac coords
+
+        let window: id = msg_send![this, window];
+        let frame: NSRect = msg_send![window, frame];
+
+        let mut new_frame = frame;
+        new_frame.origin.x = position.x;
+        let screen_height = crate::Screen::get_display_rect().height();
+        new_frame.origin.y = screen_height - position.y - frame.size.height; // Flip back
+        let () = msg_send![window, setFrame: new_frame display: YES];
+        log::debug!("set_position_deferred {:?}", position);
+    }
+}
+
 extern "C" fn run_idle(this: &mut Object, _: Sel) {
     let view_state = unsafe {
         let view_state: *mut c_void = *this.get_ivar("viewState");
@@ -773,6 +814,7 @@ extern "C" fn run_idle(this: &mut Object, _: Sel) {
             IdleKind::Token(it) => {
                 view_state.handler.as_mut().idle(it);
             }
+            IdleKind::DeferredOp(op) => run_deferred(this, view_state, op),
         }
     }
 }
@@ -1005,17 +1047,7 @@ impl WindowHandle {
 
     // Need to translate mac y coords, as they start from bottom left
     pub fn set_position(&self, position: Point) {
-        unsafe {
-            // TODO this should be the max y in orig mac coords
-            let screen_height = crate::Screen::get_display_rect().height();
-            let window: id = msg_send![*self.nsview.load(), window];
-            let frame: NSRect = msg_send![window, frame];
-
-            let mut new_frame = frame;
-            new_frame.origin.x = position.x;
-            new_frame.origin.y = screen_height - position.y - frame.size.height; // Flip back
-            let () = msg_send![window, setFrame: new_frame display: YES];
-        }
+        self.defer(DeferredOp::SetPosition(position))
     }
 
     pub fn get_position(&self) -> Point {
@@ -1033,6 +1065,34 @@ impl WindowHandle {
         }
     }
 
+    pub fn get_content_insets(&self) -> Insets {
+        unsafe {
+            let screen_height = crate::Screen::get_display_rect().height();
+
+            let window: id = msg_send![*self.nsview.load(), window];
+            let clr: NSRect = msg_send![window, contentLayoutRect];
+
+            let window_frame_r: NSRect = NSWindow::frame(window);
+            let content_frame_r: NSRect = NSWindow::convertRectToScreen_(window, clr);
+
+            let window_frame_rk = Rect::from_origin_size(
+                (
+                    window_frame_r.origin.x,
+                    screen_height - window_frame_r.origin.y - window_frame_r.size.height,
+                ),
+                (window_frame_r.size.width, window_frame_r.size.height),
+            );
+            let content_frame_rk = Rect::from_origin_size(
+                (
+                    content_frame_r.origin.x,
+                    screen_height - content_frame_r.origin.y - content_frame_r.size.height,
+                ),
+                (content_frame_r.size.width, content_frame_r.size.height),
+            );
+            window_frame_rk - content_frame_rk
+        }
+    }
+
     pub fn set_level(&self, level: WindowLevel) {
         unsafe {
             let level = levels::as_raw_window_level(level);
@@ -1042,14 +1102,7 @@ impl WindowHandle {
     }
 
     pub fn set_size(&self, size: Size) {
-        unsafe {
-            let window: id = msg_send![*self.nsview.load(), window];
-            let current_frame: NSRect = msg_send![window, frame];
-            let mut new_frame = current_frame;
-            new_frame.size.width = size.width;
-            new_frame.size.height = size.height;
-            let () = msg_send![window, setFrame: new_frame display: YES];
-        }
+        self.defer(DeferredOp::SetSize(size));
     }
 
     pub fn get_size(&self) -> Size {
@@ -1132,6 +1185,12 @@ impl WindowHandle {
         }
     }
 
+    fn defer(&self, op: DeferredOp) {
+        if let Some(i) = self.get_idle_handle() {
+            i.add_idle(IdleKind::DeferredOp(op))
+        }
+    }
+
     /// Get a handle that can be used to schedule an idle task.
     pub fn get_idle_handle(&self) -> Option<IdleHandle> {
         if self.nsview.load().is_null() {
@@ -1154,6 +1213,21 @@ impl WindowHandle {
 unsafe impl Send for IdleHandle {}
 
 impl IdleHandle {
+    fn add_idle(&self, idle: IdleKind) {
+        if let Some(queue) = self.idle_queue.upgrade() {
+            let mut queue = queue.lock().expect("queue lock");
+            if queue.is_empty() {
+                unsafe {
+                    let nsview = self.nsview.load();
+                    // Note: the nsview might be nil here if the window has been dropped, but that's ok.
+                    let () = msg_send!(*nsview, performSelectorOnMainThread: sel!(runIdle)
+                        withObject: nil waitUntilDone: NO);
+                }
+            }
+            queue.push(idle);
+        }
+    }
+
     /// Add an idle handler, which is called (once) when the message loop
     /// is empty. The idle handler will be run from the main UI thread, and
     /// won't be scheduled if the associated view has been dropped.
@@ -1164,33 +1238,11 @@ impl IdleHandle {
     where
         F: FnOnce(&dyn Any) + Send + 'static,
     {
-        if let Some(queue) = self.idle_queue.upgrade() {
-            let mut queue = queue.lock().expect("queue lock");
-            if queue.is_empty() {
-                unsafe {
-                    let nsview = self.nsview.load();
-                    // Note: the nsview might be nil here if the window has been dropped, but that's ok.
-                    let () = msg_send!(*nsview, performSelectorOnMainThread: sel!(runIdle)
-                        withObject: nil waitUntilDone: NO);
-                }
-            }
-            queue.push(IdleKind::Callback(Box::new(callback)));
-        }
+        self.add_idle(IdleKind::Callback(Box::new(callback)));
     }
 
     pub fn add_idle_token(&self, token: IdleToken) {
-        if let Some(queue) = self.idle_queue.upgrade() {
-            let mut queue = queue.lock().expect("queue lock");
-            if queue.is_empty() {
-                unsafe {
-                    let nsview = self.nsview.load();
-                    // Note: the nsview might be nil here if the window has been dropped, but that's ok.
-                    let () = msg_send!(*nsview, performSelectorOnMainThread: sel!(runIdle)
-                        withObject: nil waitUntilDone: NO);
-                }
-            }
-            queue.push(IdleKind::Token(token));
-        }
+        self.add_idle(IdleKind::Token(token));
     }
 }
 

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -775,7 +775,7 @@ fn set_size_deferred(this: &mut Object, _view_state: &mut ViewState, size: Size)
         let current_frame: NSRect = msg_send![window, frame];
         let mut new_frame = current_frame;
 
-        // TODO: maintain druid origin (as mac origin is bottom left)
+        // maintain druid origin (as mac origin is bottom left)
         new_frame.origin.y -= size.height - current_frame.size.height;
         new_frame.size.width = size.width;
         new_frame.size.height = size.height;
@@ -785,13 +785,19 @@ fn set_size_deferred(this: &mut Object, _view_state: &mut ViewState, size: Size)
 
 fn set_position_deferred(this: &mut Object, _view_state: &mut ViewState, position: Point) {
     unsafe {
-        // TODO this should be the max y in orig mac coords
+
 
         let window: id = msg_send![this, window];
         let frame: NSRect = msg_send![window, frame];
 
         let mut new_frame = frame;
         new_frame.origin.x = position.x;
+        // TODO Everywhere we use the height for flipping around y it should be the max y in orig mac coords.
+        // Need to set up a 3 screen config to test in this arrangement.
+        // 3
+        // 1
+        // 2
+
         let screen_height = crate::Screen::get_display_rect().height();
         new_frame.origin.y = screen_height - position.y - frame.size.height; // Flip back
         let () = msg_send![window, setFrame: new_frame display: YES];

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -25,7 +25,7 @@ use instant::Instant;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
-use crate::kurbo::{Point, Rect, Size, Vec2};
+use crate::kurbo::{Insets, Point, Rect, Size, Vec2};
 
 use crate::piet::{PietText, RenderContext};
 
@@ -475,6 +475,11 @@ impl WindowHandle {
     pub fn get_size(&self) -> Size {
         log::warn!("WindowHandle::get_size unimplemented for web.");
         Size::new(0.0, 0.0)
+    }
+
+    pub fn get_content_insets(&self) -> Insets {
+        log::warn!("WindowHandle::get_content_insets unimplemented for web.");
+        Insets::ZERO
     }
 
     pub fn set_window_state(&self, _state: window::WindowState) {

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -477,8 +477,8 @@ impl WindowHandle {
         Size::new(0.0, 0.0)
     }
 
-    pub fn get_content_insets(&self) -> Insets {
-        log::warn!("WindowHandle::get_content_insets unimplemented for web.");
+    pub fn content_insets(&self) -> Insets {
+        log::warn!("WindowHandle::content_insets unimplemented for web.");
         Insets::ZERO
     }
 

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -1657,8 +1657,8 @@ impl WindowHandle {
         Point::new(0.0, 0.0)
     }
 
-    pub fn get_content_insets(&self) -> Insets {
-        log::warn!("WindowHandle::get_content_insets unimplemented for windows.");
+    pub fn content_insets(&self) -> Insets {
+        log::warn!("WindowHandle::content_insets unimplemented for windows.");
         Insets::ZERO
     }
 

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -47,7 +47,7 @@ use winapi::um::winuser::*;
 use piet_common::d2d::{D2DFactory, DeviceContext};
 use piet_common::dwrite::DwriteFactory;
 
-use crate::kurbo::{Point, Rect, Size, Vec2};
+use crate::kurbo::{Insets, Point, Rect, Size, Vec2};
 use crate::piet::{Piet, PietText, RenderContext};
 
 use super::accels::register_accel;
@@ -1655,6 +1655,11 @@ impl WindowHandle {
             }
         }
         Point::new(0.0, 0.0)
+    }
+
+    pub fn get_content_insets(&self) -> Insets {
+        log::warn!("WindowHandle::get_content_insets unimplemented for windows.");
+        Insets::ZERO
     }
 
     // Sets the size of the window in DP

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -1404,8 +1404,8 @@ impl WindowHandle {
         Point::new(0.0, 0.0)
     }
 
-    pub fn get_content_insets(&self) -> Insets {
-        log::warn!("WindowHandle::get_content_insets unimplemented for X11 platforms.");
+    pub fn content_insets(&self) -> Insets {
+        log::warn!("WindowHandle::content_insets unimplemented for X11 platforms.");
         Insets::ZERO
     }
 

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -41,7 +41,7 @@ use crate::common_util::IdleCallback;
 use crate::dialog::FileDialogOptions;
 use crate::error::Error as ShellError;
 use crate::keyboard::{KeyEvent, KeyState, Modifiers};
-use crate::kurbo::{Point, Rect, Size, Vec2};
+use crate::kurbo::{Insets, Point, Rect, Size, Vec2};
 use crate::mouse::{Cursor, CursorDesc, MouseButton, MouseButtons, MouseEvent};
 use crate::piet::{Piet, PietText, RenderContext};
 use crate::region::Region;
@@ -1402,6 +1402,11 @@ impl WindowHandle {
     pub fn get_position(&self) -> Point {
         log::warn!("WindowHandle::get_position is currently unimplemented for X11 platforms.");
         Point::new(0.0, 0.0)
+    }
+
+    pub fn get_content_insets(&self) -> Insets {
+        log::warn!("WindowHandle::get_content_insets unimplemented for X11 platforms.");
+        Insets::ZERO
     }
 
     pub fn set_level(&self, _level: WindowLevel) {

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -203,8 +203,8 @@ impl WindowHandle {
     /// Returns the insets of the window content from its position and size in [pixels](crate::Scale).
     ///
     /// This is to account for any window system provided chrome, eg. title bars.
-    pub fn get_content_insets(&self) -> Insets {
-        self.0.get_content_insets()
+    pub fn content_insets(&self) -> Insets {
+        self.0.content_insets()
     }
 
     /// Set the window's size in [display points](crate::Scale).

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -22,7 +22,7 @@ use crate::common_util::Counter;
 use crate::dialog::{FileDialogOptions, FileInfo};
 use crate::error::Error;
 use crate::keyboard::KeyEvent;
-use crate::kurbo::{Point, Rect, Size};
+use crate::kurbo::{Insets, Point, Rect, Size};
 use crate::menu::Menu;
 use crate::mouse::{Cursor, CursorDesc, MouseEvent};
 use crate::platform::window as platform;
@@ -194,10 +194,16 @@ impl WindowHandle {
         self.0.set_position(position.into())
     }
 
-    /// Returns the position of the window in [pixels](crate::Scale), relative to the origin of the
+    /// Returns the position of the top left corner of the window in [pixels](crate::Scale), relative to the origin of the
     /// virtual screen.
     pub fn get_position(&self) -> Point {
         self.0.get_position()
+    }
+
+    /// Returns the insets of the window content from its position and size in [pixels](crate::Scale).
+    /// This is to account for any window system provided chrome, eg. title bars.
+    pub fn get_content_insets(&self) -> Insets {
+        self.0.get_content_insets()
     }
 
     /// Set the window's size in [display points](crate::Scale).

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -201,6 +201,7 @@ impl WindowHandle {
     }
 
     /// Returns the insets of the window content from its position and size in [pixels](crate::Scale).
+    ///
     /// This is to account for any window system provided chrome, eg. title bars.
     pub fn get_content_insets(&self) -> Insets {
         self.0.get_content_insets()

--- a/druid/examples/hello.rs
+++ b/druid/examples/hello.rs
@@ -40,6 +40,7 @@ pub fn main() {
 
     // start the application
     AppLauncher::with_window(main_window)
+        .use_simple_logger()
         .launch(initial_state)
         .expect("Failed to launch application");
 }

--- a/druid/examples/sub_window.rs
+++ b/druid/examples/sub_window.rs
@@ -20,7 +20,7 @@ use druid::widget::{
 use druid::{
     theme, Affine, AppLauncher, BoxConstraints, Color, Data, Env, Event, EventCtx, LayoutCtx, Lens,
     LensExt, LifeCycle, LifeCycleCtx, LocalizedString, PaintCtx, Point, Rect, RenderContext, Size,
-    TimerToken, UpdateCtx, Widget, WidgetExt, WindowConfig, WindowDesc, WindowId,
+    TimerToken, UpdateCtx, Widget, WidgetExt, WindowConfig, WindowDesc, WindowId, WindowSizePolicy,
 };
 use druid_shell::piet::Text;
 use druid_shell::{Screen, WindowLevel};
@@ -141,7 +141,7 @@ impl<T, W: Widget<T>> Controller<T, W> for TooltipController {
                         let win_id = ctx.new_sub_window(
                             WindowConfig::default()
                                 .show_titlebar(false)
-                                .window_size(Size::new(100.0, 23.0))
+                                .window_size_policy(WindowSizePolicy::Content)
                                 .set_level(WindowLevel::Tooltip)
                                 .set_position(
                                     ctx.window().get_position()

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -39,7 +39,10 @@ pub struct AppLauncher<T> {
 /// Defines how a windows size should be determined
 #[derive(Copy, Clone, Debug)]
 pub enum WindowSizePolicy {
-    /// Use the content of the window to determine the size
+    /// Use the content of the window to determine the size.
+    ///
+    /// If you use this option, your root widget will be passed infinite constraints;
+    /// you are responsible for ensuring that your content picks an appropriate size.
     Content,
     /// Use the provided window size
     User,

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -27,8 +27,8 @@ use crate::piet::{Piet, PietText, RenderContext};
 use crate::shell::Region;
 use crate::{
     commands, sub_window::SubWindowDesc, widget::Widget, Affine, Command, ContextMenu, Cursor,
-    Data, Env, ExtEventSink, Insets, MenuDesc, Notification, Point, Rect, Vec2, SingleUse, Size, Target,
-    TimerToken, WidgetId, WindowConfig, WindowDesc, WindowHandle, WindowId,
+    Data, Env, ExtEventSink, Insets, MenuDesc, Notification, Point, Rect, SingleUse, Size, Target,
+    TimerToken, Vec2, WidgetId, WindowConfig, WindowDesc, WindowHandle, WindowId,
 };
 
 /// A macro for implementing methods on multiple contexts.
@@ -188,7 +188,7 @@ impl_context_method!(
 
         /// The origin of the widget in window coordinates.
         pub fn window_origin(&self) -> Point {
-            self.widget_state.window_origin
+            self.widget_state.window_origin()
         }
 
         /// Takes a point in widget coordinates and transforms it to

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -198,8 +198,7 @@ impl_context_method!(
             self.window_origin() + widget_point.to_vec2()
         }
 
-        /// Takes a point in widget coordinates and transforms it to
-        /// screen coordinates
+        /// Convert a point from the widget's coordinate space to the screen's.
         pub fn to_screen(&self, widget_point: Point) -> Point {
             let insets = self.window().get_content_insets();
             let content_origin = self.window().get_position() + Vec2::new(insets.x0, insets.y0);

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -191,8 +191,9 @@ impl_context_method!(
             self.widget_state.window_origin()
         }
 
-        /// Takes a point in widget coordinates and transforms it to
-        /// window coordinates (relative to the content area, excluding chrome)
+        /// Convert a point from the widget's coordinate space to the window's.
+        ///
+        /// The returned point is relative to the content area; it excludes window chrome.
         pub fn to_window(&self, widget_point: Point) -> Point {
             self.window_origin() + widget_point.to_vec2()
         }

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -186,7 +186,8 @@ impl_context_method!(
             self.widget_state.size()
         }
 
-        /// The origin of the widget in window coordinates.
+        /// The origin of the widget in window coordinates, relative to the top left corner of the
+        /// content area.
         pub fn window_origin(&self) -> Point {
             self.widget_state.window_origin()
         }
@@ -199,8 +200,11 @@ impl_context_method!(
         }
 
         /// Convert a point from the widget's coordinate space to the screen's.
+        /// See the [`Screen`] module
+        ///
+        /// [`Screen`]: crate::shell::Screen
         pub fn to_screen(&self, widget_point: Point) -> Point {
-            let insets = self.window().get_content_insets();
+            let insets = self.window().content_insets();
             let content_origin = self.window().get_position() + Vec2::new(insets.x0, insets.y0);
             content_origin + self.to_window(widget_point).to_vec2()
         }

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -27,7 +27,7 @@ use crate::piet::{Piet, PietText, RenderContext};
 use crate::shell::Region;
 use crate::{
     commands, sub_window::SubWindowDesc, widget::Widget, Affine, Command, ContextMenu, Cursor,
-    Data, Env, ExtEventSink, Insets, MenuDesc, Notification, Point, Rect, SingleUse, Size, Target,
+    Data, Env, ExtEventSink, Insets, MenuDesc, Notification, Point, Rect, Vec2, SingleUse, Size, Target,
     TimerToken, WidgetId, WindowConfig, WindowDesc, WindowHandle, WindowId,
 };
 
@@ -184,6 +184,25 @@ impl_context_method!(
         /// [`layout`]: trait.Widget.html#tymethod.layout
         pub fn size(&self) -> Size {
             self.widget_state.size()
+        }
+
+        /// The origin of the widget in window coordinates.
+        pub fn window_origin(&self) -> Point {
+            self.widget_state.window_origin
+        }
+
+        /// Takes a point in widget coordinates and transforms it to
+        /// window coordinates (relative to the content area, excluding chrome)
+        pub fn to_window(&self, widget_point: Point) -> Point {
+            self.window_origin() + widget_point.to_vec2()
+        }
+
+        /// Takes a point in widget coordinates and transforms it to
+        /// screen coordinates
+        pub fn to_screen(&self, widget_point: Point) -> Point {
+            let insets = self.window().get_content_insets();
+            let content_origin = self.window().get_position() + Vec2::new(insets.x0, insets.y0);
+            content_origin + self.to_window(widget_point).to_vec2()
         }
 
         /// The "hot" (aka hover) status of a widget.

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -79,8 +79,8 @@ pub(crate) struct WidgetState {
     /// The origin of the child in the parent's coordinate space; together with
     /// `size` these constitute the child's layout rect.
     origin: Point,
-    /// The origin of the child in the window coordinate space;
-    pub(crate) window_origin: Point,
+    /// The origin of the parent in the window coordinate space;
+    pub(crate) parent_window_origin: Point,
     /// A flag used to track and debug missing calls to set_origin.
     is_expecting_set_origin_call: bool,
     /// The insets applied to the layout rect to generate the paint rect.
@@ -286,6 +286,12 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
     ///
     /// [`Scroll`]: widget/struct.Scroll.html
     pub fn set_viewport_offset(&mut self, offset: Vec2) {
+        if offset != self.state.viewport_offset {
+            // We need the parent_window_origin recalculated.
+            // It should be possible to just trigger the InternalLifeCycle::ParentWindowOrigin here,
+            // instead of full layout. Would need more management in WidgetState.
+            self.state.needs_layout = true;
+        }
         self.state.viewport_offset = offset;
     }
 
@@ -912,13 +918,9 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                         _ => false,
                     }
                 }
-                InternalLifeCycle::ParentWindowOrigin(parent_window_origin) => {
-                    self.state.window_origin = *parent_window_origin + self.state.origin.to_vec2()
-                        - self.state.viewport_offset;
-                    extra_event = Some(LifeCycle::Internal(InternalLifeCycle::ParentWindowOrigin(
-                        self.state.window_origin,
-                    )));
-                    false
+                InternalLifeCycle::ParentWindowOrigin => {
+                    self.state.parent_window_origin = ctx.widget_state.window_origin();
+                    true
                 }
                 #[cfg(test)]
                 InternalLifeCycle::DebugRequestState { widget, state_cell } => {
@@ -1083,7 +1085,7 @@ impl WidgetState {
         WidgetState {
             id,
             origin: Point::ORIGIN,
-            window_origin: Point::ORIGIN,
+            parent_window_origin: Point::ORIGIN,
             size: size.unwrap_or_default(),
             is_expecting_set_origin_call: true,
             paint_insets: Insets::ZERO,
@@ -1187,6 +1189,10 @@ impl WidgetState {
 
     pub(crate) fn add_sub_window_host(&mut self, window_id: WindowId, host_id: WidgetId) {
         self.sub_window_hosts.push((window_id, host_id))
+    }
+
+    pub(crate) fn window_origin(&self) -> Point {
+        self.parent_window_origin + self.origin.to_vec2() - self.viewport_offset
     }
 }
 

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -14,7 +14,7 @@
 
 //! Events.
 
-use crate::kurbo::{Point, Rect, Shape, Size, Vec2};
+use crate::kurbo::{Rect, Shape, Size, Vec2};
 
 use druid_shell::{Clipboard, KeyEvent, TimerToken};
 
@@ -299,9 +299,8 @@ pub enum InternalLifeCycle {
         /// the widget that is gaining focus, if any
         new: Option<WidgetId>,
     },
-    /// The widget parents origin in window coordinate space.
-    /// This occurs when a whole window has been laid out.
-    ParentWindowOrigin(Point),
+    /// The parents widget origin in window coordinate space has changed.
+    ParentWindowOrigin,
     /// Testing only: request the `WidgetState` of a specific widget.
     ///
     /// During testing, you may wish to verify that the state of a widget

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -14,7 +14,7 @@
 
 //! Events.
 
-use crate::kurbo::{Rect, Shape, Size, Vec2};
+use crate::kurbo::{Point, Rect, Shape, Size, Vec2};
 
 use druid_shell::{Clipboard, KeyEvent, TimerToken};
 
@@ -299,6 +299,9 @@ pub enum InternalLifeCycle {
         /// the widget that is gaining focus, if any
         new: Option<WidgetId>,
     },
+    /// The widget parents origin in window coordinate space.
+    /// This occurs when a whole window has been laid out.
+    ParentWindowOrigin(Point),
     /// Testing only: request the `WidgetState` of a specific widget.
     ///
     /// During testing, you may wish to verify that the state of a widget

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -188,11 +188,11 @@ pub use shell::{
     Application, Clipboard, ClipboardFormat, Code, Cursor, CursorDesc, Error as PlatformError,
     FileInfo, FileSpec, FormatId, HotKey, KbKey, KeyEvent, Location, Modifiers, Monitor,
     MouseButton, MouseButtons, RawMods, Region, Scalable, Scale, Screen, SysMods, TimerToken,
-    WindowHandle, WindowState,
+    WindowHandle, WindowLevel, WindowState,
 };
 
 pub use crate::core::WidgetPod;
-pub use app::{AppLauncher, WindowConfig, WindowDesc};
+pub use app::{AppLauncher, WindowConfig, WindowDesc, WindowSizePolicy};
 pub use app_delegate::{AppDelegate, DelegateCtx};
 pub use box_constraints::BoxConstraints;
 pub use command::{sys as commands, Command, Notification, Selector, SingleUse, Target};

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -796,6 +796,7 @@ impl<T: Data> AppState<T> {
         let data = self.data();
         let env = self.env();
 
+        pending.size_policy = config.size_policy;
         pending.title.resolve(&data, &env);
         builder.set_title(pending.title.display_text().to_string());
 

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -382,10 +382,10 @@ impl<T: Data> Window<T> {
             WindowSizePolicy::User => BoxConstraints::tight(self.size),
             WindowSizePolicy::Content => BoxConstraints::UNBOUNDED,
         };
-        let ret = self.root.layout(&mut layout_ctx, &bc, data, env);
+        let content_size = self.root.layout(&mut layout_ctx, &bc, data, env);
         if let WindowSizePolicy::Content = self.size_policy {
             let insets = self.handle.get_content_insets();
-            let full_size = (ret.to_rect() + insets).size();
+            let full_size = (content_size.to_rect() + insets).size();
             if self.size != full_size {
                 self.size = full_size;
                 self.handle.set_size(full_size)
@@ -395,7 +395,7 @@ impl<T: Data> Window<T> {
             .set_origin(&mut layout_ctx, data, env, Point::ORIGIN);
         self.lifecycle(
             queue,
-            &LifeCycle::Internal(InternalLifeCycle::ParentWindowOrigin(Point::ORIGIN)),
+            &LifeCycle::Internal(InternalLifeCycle::ParentWindowOrigin),
             data,
             env,
             false,

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -384,7 +384,7 @@ impl<T: Data> Window<T> {
         };
         let content_size = self.root.layout(&mut layout_ctx, &bc, data, env);
         if let WindowSizePolicy::Content = self.size_policy {
-            let insets = self.handle.get_content_insets();
+            let insets = self.handle.content_insets();
             let full_size = (content_size.to_rect() + insets).size();
             if self.size != full_size {
                 self.size = full_size;


### PR DESCRIPTION
Expose WindowLevel, add get_content_insets, track widgets window relative coordinates.
Add WindowSizePolicy to allow windows to size themselves to their content.
Make scroll contained things re layout if the scroll offset changes. 

All of these are to let subwindows like dropdowns be laid out relative to their parent widget.

The drop down widget itself isn't here. It is currently in nursery locally.