### PR TITLE
Transparent background for tooltips, dropdowns etc.

### DIFF
--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -24,8 +24,8 @@ use std::time::Instant;
 
 use block::ConcreteBlock;
 use cocoa::appkit::{
-    CGFloat, NSApp, NSApplication, NSAutoresizingMaskOptions, NSBackingStoreBuffered, NSEvent,
-    NSView, NSViewHeightSizable, NSViewWidthSizable, NSWindow, NSWindowStyleMask,
+    CGFloat, NSApp, NSApplication, NSAutoresizingMaskOptions, NSBackingStoreBuffered, NSColor,
+    NSEvent, NSView, NSViewHeightSizable, NSViewWidthSizable, NSWindow, NSWindowStyleMask,
 };
 use cocoa::base::{id, nil, BOOL, NO, YES};
 use cocoa::foundation::{
@@ -119,6 +119,7 @@ pub(crate) struct WindowBuilder {
     window_state: Option<WindowState>,
     resizable: bool,
     show_titlebar: bool,
+    transparent: bool,
 }
 
 #[derive(Clone)]
@@ -170,6 +171,7 @@ impl WindowBuilder {
             window_state: None,
             resizable: true,
             show_titlebar: true,
+            transparent: false,
         }
     }
 
@@ -191,6 +193,10 @@ impl WindowBuilder {
 
     pub fn show_titlebar(&mut self, show_titlebar: bool) {
         self.show_titlebar = show_titlebar;
+    }
+
+    pub fn set_transparent(&mut self, transparent: bool) {
+        self.transparent = transparent;
     }
 
     pub fn set_level(&mut self, level: WindowLevel) {
@@ -244,6 +250,11 @@ impl WindowBuilder {
             if let Some(min_size) = self.min_size {
                 let size = NSSize::new(min_size.width, min_size.height);
                 window.setContentMinSize_(size);
+            }
+
+            if self.transparent {
+                window.setOpaque_(NO);
+                window.setBackgroundColor_(NSColor::clearColor(nil));
             }
 
             window.setTitle_(make_nsstring(&self.title));

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -357,6 +357,10 @@ impl WindowBuilder {
         // Ignored
     }
 
+    pub fn set_transparent(&mut self, _transparent: bool) {
+        // Ignored
+    }
+
     pub fn set_position(&mut self, _position: Point) {
         // Ignored
     }

--- a/druid-shell/src/platform/windows/paint.rs
+++ b/druid-shell/src/platform/windows/paint.rs
@@ -46,6 +46,7 @@ pub(crate) unsafe fn create_render_target_dxgi(
     d2d_factory: &D2DFactory,
     swap_chain: *mut IDXGISwapChain1,
     scale: Scale,
+    transparent: bool,
 ) -> Result<DxgiSurfaceRenderTarget, Error> {
     let mut buffer: *mut IDXGISurface = null_mut();
     as_result((*swap_chain).GetBuffer(
@@ -57,7 +58,11 @@ pub(crate) unsafe fn create_render_target_dxgi(
         _type: D2D1_RENDER_TARGET_TYPE_DEFAULT,
         pixelFormat: D2D1_PIXEL_FORMAT {
             format: DXGI_FORMAT_B8G8R8A8_UNORM,
-            alphaMode: D2D1_ALPHA_MODE_IGNORE,
+            alphaMode: if transparent {
+                D2D1_ALPHA_MODE_PREMULTIPLIED
+            } else {
+                D2D1_ALPHA_MODE_IGNORE
+            },
         },
         dpiX: (scale.x() * SCALE_TARGET_DPI) as f32,
         dpiY: (scale.y() * SCALE_TARGET_DPI) as f32,

--- a/druid-shell/src/platform/windows/util.rs
+++ b/druid-shell/src/platform/windows/util.rs
@@ -24,6 +24,9 @@ use std::ptr;
 use std::slice;
 
 use lazy_static::lazy_static;
+use winapi::ctypes::c_void;
+use winapi::shared::dxgi::IDXGIDevice;
+use winapi::shared::guiddef::REFIID;
 use winapi::shared::minwindef::{BOOL, HMODULE, UINT};
 use winapi::shared::ntdef::{HRESULT, LPWSTR};
 use winapi::shared::windef::{HMONITOR, HWND, RECT};
@@ -147,6 +150,11 @@ type GetSystemMetricsForDpi =
 // from shcore.dll
 type GetDpiForMonitor = unsafe extern "system" fn(HMONITOR, MONITOR_DPI_TYPE, *mut UINT, *mut UINT);
 type SetProcessDpiAwareness = unsafe extern "system" fn(PROCESS_DPI_AWARENESS) -> HRESULT;
+type DCompositionCreateDevice = unsafe extern "system" fn(
+    dxgiDevice: *const IDXGIDevice,
+    iid: REFIID,
+    dcompositionDevice: *mut *mut c_void,
+) -> HRESULT;
 
 #[allow(non_snake_case)] // For member fields
 pub struct OptionalFunctions {
@@ -156,6 +164,7 @@ pub struct OptionalFunctions {
     pub GetDpiForMonitor: Option<GetDpiForMonitor>,
     pub SetProcessDpiAwareness: Option<SetProcessDpiAwareness>,
     pub GetSystemMetricsForDpi: Option<GetSystemMetricsForDpi>,
+    pub DCompositionCreateDevice: Option<DCompositionCreateDevice>,
 }
 
 #[allow(non_snake_case)] // For local variables
@@ -201,6 +210,7 @@ fn load_optional_functions() -> OptionalFunctions {
 
     let shcore = load_library("shcore.dll");
     let user32 = load_library("user32.dll");
+    let dcomp = load_library("dcomp.dll");
 
     let mut GetDpiForSystem = None;
     let mut GetDpiForMonitor = None;
@@ -208,6 +218,7 @@ fn load_optional_functions() -> OptionalFunctions {
     let mut SetProcessDpiAwarenessContext = None;
     let mut SetProcessDpiAwareness = None;
     let mut GetSystemMetricsForDpi = None;
+    let mut DCompositionCreateDevice = None;
 
     if shcore.is_null() {
         tracing::info!("No shcore.dll");
@@ -225,6 +236,12 @@ fn load_optional_functions() -> OptionalFunctions {
         load_function!(user32, GetSystemMetricsForDpi, "10");
     }
 
+    if dcomp.is_null() {
+        tracing::info!("No dcomp.dll");
+    } else {
+        load_function!(dcomp, DCompositionCreateDevice, "8.1");
+    }
+
     OptionalFunctions {
         GetDpiForSystem,
         GetDpiForWindow,
@@ -232,6 +249,7 @@ fn load_optional_functions() -> OptionalFunctions {
         GetDpiForMonitor,
         SetProcessDpiAwareness,
         GetSystemMetricsForDpi,
+        DCompositionCreateDevice,
     }
 }
 

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -272,6 +272,8 @@ impl Drop for HCursor {
 const DS_RUN_IDLE: UINT = WM_USER;
 
 /// Transparent bg clearing color
+///
+/// FIXME: Replace usage with Color::TRANSPARENT on next Piet release
 const TRANSPARENT: Color = Color::rgba8(0, 0, 0, 0);
 
 /// Message relaying a request to destroy the window.
@@ -398,15 +400,12 @@ impl WndState {
             // Piet is missing alpha blending setting, so we have to call
             // ID2D1DeviceContext::SetPrimitiveBlend() manually to clear just
             // the required pixels
-            let dc_for_transparency: Option<&ComPtr<ID2D1DeviceContext>> = if self.transparent {
-                Some(unsafe {
+            let dc_for_transparency: Option<&ComPtr<ID2D1DeviceContext>> =
+                self.transparent.then(|| unsafe {
                     (rt as *mut _ as *mut ComPtr<ID2D1DeviceContext>)
                         .as_ref()
                         .unwrap()
-                })
-            } else {
-                None
-            };
+                });
 
             let mut piet_ctx = Piet::new(d2d, dw.clone(), rt);
 

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -133,6 +133,10 @@ impl WindowBuilder {
         warn!("WindowBuilder::show_titlebar is currently unimplemented for X11 platforms.");
     }
 
+    pub fn set_transparent(&mut self, _transparent: bool) {
+        // Ignored
+    }
+
     pub fn set_position(&mut self, _position: Point) {
         warn!("WindowBuilder::set_position is currently unimplemented for X11 platforms.");
     }

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -388,6 +388,11 @@ impl WindowBuilder {
         self.0.show_titlebar(show_titlebar)
     }
 
+    /// Set whether the window background should be transparent
+    pub fn set_transparent(&mut self, transparent: bool) {
+        self.0.set_transparent(transparent)
+    }
+
     /// Sets the initial window position in [pixels](crate::Scale), relative to the origin of the
     /// virtual screen.
     pub fn set_position(&mut self, position: Point) {

--- a/druid/examples/transparency.rs
+++ b/druid/examples/transparency.rs
@@ -1,0 +1,88 @@
+// Copyright 2019 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! An example of a transparent window background.
+//! Useful for dropdowns, tooltips and other overlay windows.
+
+use druid::kurbo::Circle;
+use druid::widget::prelude::*;
+use druid::widget::{Button, Flex};
+use druid::{AppLauncher, Color, Rect, WindowDesc};
+
+struct CustomWidget;
+
+impl Widget<String> for CustomWidget {
+    fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut String, _env: &Env) {}
+
+    fn lifecycle(
+        &mut self,
+        _ctx: &mut LifeCycleCtx,
+        _event: &LifeCycle,
+        _data: &String,
+        _env: &Env,
+    ) {
+    }
+
+    fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: &String, _data: &String, _env: &Env) {}
+
+    fn layout(
+        &mut self,
+        _layout_ctx: &mut LayoutCtx,
+        bc: &BoxConstraints,
+        _data: &String,
+        _env: &Env,
+    ) -> Size {
+        bc.max()
+    }
+
+    // The paint method gets called last, after an event flow.
+    // It goes event -> update -> layout -> paint, and each method can influence the next.
+    // Basically, anything that changes the appearance of a widget causes a paint.
+    fn paint(&mut self, ctx: &mut PaintCtx, _data: &String, _env: &Env) {
+        let boundaries = ctx.size().to_rect();
+        let center = (boundaries.width() / 2., boundaries.height() / 2.);
+        let circle = Circle::new(center, center.0.min(center.1));
+        ctx.fill(circle, &Color::RED);
+
+        let rect1 = Rect::new(0., 0., boundaries.width() / 2., boundaries.height() / 2.);
+        ctx.fill(rect1, &Color::rgba8(0x0, 0xff, 0, 125));
+
+        let rect2 = Rect::new(
+            boundaries.width() / 2.,
+            boundaries.height() / 2.,
+            boundaries.width(),
+            boundaries.height(),
+        );
+        ctx.fill(rect2, &Color::rgba8(0x0, 0x0, 0xff, 125));
+    }
+}
+
+pub fn main() {
+    let btn = Button::new("Example button on transparent bg");
+    let example = Flex::column()
+        .with_flex_child(CustomWidget {}, 10.0)
+        .with_flex_child(btn, 1.0);
+    let window = WindowDesc::new(example)
+        .show_titlebar(false)
+        .set_position((50., 50.))
+        .window_size((823., 823.))
+        .transparent(true)
+        .resizable(true)
+        .title("Transparent background");
+
+    AppLauncher::with_window(window)
+        .use_simple_logger()
+        .launch("Druid + Piet".to_string())
+        .expect("launch failed");
+}

--- a/druid/examples/transparency.rs
+++ b/druid/examples/transparency.rs
@@ -82,7 +82,7 @@ pub fn main() {
         .title("Transparent background");
 
     AppLauncher::with_window(window)
-        .use_simple_logger()
+        .use_env_tracing()
         .launch("Druid + Piet".to_string())
         .expect("launch failed");
 }

--- a/druid/examples/transparency.rs
+++ b/druid/examples/transparency.rs
@@ -17,39 +17,12 @@
 
 use druid::kurbo::Circle;
 use druid::widget::prelude::*;
-use druid::widget::{Button, Flex};
+use druid::widget::{Button, Flex, Painter, WidgetExt};
 use druid::{AppLauncher, Color, Rect, WindowDesc};
 
-struct CustomWidget;
-
-impl Widget<String> for CustomWidget {
-    fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut String, _env: &Env) {}
-
-    fn lifecycle(
-        &mut self,
-        _ctx: &mut LifeCycleCtx,
-        _event: &LifeCycle,
-        _data: &String,
-        _env: &Env,
-    ) {
-    }
-
-    fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: &String, _data: &String, _env: &Env) {}
-
-    fn layout(
-        &mut self,
-        _layout_ctx: &mut LayoutCtx,
-        bc: &BoxConstraints,
-        _data: &String,
-        _env: &Env,
-    ) -> Size {
-        bc.max()
-    }
-
-    // The paint method gets called last, after an event flow.
-    // It goes event -> update -> layout -> paint, and each method can influence the next.
-    // Basically, anything that changes the appearance of a widget causes a paint.
-    fn paint(&mut self, ctx: &mut PaintCtx, _data: &String, _env: &Env) {
+pub fn main() {
+    // Draw red circle, and two semi-transparent rectangles
+    let circle_and_rects = Painter::new(|ctx, _data, _env| {
         let boundaries = ctx.size().to_rect();
         let center = (boundaries.width() / 2., boundaries.height() / 2.);
         let circle = Circle::new(center, center.0.min(center.1));
@@ -65,15 +38,15 @@ impl Widget<String> for CustomWidget {
             boundaries.height(),
         );
         ctx.fill(rect2, &Color::rgba8(0x0, 0x0, 0xff, 125));
-    }
-}
+    });
 
-pub fn main() {
     let btn = Button::new("Example button on transparent bg");
-    let example = Flex::column()
-        .with_flex_child(CustomWidget {}, 10.0)
+
+    let root_widget = Flex::column()
+        .with_flex_child(circle_and_rects.expand(), 10.0)
         .with_flex_child(btn, 1.0);
-    let window = WindowDesc::new(example)
+
+    let window = WindowDesc::new(root_widget)
         .show_titlebar(false)
         .set_position((50., 50.))
         .window_size((823., 823.))

--- a/druid/examples/web/src/lib.rs
+++ b/druid/examples/web/src/lib.rs
@@ -79,6 +79,7 @@ impl_example!(styled_text.unwrap());
 impl_example!(switches);
 impl_example!(timer);
 impl_example!(tabs);
+impl_example!(transparency);
 impl_example!(view_switcher);
 impl_example!(widget_gallery);
 impl_example!(text);

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -57,6 +57,7 @@ pub struct WindowConfig {
     pub(crate) min_size: Option<Size>,
     pub(crate) position: Option<Point>,
     pub(crate) resizable: Option<bool>,
+    pub(crate) transparent: Option<bool>,
     pub(crate) show_titlebar: Option<bool>,
     pub(crate) level: Option<WindowLevel>,
     pub(crate) state: Option<WindowState>,
@@ -79,6 +80,7 @@ pub struct WindowDesc<T> {
 pub struct PendingWindow<T> {
     pub(crate) root: Box<dyn Widget<T>>,
     pub(crate) title: LabelText<T>,
+    pub(crate) transparent: bool,
     pub(crate) menu: Option<MenuDesc<T>>,
     pub(crate) size_policy: WindowSizePolicy, // This is copied over from the WindowConfig
                                               // when the native window is constructed.
@@ -95,6 +97,7 @@ impl<T: Data> PendingWindow<T> {
             root: Box::new(root),
             title: LocalizedString::new("app-name").into(),
             menu: MenuDesc::platform_default(),
+            transparent: false,
             size_policy: WindowSizePolicy::User,
         }
     }
@@ -107,6 +110,12 @@ impl<T: Data> PendingWindow<T> {
     /// [`LocalizedString`]: struct.LocalizedString.html
     pub fn title(mut self, title: impl Into<LabelText<T>>) -> Self {
         self.title = title.into();
+        self
+    }
+
+    /// Set wether the background should be transparent
+    pub fn transparent(mut self, transparent: bool) -> Self {
+        self.transparent = transparent;
         self
     }
 
@@ -265,6 +274,7 @@ impl Default for WindowConfig {
             position: None,
             resizable: None,
             show_titlebar: None,
+            transparent: None,
             level: None,
             state: None,
         }
@@ -352,6 +362,12 @@ impl WindowConfig {
         self
     }
 
+    /// Set whether the window background should be transparent
+    pub fn transparent(mut self, transparent: bool) -> Self {
+        self.transparent = Some(transparent);
+        self
+    }
+
     /// Apply this window configuration to the passed in WindowBuilder
     pub fn apply_to_builder(&self, builder: &mut WindowBuilder) {
         if let Some(resizable) = self.resizable {
@@ -370,6 +386,10 @@ impl WindowConfig {
 
         if let Some(position) = self.position {
             builder.set_position(position);
+        }
+
+        if let Some(transparent) = self.transparent {
+            builder.set_transparent(transparent);
         }
 
         if let Some(level) = self.level {
@@ -500,6 +520,14 @@ impl<T: Data> WindowDesc<T> {
     /// Builder-style method to set whether this window's titlebar is visible.
     pub fn show_titlebar(mut self, show_titlebar: bool) -> Self {
         self.config = self.config.show_titlebar(show_titlebar);
+        self
+    }
+
+    /// Builder-style method to set whether this window's background should be
+    /// transparent.
+    pub fn transparent(mut self, transparent: bool) -> Self {
+        self.config = self.config.transparent(transparent);
+        self.pending = self.pending.transparent(transparent);
         self
     }
 

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -35,6 +35,7 @@ use crate::{
     TimerToken, UpdateCtx, Widget, WidgetId, WidgetPod,
 };
 
+/// FIXME: Replace usage with Color::TRANSPARENT on next Piet release
 const TRANSPARENT: Color = Color::rgba8(0, 0, 0, 0);
 
 /// A unique identifier for a window.

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -20,7 +20,7 @@ use std::mem;
 // Automatically defaults to std::time::Instant on non Wasm platforms
 use instant::Instant;
 
-use crate::piet::{Piet, RenderContext};
+use crate::piet::{Color, Piet, RenderContext};
 use crate::shell::{Counter, Cursor, Region, WindowHandle};
 
 use crate::app::{PendingWindow, WindowSizePolicy};
@@ -34,6 +34,8 @@ use crate::{
     InternalLifeCycle, LayoutCtx, LifeCycle, LifeCycleCtx, MenuDesc, PaintCtx, Point, Size,
     TimerToken, UpdateCtx, Widget, WidgetId, WidgetPod,
 };
+
+const TRANSPARENT: Color = Color::rgba8(0, 0, 0, 0);
 
 /// A unique identifier for a window.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -55,6 +57,7 @@ pub struct Window<T> {
     pub(crate) focus: Option<WidgetId>,
     pub(crate) handle: WindowHandle,
     pub(crate) timers: HashMap<TimerToken, WidgetId>,
+    pub(crate) transparent: bool,
     ext_handle: ExtEventSink,
     // delegate?
 }
@@ -73,6 +76,7 @@ impl<T> Window<T> {
             size: Size::ZERO,
             invalid: Region::EMPTY,
             title: pending.title,
+            transparent: pending.transparent,
             menu: pending.menu,
             context_menu: None,
             last_anim: None,
@@ -364,7 +368,11 @@ impl<T: Data> Window<T> {
 
         piet.fill(
             invalid.bounding_box(),
-            &env.get(crate::theme::WINDOW_BACKGROUND_COLOR),
+            &(if self.transparent {
+                TRANSPARENT
+            } else {
+                env.get(crate::theme::WINDOW_BACKGROUND_COLOR)
+            }),
         );
         self.paint(piet, invalid, queue, data, env);
     }


### PR DESCRIPTION
Goal is to allow create overlay windows, such as tooltips, dropdowns etc. by simply setting the backround of the window to transparent. It also allowes to do windows without decorations (#427) and would be better way for creating overlay widgets (#1577). Additionally #1249.

https://xi.zulipchat.com/#narrow/stream/147926-druid/topic/Semi-transparent.20windows.20without.20titlebars

For instance transparency is required to make tooltip shaped window:

<img src="https://user-images.githubusercontent.com/64731/107711424-4ca7e100-6cd0-11eb-83e5-c4c35893ab03.png" width="110" />

Or dropdown window with custom shadows:

<img src="https://user-images.githubusercontent.com/64731/107711737-cb048300-6cd0-11eb-96d1-ff19148b3b87.png" width="200" />

Or if you want to make your UI go full WinAmp style from 90's:

<img src="https://user-images.githubusercontent.com/64731/108082087-5d62a900-707a-11eb-9fcd-190a84d1640a.png" width="200" />

---

New API for window builder `transparent`:

```rust
    let main_window = WindowDesc::new(build_root_widget())
        .title("Hello World!")
        .transparent(true) // <-- NEW SETTING HERE
        .window_size((400.0, 400.0));
```

To get fully transparent background, hide also the title bar with `show_titlebar(false)`.

---

Changes include a simple example in `examples/transparency.rs`, currently it renders a test widget like this on a transparent background:

<img src="https://user-images.githubusercontent.com/64731/107776818-bd8bdf00-6d4a-11eb-9c3a-19bae6768583.png" width="390" />


---

Note about Windows 10 code changes: This feature is not supposed to change any behavior of non-transparent windows at all, the opaque windows still should use the same code as before.

The method I chose follows this tutorial: ["Windows with C++ : High-Performance Window Layering Using the Windows Composition Engine"](https://docs.microsoft.com/en-us/archive/msdn-magazine/2014/june/windows-with-c-high-performance-window-layering-using-the-windows-composition-engine), it's the most recent, I asked about that in [window-rs repo](https://github.com/microsoft/windows-rs/issues/541). 

Included are Mac support by @rjwittams, and Linux (GTK) support by @JAicewizard. X11 and web support is stubbed.
