### PR TITLE
Augmentation - adding arbitrary data to widgets

### DIFF
--- a/druid/src/widget/align.rs
+++ b/druid/src/widget/align.rs
@@ -16,6 +16,7 @@
 
 use crate::widget::prelude::*;
 use crate::{Data, Rect, Size, UnitPoint, WidgetPod};
+use std::any::{Any, TypeId};
 
 /// A widget that aligns its child.
 pub struct Align<T> {
@@ -127,6 +128,10 @@ impl<T: Data> Widget<T> for Align<T> {
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         self.child.paint(ctx, data, env);
+    }
+
+    fn augmentation_raw(&self, type_id: TypeId) -> Option<&dyn Any> {
+        self.child.widget().augmentation_raw(type_id)
     }
 }
 

--- a/druid/src/widget/augmented.rs
+++ b/druid/src/widget/augmented.rs
@@ -1,0 +1,49 @@
+use crate::widget::prelude::*;
+use std::any::{Any, TypeId};
+
+/// A widget augmented with additional data (often used by its parent).
+pub struct Augmented<W, Aug> {
+    widget: W,
+    aug: Aug,
+}
+
+impl<W, Aug> Augmented<W, Aug> {
+    /// Create an Augmented widget
+    pub fn new(widget: W, aug: Aug) -> Self {
+        Augmented { widget, aug }
+    }
+}
+
+impl<T, W: Widget<T>, Aug: 'static> Widget<T> for Augmented<W, Aug> {
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
+        self.widget.event(ctx, event, data, env)
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        self.widget.lifecycle(ctx, event, data, env)
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
+        self.widget.update(ctx, old_data, data, env)
+    }
+
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
+        self.widget.layout(ctx, bc, data, env)
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
+        self.widget.paint(ctx, data, env)
+    }
+
+    fn id(&self) -> Option<WidgetId> {
+        self.widget.id()
+    }
+
+    fn augmentation_raw(&self, type_id: TypeId) -> Option<&dyn Any> {
+        if TypeId::of::<Aug>() == type_id {
+            Some(&self.aug)
+        } else {
+            self.widget.augmentation_raw(type_id)
+        }
+    }
+}

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -17,6 +17,7 @@
 use super::BackgroundBrush;
 use crate::widget::prelude::*;
 use crate::{Color, Data, KeyOrValue, Point, WidgetPod};
+use std::any::{Any, TypeId};
 
 struct BorderStyle {
     width: KeyOrValue<f64>,
@@ -190,5 +191,9 @@ impl<T: Data> Widget<T> for Container<T> {
         };
 
         self.inner.paint(ctx, data, env);
+    }
+
+    fn augmentation_raw(&self, type_id: TypeId) -> Option<&dyn Any> {
+        self.inner.widget().augmentation_raw(type_id)
     }
 }

--- a/druid/src/widget/controller.rs
+++ b/druid/src/widget/controller.rs
@@ -16,6 +16,7 @@
 
 use crate::widget::prelude::*;
 use crate::widget::WidgetWrapper;
+use std::any::{Any, TypeId};
 
 /// A trait for types that modify behaviour of a child widget.
 ///
@@ -132,6 +133,10 @@ impl<T, W: Widget<T>, C: Controller<T, W>> Widget<T> for ControllerHost<W, C> {
 
     fn id(&self) -> Option<WidgetId> {
         self.widget.id()
+    }
+
+    fn augmentation_raw(&self, type_id: TypeId) -> Option<&dyn Any> {
+        self.widget.augmentation_raw(type_id)
     }
 }
 

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -17,6 +17,7 @@
 use crate::widget::prelude::*;
 use crate::widget::WidgetWrapper;
 use crate::{Data, Point, WidgetPod};
+use std::any::{Any, TypeId};
 
 /// A widget that accepts a closure to update the environment for its child.
 pub struct EnvScope<T, W> {
@@ -93,6 +94,10 @@ impl<T: Data, W: Widget<T>> Widget<T> for EnvScope<T, W> {
         (self.f)(&mut new_env, &data);
 
         self.child.paint(ctx, data, &new_env);
+    }
+
+    fn augmentation_raw(&self, type_id: TypeId) -> Option<&dyn Any> {
+        self.child.widget().augmentation_raw(type_id)
     }
 }
 

--- a/druid/src/widget/identity_wrapper.rs
+++ b/druid/src/widget/identity_wrapper.rs
@@ -18,6 +18,7 @@ use crate::kurbo::Size;
 use crate::widget::prelude::*;
 use crate::widget::WidgetWrapper;
 use crate::Data;
