### PR TITLE
Updates for rustc 1.50

### DIFF
--- a/druid-shell/src/platform/windows/application.rs
+++ b/druid-shell/src/platform/windows/application.rs
@@ -62,6 +62,7 @@ impl Application {
 
     /// Initialize the app. At the moment, this is mostly needed for hi-dpi.
     // TODO: Report back an error instead of panicking
+    #[allow(clippy::unnecessary_wraps)]
     fn init() -> Result<(), Error> {
         util::attach_console();
         if let Some(func) = OPTIONAL_FUNCTIONS.SetProcessDpiAwarenessContext {

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -841,6 +841,7 @@ impl Window {
         // TODO(x11/menus): implement Window::set_menu (currently a no-op)
     }
 
+    #[allow(clippy::unnecessary_wraps)]
     fn get_scale(&self) -> Result<Scale, Error> {
         // TODO(x11/dpi_scaling): figure out DPI scaling
         Ok(Scale::new(1.0, 1.0))

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -196,8 +196,8 @@ impl<T> Split<T> {
     fn update_split_point(&mut self, size: Size, mouse_pos: Point) {
         let (min_limit, max_limit) = self.split_side_limits(size);
         self.split_point_chosen = match self.split_axis {
-            Axis::Horizontal => clamp(mouse_pos.x, min_limit, max_limit) / size.width,
-            Axis::Vertical => clamp(mouse_pos.y, min_limit, max_limit) / size.height,
+            Axis::Horizontal => mouse_pos.x.clamp(min_limit, max_limit) / size.width,
+            Axis::Vertical => mouse_pos.y.clamp(min_limit, max_limit) / size.height,
         }
     }
 
@@ -361,11 +361,8 @@ impl<T: Data> Widget<T> for Split<T> {
             if reduced_axis_size.is_infinite() || reduced_axis_size <= std::f64::EPSILON {
                 0.5
             } else {
-                clamp(
-                    self.split_point_chosen,
-                    min_limit / reduced_axis_size,
-                    max_limit / reduced_axis_size,
-                )
+                self.split_point_chosen
+                    .clamp(min_limit / reduced_axis_size, max_limit / reduced_axis_size)
             }
         };
 
@@ -438,16 +435,4 @@ impl<T: Data> Widget<T> for Split<T> {
         self.child1.paint(ctx, &data, env);
         self.child2.paint(ctx, &data, env);
     }
-}
-
-// Move to std lib clamp as soon as https://github.com/rust-lang/rust/issues/44095 lands
-fn clamp(mut x: f64, min: f64, max: f64) -> f64 {
-    assert!(min <= max);
-    if x < min {
-        x = min;
-    }
-    if x > max {
-        x = max;
-    }
-    x
 }


### PR DESCRIPTION
Suppresses a few new clippy lints and move to using the
std f64::clamp method.