### PR TITLE
Take root widget directly in WindowDesc::new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ You can find its changes [documented below](#070---2021-01-01).
 ### Changed
 
 - Warn on unhandled Commands ([#1533] by [@Maan2003])
+- `WindowDesc::new` takes the root widget directly instead of a closure ([#1559] by [@lassipulkkinen])
 
 ### Deprecated
 
@@ -411,6 +412,7 @@ Last release without a changelog :(
 [@Maan2003]: https://github.com/Maan2003
 [@derekdreery]: https://github.com/derekdreery
 [@MaximilianKoestler]: https://github.com/MaximilianKoestler
+[@lassipulkkinen]: https://github.com/lassipulkkinen
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611
@@ -608,6 +610,7 @@ Last release without a changelog :(
 [#1533]: https://github.com/linebender/druid/pull/1533
 [#1534]: https://github.com/linebender/druid/pull/1534
 [#1254]: https://github.com/linebender/druid/pull/1254
+[#1559]: https://github.com/linebender/druid/pull/1559
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.6.0...master
 [0.6.0]: https://github.com/linebender/druid/compare/v0.5.0...v0.6.0

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ use druid::widget::{Button, Flex, Label};
 use druid::{AppLauncher, LocalizedString, PlatformError, Widget, WidgetExt, WindowDesc};
 
 fn main() -> Result<(), PlatformError> {
-    let main_window = WindowDesc::new(ui_builder);
+    let main_window = WindowDesc::new(ui_builder());
     let data = 0_u32;
     AppLauncher::with_window(main_window)
         .use_simple_logger()

--- a/druid/examples/anim.rs
+++ b/druid/examples/anim.rs
@@ -81,7 +81,7 @@ impl Widget<()> for AnimWidget {
 }
 
 pub fn main() {
-    let window = WindowDesc::new(|| AnimWidget { t: 0.0 }).title(
+    let window = WindowDesc::new(AnimWidget { t: 0.0 }).title(
         LocalizedString::new("anim-demo-window-title")
             .with_placeholder("You spin me right round..."),
     );

--- a/druid/examples/async_event.rs
+++ b/druid/examples/async_event.rs
@@ -31,7 +31,7 @@ use druid::{AppLauncher, Color, Selector, Target, WidgetExt, WindowDesc};
 const SET_COLOR: Selector<Color> = Selector::new("event-example.set-color");
 
 pub fn main() {
-    let window = WindowDesc::new(make_ui).title("External Event Demo");
+    let window = WindowDesc::new(make_ui()).title("External Event Demo");
 
     let launcher = AppLauncher::with_window(window);
 

--- a/druid/examples/blocking_function.rs
+++ b/druid/examples/blocking_function.rs
@@ -100,7 +100,8 @@ impl AppDelegate<AppState> for Delegate {
 }
 
 fn main() {
-    let main_window = WindowDesc::new(ui_builder).title(LocalizedString::new("Blocking functions"));
+    let main_window =
+        WindowDesc::new(ui_builder()).title(LocalizedString::new("Blocking functions"));
     AppLauncher::with_window(main_window)
         .delegate(Delegate {})
         .launch(AppState::default())

--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -243,7 +243,7 @@ fn build_calc() -> impl Widget<CalcState> {
 }
 
 pub fn main() {
-    let window = WindowDesc::new(build_calc)
+    let window = WindowDesc::new(build_calc())
         .window_size((223., 300.))
         .resizable(false)
         .title(

--- a/druid/examples/cursor.rs
+++ b/druid/examples/cursor.rs
@@ -106,7 +106,8 @@ impl AppState {
 }
 
 pub fn main() {
-    let main_window = WindowDesc::new(ui_builder).title(LocalizedString::new("Blocking functions"));
+    let main_window =
+        WindowDesc::new(ui_builder()).title(LocalizedString::new("Blocking functions"));
     let cursor_image = ImageBuf::from_data(include_bytes!("./assets/PicWithAlpha.png")).unwrap();
     // The (0,0) refers to where the "hotspot" is located, so where the mouse actually points.
     // (0,0) is the top left, and (cursor_image.width(), cursor_image.width()) the bottom right.

--- a/druid/examples/custom_widget.rs
+++ b/druid/examples/custom_widget.rs
@@ -151,7 +151,7 @@ impl Widget<String> for CustomWidget {
 }
 
 pub fn main() {
-    let window = WindowDesc::new(|| CustomWidget {}).title(LocalizedString::new("Fancy Colors"));
+    let window = WindowDesc::new(CustomWidget {}).title(LocalizedString::new("Fancy Colors"));
     AppLauncher::with_window(window)
         .use_simple_logger()
         .launch("Druid + Piet".to_string())

--- a/druid/examples/either.rs
+++ b/druid/examples/either.rs
@@ -45,7 +45,7 @@ fn ui_builder() -> impl Widget<AppState> {
 }
 
 pub fn main() {
-    let main_window = WindowDesc::new(ui_builder).title("Switcheroo");
+    let main_window = WindowDesc::new(ui_builder()).title("Switcheroo");
     AppLauncher::with_window(main_window)
         .use_simple_logger()
         .launch(AppState::default())

--- a/druid/examples/event_viewer.rs
+++ b/druid/examples/event_viewer.rs
@@ -322,7 +322,7 @@ fn make_list_item() -> impl Widget<LoggedEvent> {
 
 pub fn main() {
     //describe the main window
-    let main_window = WindowDesc::new(build_root_widget)
+    let main_window = WindowDesc::new(build_root_widget())
         .title("Event Viewer")
         .window_size((760.0, 680.0));
 

--- a/druid/examples/flex.rs
+++ b/druid/examples/flex.rs
@@ -317,7 +317,7 @@ fn make_ui() -> impl Widget<AppState> {
 }
 
 pub fn main() {
-    let main_window = WindowDesc::new(make_ui)
+    let main_window = WindowDesc::new(make_ui())
         .window_size((720., 600.))
         .with_min_size((620., 300.))
         .title("Flex Container Options");

--- a/druid/examples/game_of_life.rs
+++ b/druid/examples/game_of_life.rs
@@ -416,7 +416,7 @@ fn make_widget() -> impl Widget<AppData> {
 }
 
 pub fn main() {
-    let window = WindowDesc::new(make_widget)
+    let window = WindowDesc::new(make_widget())
         .window_size(Size {
             width: 800.0,
             height: 800.0,

--- a/druid/examples/hello.rs
+++ b/druid/examples/hello.rs
@@ -29,7 +29,7 @@ struct HelloState {
 
 pub fn main() {
     // describe the main window
-    let main_window = WindowDesc::new(build_root_widget)
+    let main_window = WindowDesc::new(build_root_widget())
         .title("Hello World!")
         .window_size((400.0, 400.0));
 

--- a/druid/examples/hello_web/src/lib.rs
+++ b/druid/examples/hello_web/src/lib.rs
@@ -39,7 +39,7 @@ pub fn main() {
     //
     // Window title is set in index.html and window size is ignored on the web,
     // so can we leave those off.
-    let main_window = WindowDesc::new(build_root_widget);
+    let main_window = WindowDesc::new(build_root_widget());
 
     // create the initial app state
     let initial_state = HelloState {

--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -40,7 +40,7 @@ struct OurData {
 }
 
 pub fn main() {
-    let window = WindowDesc::new(make_ui).title("identity example");
+    let window = WindowDesc::new(make_ui()).title("identity example");
     let data = OurData {
         counter_one: 0,
         counter_two: 0,

--- a/druid/examples/image.rs
+++ b/druid/examples/image.rs
@@ -204,7 +204,7 @@ fn make_ui() -> impl Widget<AppState> {
 }
 
 pub fn main() {
-    let main_window = WindowDesc::new(make_ui)
+    let main_window = WindowDesc::new(make_ui())
         .window_size((650., 450.))
         .title("Flex Container Options");
 

--- a/druid/examples/invalidation.rs
+++ b/druid/examples/invalidation.rs
@@ -24,7 +24,7 @@ use druid::{AppLauncher, Color, Data, Lens, LocalizedString, Point, WidgetExt, W
 use instant::Instant;
 
 pub fn main() {
-    let window = WindowDesc::new(build_widget).title(
+    let window = WindowDesc::new(build_widget()).title(
         LocalizedString::new("invalidate-demo-window-title").with_placeholder("Invalidate demo"),
     );
     let state = AppState {

--- a/druid/examples/layout.rs
+++ b/druid/examples/layout.rs
@@ -66,7 +66,7 @@ fn build_app() -> impl Widget<u32> {
 }
 
 pub fn main() {
-    let window = WindowDesc::new(build_app).title("Very flexible");
+    let window = WindowDesc::new(build_app()).title("Very flexible");
 
     AppLauncher::with_window(window)
         .use_simple_logger()

--- a/druid/examples/lens.rs
+++ b/druid/examples/lens.rs
@@ -19,7 +19,7 @@ use druid::widget::{CrossAxisAlignment, Flex, Label, TextBox};
 use druid::{AppLauncher, Data, Env, Lens, LocalizedString, Widget, WidgetExt, WindowDesc};
 
 pub fn main() {
-    let main_window = WindowDesc::new(ui_builder)
+    let main_window = WindowDesc::new(ui_builder())
         .title(LocalizedString::new("lens-demo-window-title").with_placeholder("Lens Demo"));
     let data = MyComplexState {
         term: "hello".into(),

--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -30,7 +30,7 @@ struct AppData {
 }
 
 pub fn main() {
-    let main_window = WindowDesc::new(ui_builder)
+    let main_window = WindowDesc::new(ui_builder())
         .title(LocalizedString::new("list-demo-window-title").with_placeholder("List Demo"));
     // Set our initial data
     let left = vector![1, 2];

--- a/druid/examples/markdown_preview.rs
+++ b/druid/examples/markdown_preview.rs
@@ -64,7 +64,7 @@ impl<W: Widget<AppState>> Controller<AppState, W> for RichTextRebuilder {
 
 pub fn main() {
     // describe the main window
-    let main_window = WindowDesc::new(build_root_widget)
+    let main_window = WindowDesc::new(build_root_widget())
         .title(WINDOW_TITLE)
         .menu(make_menu())
         .window_size((700.0, 600.0));

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -39,7 +39,7 @@ struct State {
 }
 
 pub fn main() {
-    let main_window = WindowDesc::new(ui_builder)
+    let main_window = WindowDesc::new(ui_builder())
         .menu(make_menu(&State::default()))
         .title(
             LocalizedString::new("multiwin-demo-window-title").with_placeholder("Many windows!"),
@@ -157,7 +157,7 @@ impl AppDelegate<State> for Delegate {
     ) -> Handled {
         match cmd {
             _ if cmd.is(sys_cmds::NEW_FILE) => {
-                let new_win = WindowDesc::new(ui_builder)
+                let new_win = WindowDesc::new(ui_builder())
                     .menu(make_menu(data))
                     .window_size((data.selected as f64 * 100.0 + 300.0, 500.0));
                 ctx.new_window(new_win);

--- a/druid/examples/open_save.rs
+++ b/druid/examples/open_save.rs
@@ -23,7 +23,7 @@ use druid::{
 struct Delegate;
 
 pub fn main() {
-    let main_window = WindowDesc::new(ui_builder)
+    let main_window = WindowDesc::new(ui_builder())
         .title(LocalizedString::new("open-save-demo").with_placeholder("Opening/Saving Demo"));
     let data = "Type here.".to_owned();
     AppLauncher::with_window(main_window)

--- a/druid/examples/panels.rs
+++ b/druid/examples/panels.rs
@@ -92,7 +92,7 @@ fn build_app() -> impl Widget<()> {
 }
 
 pub fn main() -> Result<(), PlatformError> {
-    let main_window = WindowDesc::new(build_app)
+    let main_window = WindowDesc::new(build_app())
         .title(LocalizedString::new("panels-demo-window-title").with_placeholder("Fancy Boxes!"));
     AppLauncher::with_window(main_window)
         .use_simple_logger()

--- a/druid/examples/scroll.rs
+++ b/druid/examples/scroll.rs
@@ -22,7 +22,7 @@ use druid::widget::{Flex, Padding, Scroll};
 use druid::{AppLauncher, Data, Insets, LocalizedString, Rect, WindowDesc};
 
 pub fn main() {
-    let window = WindowDesc::new(build_widget)
+    let window = WindowDesc::new(build_widget())
         .title(LocalizedString::new("scroll-demo-window-title").with_placeholder("Scroll demo"));
     AppLauncher::with_window(window)
         .use_simple_logger()

--- a/druid/examples/scroll_colors.rs
+++ b/druid/examples/scroll_colors.rs
@@ -42,7 +42,7 @@ fn build_app() -> impl Widget<u32> {
 }
 
 pub fn main() {
-    let main_window = WindowDesc::new(build_app).title(
+    let main_window = WindowDesc::new(build_app()).title(
         LocalizedString::new("scroll-colors-demo-window-title").with_placeholder("Rainbows!"),
     );
     let data = 0_u32;

--- a/druid/examples/split_demo.rs
+++ b/druid/examples/split_demo.rs
@@ -77,7 +77,7 @@ fn build_app() -> impl Widget<u32> {
 }
 
 pub fn main() {
-    let window = WindowDesc::new(build_app)
+    let window = WindowDesc::new(build_app())
         .title(LocalizedString::new("split-demo-window-title").with_placeholder("Split Demo"));
     AppLauncher::with_window(window)
         .use_simple_logger()

--- a/druid/examples/styled_text.rs
+++ b/druid/examples/styled_text.rs
@@ -48,7 +48,7 @@ impl Display for AppData {
 }
 
 pub fn main() -> Result<(), PlatformError> {
-    let main_window = WindowDesc::new(ui_builder).title(
+    let main_window = WindowDesc::new(ui_builder()).title(
         LocalizedString::new("styled-text-demo-window-title").with_placeholder("Type Styler"),
     );
     let data = AppData {

--- a/druid/examples/sub_window.rs
+++ b/druid/examples/sub_window.rs
@@ -45,7 +45,7 @@ struct HelloState {
 
 pub fn main() {
     // describe the main window
-    let main_window = WindowDesc::new(build_root_widget)
+    let main_window = WindowDesc::new(build_root_widget())
         .title(WINDOW_TITLE)
         .window_size((400.0, 400.0));
 

--- a/druid/examples/svg.rs
+++ b/druid/examples/svg.rs
@@ -22,7 +22,7 @@ use druid::{
 };
 
 pub fn main() {
-    let main_window = WindowDesc::new(ui_builder)
+    let main_window = WindowDesc::new(ui_builder())
         .title(LocalizedString::new("svg-demo-window-title").with_placeholder("Rawr!"));
     let data = 0_u32;
     AppLauncher::with_window(main_window)

--- a/druid/examples/switches.rs
+++ b/druid/examples/switches.rs
@@ -67,7 +67,7 @@ fn build_widget() -> impl Widget<DemoState> {
 }
 
 pub fn main() {
-    let window = WindowDesc::new(build_widget)
+    let window = WindowDesc::new(build_widget())
         .title(LocalizedString::new("switch-demo-window-title").with_placeholder("Switch Demo"));
     AppLauncher::with_window(window)
         .use_simple_logger()

--- a/druid/examples/tabs.rs
+++ b/druid/examples/tabs.rs
@@ -72,7 +72,7 @@ struct AppState {
 
 pub fn main() {
     // describe the main window
-    let main_window = WindowDesc::new(build_root_widget)
+    let main_window = WindowDesc::new(build_root_widget())
         .title("Tabs")
         .window_size((700.0, 400.0));
 

--- a/druid/examples/text.rs
+++ b/druid/examples/text.rs
@@ -79,7 +79,7 @@ impl Controller<AppState, RawLabel<AppState>> for LabelController {
 
 pub fn main() {
     // describe the main window
-    let main_window = WindowDesc::new(build_root_widget)
+    let main_window = WindowDesc::new(build_root_widget())
         .title(WINDOW_TITLE)
         .window_size((400.0, 600.0));
 

--- a/druid/examples/timer.rs
+++ b/druid/examples/timer.rs
@@ -116,7 +116,7 @@ impl Widget<u32> for SimpleBox {
 }
 
 pub fn main() {
-    let window = WindowDesc::new(|| TimerWidget {
+    let window = WindowDesc::new(TimerWidget {
         timer_id: TimerToken::INVALID,
         simple_box: WidgetPod::new(SimpleBox),
         pos: Point::ZERO,

--- a/druid/examples/value_formatting/src/main.rs
+++ b/druid/examples/value_formatting/src/main.rs
@@ -37,7 +37,7 @@ pub struct AppData {
 }
 
 pub fn main() {
-    let main_window = WindowDesc::new(ui_builder).title("Formatting and Validation");
+    let main_window = WindowDesc::new(ui_builder()).title("Formatting and Validation");
 
     let data = AppData {
         dollars: 12.2,

--- a/druid/examples/view_switcher.rs
+++ b/druid/examples/view_switcher.rs
@@ -24,7 +24,7 @@ struct AppState {
 }
 
 pub fn main() {
-    let main_window = WindowDesc::new(make_ui).title(LocalizedString::new("View Switcher"));
+    let main_window = WindowDesc::new(make_ui()).title(LocalizedString::new("View Switcher"));
     let data = AppState {
         current_view: 0,
         current_text: "Edit me!".to_string(),

--- a/druid/examples/widget_gallery.rs
+++ b/druid/examples/widget_gallery.rs
@@ -48,7 +48,7 @@ enum MyRadio {
 }
 
 pub fn main() {
-    let main_window = WindowDesc::new(ui_builder).title("Widget Gallery");
+    let main_window = WindowDesc::new(ui_builder()).title("Widget Gallery");
     // Set our initial data
     let data = AppData {
         label_data: "test".into(),

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -86,14 +86,13 @@ pub struct PendingWindow<T> {
 
 impl<T: Data> PendingWindow<T> {
     /// Create a pending window from any widget.
-    pub fn new<W, F>(root: F) -> PendingWindow<T>
+    pub fn new<W>(root: W) -> PendingWindow<T>
     where
         W: Widget<T> + 'static,
-        F: FnOnce() -> W + 'static,
     {
         // This just makes our API slightly cleaner; callers don't need to explicitly box.
         PendingWindow {
-            root: Box::new(root()),
+            root: Box::new(root),
             title: LocalizedString::new("app-name").into(),
             menu: MenuDesc::platform_default(),
             size_policy: WindowSizePolicy::User,
@@ -387,10 +386,9 @@ impl<T: Data> WindowDesc<T> {
     /// It is possible that a `WindowDesc` can be reused to launch multiple windows.
     ///
     /// [`Widget`]: trait.Widget.html
-    pub fn new<W, F>(root: F) -> WindowDesc<T>
+    pub fn new<W>(root: W) -> WindowDesc<T>
     where
         W: Widget<T> + 'static,
-        F: FnOnce() -> W + 'static,
     {
         WindowDesc {
             pending: PendingWindow::new(root),

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -380,10 +380,7 @@ impl WindowConfig {
 }
 
 impl<T: Data> WindowDesc<T> {
-    /// Create a new `WindowDesc`, taking a function that will generate the root
-    /// [`Widget`] for this window.
-    ///
-    /// It is possible that a `WindowDesc` can be reused to launch multiple windows.
+    /// Create a new `WindowDesc`, taking the root [`Widget`] for this window.
     ///
     /// [`Widget`]: trait.Widget.html
     pub fn new<W>(root: W) -> WindowDesc<T>

--- a/druid/src/env.rs
+++ b/druid/src/env.rs
@@ -75,7 +75,7 @@ struct EnvImpl {
 /// }
 ///
 /// fn main() {
-///     let main_window = WindowDesc::new(important_label);
+///     let main_window = WindowDesc::new(important_label());
 ///
 ///     AppLauncher::with_window(main_window)
 ///         .configure_env(|env, _state| {

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -56,7 +56,7 @@
 //!
 //! fn main() {
 //!     // describe the main window
-//!     let main_window = WindowDesc::new(build_root_widget)
+//!     let main_window = WindowDesc::new(build_root_widget())
 //!         .title(WINDOW_TITLE)
 //!         .window_size((400.0, 400.0));
 //!

--- a/druid/src/sub_window.rs
+++ b/druid/src/sub_window.rs
@@ -72,7 +72,7 @@ impl SubWindowDesc {
         app_state: &mut AppState<T>,
     ) -> Result<WindowHandle, Error> {
         let sub_window_root = self.sub_window_root;
-        let pending = PendingWindow::new(|| sub_window_root.lens(Unit::default()));
+        let pending = PendingWindow::new(sub_window_root.lens(Unit::default()));
         app_state.build_native_window(self.window_id, pending, self.window_config)
     }
 }

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -148,7 +148,7 @@ impl<T: Data> Harness<'_, T> {
         {
             let piet = target.0.as_mut().unwrap().render_context();
 
-            let pending = PendingWindow::new(|| root);
+            let pending = PendingWindow::new(root);
             let window = Window::new(WindowId::next(), Default::default(), pending, ext_handle);
 
             let inner = Inner {


### PR DESCRIPTION
`WindowDesc::new` currently accepts the root widget as a closure that returns `W: Widget<_>`, which made sense before the changes in #519. This PR changes that to take `W` directly instead, as using a closure serves no purpose anymore.

EDIT: Sorry for the force push mess; I forgot to `cargo fmt`. Also, reverted AUTHORS change on second thought, as this is probably not eligible for copyright.