+use std::any::{Any, TypeId};
 
 /// A wrapper that adds an identity to an otherwise anonymous widget.
 pub struct IdentityWrapper<W> {
@@ -55,6 +56,10 @@ impl<T: Data, W: Widget<T>> Widget<T> for IdentityWrapper<W> {
 
     fn id(&self) -> Option<WidgetId> {
         Some(self.id)
+    }
+
+    fn augmentation_raw(&self, type_id: TypeId) -> Option<&dyn Any> {
+        self.inner.augmentation_raw(type_id)
     }
 }
 

--- a/druid/src/widget/lens_wrap.rs
+++ b/druid/src/widget/lens_wrap.rs
@@ -23,6 +23,7 @@ use std::marker::PhantomData;
 use crate::widget::prelude::*;
 use crate::widget::WidgetWrapper;
 use crate::{Data, Lens};
+use std::any::{Any, TypeId};
 
 /// A wrapper for its widget subtree to have access to a part
 /// of its parent's data.
@@ -113,6 +114,10 @@ where
 
     fn id(&self) -> Option<WidgetId> {
         self.inner.id()
+    }
+
+    fn augmentation_raw(&self, type_id: TypeId) -> Option<&dyn Any> {
+        self.inner.augmentation_raw(type_id)
     }
 }
 

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -20,6 +20,7 @@ mod widget_wrapper;
 
 mod added;
 mod align;
+mod augmented;
 mod button;
 mod checkbox;
 mod click;
@@ -62,6 +63,7 @@ mod widget_ext;
 pub use self::image::Image;
 pub use added::Added;
 pub use align::Align;
+pub use augmented::Augmented;
 pub use button::Button;
 pub use checkbox::Checkbox;
 pub use click::Click;

--- a/druid/src/widget/scope.rs
+++ b/druid/src/widget/scope.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use crate::widget::prelude::*;
 use crate::widget::WidgetWrapper;
 use crate::{Data, Lens, Point, WidgetPod};
+use std::any::{Any, TypeId};
 
 /// A policy that controls how a [`Scope`] will interact with its surrounding
 /// application data. Specifically, how to create an initial State from the
@@ -300,6 +301,10 @@ impl<SP: ScopePolicy, W: Widget<SP::State>> Widget<SP::In> for Scope<SP, W> {
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &SP::In, env: &Env) {
         self.with_state(data, |state, inner| inner.paint_raw(ctx, state, env));
+    }
+
+    fn augmentation_raw(&self, type_id: TypeId) -> Option<&dyn Any> {
+        self.inner.widget().augmentation_raw(type_id)
     }
 }
 

--- a/druid/src/widget/sized_box.rs
+++ b/druid/src/widget/sized_box.rs
@@ -18,6 +18,7 @@ use std::f64::INFINITY;
 
 use crate::widget::prelude::*;
 use crate::Data;
+use std::any::{Any, TypeId};
 
 /// A widget with predefined size.
 ///
@@ -174,6 +175,12 @@ impl<T: Data> Widget<T> for SizedBox<T> {
     fn id(&self) -> Option<WidgetId> {
         self.inner.as_ref().and_then(|inner| inner.id())
     }
+
+    fn augmentation_raw(&self, type_id: TypeId) -> Option<&dyn Any> {
+        self.inner
+            .as_ref()
+            .and_then(|inner| inner.augmentation_raw(type_id))
+    }
 }
 
 #[cfg(test)]
@@ -186,7 +193,7 @@ mod tests {
         let expand = SizedBox::<()>::new(Label::new("hello!")).expand();
         let bc = BoxConstraints::tight(Size::new(400., 400.)).loosen();
         let child_bc = expand.child_constraints(&bc);
-        assert_eq!(child_bc.min(), Size::new(400., 400.,));
+        assert_eq!(child_bc.min(), Size::new(400., 400.));
     }
 
     #[test]
@@ -194,7 +201,7 @@ mod tests {
         let expand = SizedBox::<()>::new(Label::new("hello!")).height(200.);
         let bc = BoxConstraints::tight(Size::new(400., 400.)).loosen();
         let child_bc = expand.child_constraints(&bc);
-        assert_eq!(child_bc.min(), Size::new(0., 200.,));
-        assert_eq!(child_bc.max(), Size::new(400., 200.,));
+        assert_eq!(child_bc.min(), Size::new(0., 200.));
+        assert_eq!(child_bc.max(), Size::new(400., 200.));
     }
 }

--- a/druid/src/widget/widget.rs
+++ b/druid/src/widget/widget.rs
@@ -16,6 +16,7 @@ use std::num::NonZeroU64;
 use std::ops::{Deref, DerefMut};
 
 use super::prelude::*;
