### PR TITLE
Initialize render target when window size is not specified on Windows

### DIFF
--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -663,6 +663,10 @@ impl WndProc for MyWndProc {
 
                     let handle = self.handle.borrow().to_owned();
                     state.handler.connect(&handle.into());
+
+                    if let Err(e) = state.rebuild_render_target(&self.d2d_factory, scale) {
+                        error!("error building render target: {}", e);
+                    }
                 }
                 Some(0)
             }


### PR DESCRIPTION
Fix #1426.

As I commented on that issue, When the window size is not specified, WM_RESIZE is not emitted before first WM_PAINT. So, rendering is called without creating the render target.

I tested on Windows 10 Pro 20H2. With this patch, all examples are successfully showing the window without panic.