### PR TITLE
Implement HasRawWindowHandle trait for win/mac

### DIFF
--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -18,7 +18,7 @@ default = ["gtk"]
 gtk = ["gio", "gdk", "gdk-sys", "glib", "glib-sys", "gtk-sys", "gtk-rs", "gdk-pixbuf"]
 x11 = ["x11rb", "nix", "cairo-sys-rs"]
 # Implement HasRawWindowHandle for WindowHandle 
-raw-win-handle = ["libc", "raw-window-handle"]
+raw-win-handle = ["raw-window-handle"]
 
 # passing on all the image features. AVIF is not supported because it does not
 # support decoding, and that's all we use `Image` for.
@@ -54,7 +54,6 @@ keyboard-types = { version = "0.5.0", default_features = false }
 # Optional dependencies
 image = { version = "0.23.12", optional = true, default_features = false }
 raw-window-handle = { version = "0.3.3", optional = true, default_features = false }
-libc = { version = "0.2.81", optional = true, default_features = false }
 
 [target.'cfg(target_os="windows")'.dependencies]
 scopeguard = "1.1.0"

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -17,6 +17,8 @@ default-target = "x86_64-pc-windows-msvc"
 default = ["gtk"]
 gtk = ["gio", "gdk", "gdk-sys", "glib", "glib-sys", "gtk-sys", "gtk-rs", "gdk-pixbuf"]
 x11 = ["x11rb", "nix", "cairo-sys-rs"]
+# Implement HasRawWindowHandle for WindowHandle 
+raw-win-handle = ["libc", "raw-window-handle"]
 
 # passing on all the image features. AVIF is not supported because it does not
 # support decoding, and that's all we use `Image` for.
@@ -51,6 +53,8 @@ keyboard-types = { version = "0.5.0", default_features = false }
 
 # Optional dependencies
 image = { version = "0.23.12", optional = true, default_features = false }
+raw-window-handle = { version = "0.3.3", optional = true, default_features = false }
+libc = { version = "0.2.81", optional = true, default_features = false }
 
 [target.'cfg(target_os="windows")'.dependencies]
 scopeguard = "1.1.0"

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -100,7 +100,7 @@ pub struct WindowHandle {
 #[cfg(feature = "raw-win-handle")]
 unsafe impl HasRawWindowHandle for WindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle {
-        error!("HasRawWindowHandle trait not implemented for gtk.")
+        error!("HasRawWindowHandle trait not implemented for gtk.");
         // GTK is not a platform, and there's no empty generic handle. Pick XCB randomly as fallback.
         RawWindowHandle::Xcb(XcbHandle::empty())
     }

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -100,7 +100,9 @@ pub struct WindowHandle {
 #[cfg(feature = "raw-win-handle")]
 unsafe impl HasRawWindowHandle for WindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle {
-        panic!("HasRawWindowHandle trait not implemented for gtk.")
+        error!("HasRawWindowHandle trait not implemented for gtk.")
+        // GTK is not a platform, and there's no empty generic handle. Pick XCB randomly as fallback.
+        RawWindowHandle::Xcb(XcbHandle::empty())
     }
 }
 

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -32,6 +32,9 @@ use gio::ApplicationExt;
 use gtk::prelude::*;
 use gtk::{AccelGroup, ApplicationWindow, DrawingArea, SettingsExt};
 
+#[cfg(feature = "raw-win-handle")]
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+
 use crate::kurbo::{Insets, Point, Rect, Size, Vec2};
 use crate::piet::{Piet, PietText, RenderContext};
 
@@ -92,6 +95,13 @@ pub struct WindowHandle {
     pub(crate) state: Weak<WindowState>,
     // Ensure that we don't implement Send, because it isn't actually safe to send the WindowState.
     marker: std::marker::PhantomData<*const ()>,
+}
+
+#[cfg(feature = "raw-win-handle")]
+unsafe impl HasRawWindowHandle for WindowHandle {
+    fn raw_window_handle(&self) -> RawWindowHandle {
+        panic!("HasRawWindowHandle trait not implemented for gtk.")
+    }
 }
 
 /// Operations that we defer in order to avoid re-entrancy. See the documentation in the windows

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -40,6 +40,9 @@ use objc::rc::WeakPtr;
 use objc::runtime::{Class, Object, Sel};
 use objc::{class, msg_send, sel, sel_impl};
 
+#[cfg(feature = "raw-win-handle")]
+use raw_window_handle::{macos::MacOSHandle, HasRawWindowHandle, RawWindowHandle};
+
 use crate::kurbo::{Insets, Point, Rect, Size, Vec2};
 use crate::piet::{Piet, PietText, RenderContext};
 
@@ -1211,6 +1214,18 @@ impl WindowHandle {
     pub fn get_scale(&self) -> Result<Scale, Error> {
         // TODO: Get actual Scale
         Ok(Scale::new(1.0, 1.0))
+    }
+}
+
+#[cfg(feature = "raw-win-handle")]
+unsafe impl HasRawWindowHandle for WindowHandle {
+    fn raw_window_handle(&self) -> RawWindowHandle {
+        let nsv = self.nsview.load();
+        let handle = MacOSHandle {
+            ns_view: *nsv as *mut _,
+            ..MacOSHandle::empty()
+        };
+        RawWindowHandle::MacOS(handle)
     }
 }
 

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -81,7 +81,8 @@ pub struct WindowHandle(Weak<WindowState>);
 #[cfg(feature = "raw-win-handle")]
 unsafe impl HasRawWindowHandle for WindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle {
-        panic!("HasRawWindowHandle trait not implemented for wasm.")
+        error!("HasRawWindowHandle trait not implemented for wasm.")
+        RawWindowHandle::Web(WebHandle::empty())
     }
 }
 

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -25,6 +25,9 @@ use instant::Instant;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
+#[cfg(feature = "raw-win-handle")]
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+
 use crate::kurbo::{Insets, Point, Rect, Size, Vec2};
 
 use crate::piet::{PietText, RenderContext};