+use std::any::{Any, TypeId};
 
 /// A unique identifier for a single [`Widget`].
 ///
@@ -197,6 +198,16 @@ pub trait Widget<T> {
     fn type_name(&self) -> &'static str {
         std::any::type_name::<Self>()
     }
+
+    #[doc(hidden)]
+    /// Get a reference to an augmentation of the given type.
+    /// This is implemented in terms of Any in order to maintain object safety.
+    /// User code should use augmentation on WidgetExt.
+    /// Single widget wrappers should delegate this to their children.
+    #[allow(unused_variables)]
+    fn augmentation_raw(&self, type_id: TypeId) -> Option<&dyn Any> {
+        None
+    }
 }
 
 impl WidgetId {
@@ -261,5 +272,9 @@ impl<T> Widget<T> for Box<dyn Widget<T>> {
 
     fn type_name(&self) -> &'static str {
         self.deref().type_name()
+    }
+
+    fn augmentation_raw(&self, type_id: TypeId) -> Option<&dyn Any> {
+        self.deref().augmentation_raw(type_id)
     }
 }

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -16,12 +16,13 @@
 
 use super::invalidation::DebugInvalidation;
 use super::{
-    Added, Align, BackgroundBrush, Click, Container, Controller, ControllerHost, EnvScope,
-    IdentityWrapper, LensWrap, Padding, Parse, SizedBox, WidgetId,
+    Added, Align, Augmented, BackgroundBrush, Click, Container, Controller, ControllerHost,
+    EnvScope, IdentityWrapper, LensWrap, Padding, Parse, SizedBox, WidgetId,
 };
 use crate::{
     Color, Data, Env, EventCtx, Insets, KeyOrValue, Lens, LifeCycleCtx, UnitPoint, Widget,
 };
+use std::any::{Any, TypeId};
 
 /// A trait that provides extra methods for combining `Widget`s.
 pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
@@ -261,6 +262,17 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     /// Wrap this widget in a `Box`.
     fn boxed(self) -> Box<dyn Widget<T>> {
         Box::new(self)
+    }
+
+    /// Get an augmentation from this widget if any of the appropriate type is present
+    fn augmentation<Aug: 'static>(&self) -> Option<&Aug> {
+        self.augmentation_raw(TypeId::of::<Aug>())
+            .and_then(Any::downcast_ref)
+    }
+
+    /// Augment this widget with the provided argument
+    fn augment<Aug: 'static>(self, aug: Aug) -> Augmented<Self, Aug> {
+        Augmented::new(self, aug)
     }
 }
 


### PR DESCRIPTION
Augmentation - adding arbitrary data to widgets. Draft, more for discussion of the idea than wanting it committed at the moment... 

The main use case that I have is decorating widgets with specific information that their parent may use, so that each type of complex layout parent (flex, list, tabs, navigation stack etc) does not need to have its own mechanism of associating information with its children (and can share dynamic content mechanisms that yield augmented child widgets - i.e supplanting the specialised mechanisms in Tabs (TabPolicy) and List (ListIter)).

e.g ( not using any suggested dynamic content mechanism) 

Tabs::new()
    .with_child( (widget1.augment(TabInfo::name("Tab 1")) )
    .with_child( (widget2.augment(TabInfo::widget(SpecialTabWidget::new()))))
 
Flex::new().with_child( (widget3.augment(FlexParams::new(0.5, None) ) )

I would expect that common augmentations would have more convenient methods (e.g supporting Into) in WidgetExt. E.g widget1.tab("Tab 1"), widget3.flex(0.5). I don't think its possible to do this generically in a convenient way (you would need to provide the target type). 

This is somewhat similar to how certain ViewModifiers in SwiftUI are used but doesn't have the view transformation aspects, just the 'attach some data' parts. 

Another use case would be information about transition effects (i.e how to animate layout changes) that a layout parent would be expected to apply.

This PR doesn't include any of that yet nor any actual use of augmentations, or any of the dynamic content ideas. For now this would be to enable experimentation (perhaps in the nursery with a copy of the container widgets?).
Most of this code is just forwarding calls in decorator widgets (so the order of decoration doesn't matter).

Open questions: 
* Not convinced on naming at all, any suggestions?
* The type is the complete key to the augmentation. It could be something like selector symbol, but not sure it is needed... 
* Currently this is completely read only - more maybe needed. E.g if transferring widgets around within augmentations, although perhaps interior mutability like SingleUse would work better there.
* There is no trait requirement on augmentations (just 'static), so you could augment with something completely arbitrary like a number or a string. Possibly there should be one?
