### PR TITLE
Use inferred as-cast instead of isize in SetWindowLongPtrW call

### DIFF
--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -330,7 +330,7 @@ fn set_style(hwnd: HWND, resizable: bool, titlebar: bool) {
         } else {
             style |= WS_MINIMIZEBOX | WS_SYSMENU | WS_OVERLAPPED;
         }
-        if SetWindowLongPtrW(hwnd, GWL_STYLE, style as isize) == 0 {
+        if SetWindowLongPtrW(hwnd, GWL_STYLE, style as _) == 0 {
             warn!(
                 "failed to set the window style: {}",
                 Error::Hr(HRESULT_FROM_WIN32(GetLastError()))


### PR DESCRIPTION
This allows it to be a valid cast for i686-pc-windows-gnu target, where
the style argument is i32 instead of isize.

Ref: #9 