@@ -74,6 +77,13 @@ pub(crate) struct WindowBuilder {
 
 #[derive(Clone, Default)]
 pub struct WindowHandle(Weak<WindowState>);
+
+#[cfg(feature = "raw-win-handle")]
+unsafe impl HasRawWindowHandle for WindowHandle {
+    fn raw_window_handle(&self) -> RawWindowHandle {
+        panic!("HasRawWindowHandle trait not implemented for wasm.")
+    }
+}
 
 /// A handle that can get used to schedule an idle handler. Note that
 /// this handle is thread safe.

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -81,7 +81,7 @@ pub struct WindowHandle(Weak<WindowState>);
 #[cfg(feature = "raw-win-handle")]
 unsafe impl HasRawWindowHandle for WindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle {
-        error!("HasRawWindowHandle trait not implemented for wasm.")
+        error!("HasRawWindowHandle trait not implemented for wasm.");
         RawWindowHandle::Web(WebHandle::empty())
     }
 }

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -176,7 +176,7 @@ unsafe impl HasRawWindowHandle for WindowHandle {
             };
             RawWindowHandle::Windows(handle)
         } else {
-            panic!("Cannot retrieved HWMD for window.");
+            panic!("Cannot retrieved HWND for window.");
         }
     }
 }

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -167,10 +167,10 @@ unsafe impl HasRawWindowHandle for WindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle {
         if let Some(hwnd) = self.get_hwnd() {
             let handle = WindowsHandle {
-                hwnd: hwnd as *mut libc::c_void,
+                hwnd: hwnd as *mut core::ffi::c_void,
                 hinstance: unsafe {
                     winapi::um::libloaderapi::GetModuleHandleW(0 as winapi::um::winnt::LPCWSTR)
-                        as *mut libc::c_void
+                        as *mut core::ffi::c_void
                 },
                 ..WindowsHandle::empty()
             };

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -176,7 +176,8 @@ unsafe impl HasRawWindowHandle for WindowHandle {
             };
             RawWindowHandle::Windows(handle)
         } else {
-            panic!("Cannot retrieved HWND for window.");
+            error!("Cannot retrieved HWND for window.");
+            RawWindowHandle::Windows(WindowsHandle::empty())
         }
     }
 }

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -1554,6 +1554,7 @@ impl WindowHandle {
 #[cfg(feature = "raw-win-handle")]
 unsafe impl HasRawWindowHandle for WindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle {
-        panic!("HasRawWindowHandle trait not implemented for x11.")
+        error!("HasRawWindowHandle trait not implemented for x11.")
+        RawWindowHandle::Xcb(XcbHandle::empty())
     }
 }

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -1554,7 +1554,7 @@ impl WindowHandle {
 #[cfg(feature = "raw-win-handle")]
 unsafe impl HasRawWindowHandle for WindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle {
-        error!("HasRawWindowHandle trait not implemented for x11.")
+        error!("HasRawWindowHandle trait not implemented for x11.");
         RawWindowHandle::Xcb(XcbHandle::empty())
     }
 }

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -37,6 +37,9 @@ use x11rb::protocol::xproto::{
 use x11rb::wrapper::ConnectionExt as _;
 use x11rb::xcb_ffi::XCBConnection;
 
+#[cfg(feature = "raw-win-handle")]
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+
 use crate::common_util::IdleCallback;
 use crate::dialog::FileDialogOptions;
 use crate::error::Error as ShellError;
@@ -1545,5 +1548,12 @@ impl WindowHandle {
             log::error!("Window {} has already been dropped", self.id);
             Ok(Scale::new(1.0, 1.0))
         }
+    }
+}
+
+#[cfg(feature = "raw-win-handle")]
+unsafe impl HasRawWindowHandle for WindowHandle {
+    fn raw_window_handle(&self) -> RawWindowHandle {
+        panic!("HasRawWindowHandle trait not implemented for x11.")
     }
 }

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -29,6 +29,8 @@ use crate::platform::window as platform;
 use crate::region::Region;
 use crate::scale::Scale;
 use piet_common::PietText;
+#[cfg(feature = "raw-win-handle")]
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 
 /// A token that uniquely identifies a running timer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
@@ -335,6 +337,13 @@ impl WindowHandle {
     /// only guaranteed to be valid for the current pass of the runloop.
     pub fn get_scale(&self) -> Result<Scale, Error> {
         self.0.get_scale().map_err(Into::into)
+    }
+}
+
+#[cfg(feature = "raw-win-handle")]
+unsafe impl HasRawWindowHandle for WindowHandle {
+    fn raw_window_handle(&self) -> RawWindowHandle {
+        self.0.raw_window_handle()
     }
 }
 


### PR DESCRIPTION
Implement the HasRawWindowHandle trait for Windows and macOS platforms,
to allow access to native window handles for interop.