### PR TITLE
Add a CrossAxisAlignment to Flex to fill the available cross space

### DIFF
--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -306,6 +306,9 @@ pub enum CrossAxisAlignment {
     ///
     /// The calculated baseline is the maximum baseline offset of the children.
     Baseline,
+    /// Fill the available space.
+    ///
+    Fill,
 }
 
 /// Arrangement of children on the main axis.
@@ -712,6 +715,15 @@ impl<T: Data> Widget<T> for Flex<T> {
                     let child_above_baseline = child_size.height - child_baseline;
                     extra_height + (max_above_baseline - child_above_baseline)
                 }
+                CrossAxisAlignment::Fill => {
+                    let fill_size: Size = self
+                        .direction
+                        .pack(self.direction.major(child_size), minor_dim)
+                        .into();
+                    let child_bc = BoxConstraints::tight(fill_size);
+                    child.widget.layout(ctx, &child_bc, data, env);
+                    0.0
+                }
                 _ => {
                     let extra_minor = minor_dim - self.direction.minor(child_size);
                     alignment.align(extra_minor)
@@ -793,6 +805,7 @@ impl CrossAxisAlignment {
             // in vertical layout, baseline is equivalent to center
             CrossAxisAlignment::Center | CrossAxisAlignment::Baseline => (val / 2.0).round(),
             CrossAxisAlignment::End => val,
+            CrossAxisAlignment::Fill => 0.0,
         }
     }
 }

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -308,6 +308,8 @@ pub enum CrossAxisAlignment {
     Baseline,
     /// Fill the available space.
     ///
+    /// The size on this axis is the size of the largest widget;
+    /// other widgets must fill that space.
     Fill,
 }
 


### PR DESCRIPTION
This is for introducing a new enum value `Fill` to `Flex`'s `CrossAxisAlignment`.
Children with the `Fill` cross axis alignment are laid out to fill the entire available cross space, resulting in such layouts:
![image](https://user-images.githubusercontent.com/5831830/105624600-fc222e00-5e5d-11eb-8b68-afedb7f098f8.png)
The same layout using `Start`looks like this:
![image](https://user-images.githubusercontent.com/5831830/105624592-f1679900-5e5d-11eb-8e69-2e17d53e2db0.png)