### PR TITLE
Add type parameters to generated lenses of generic structs.

### DIFF
--- a/druid-derive/src/lens.rs
+++ b/druid-derive/src/lens.rs
@@ -62,6 +62,23 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
             "Lens implementations can only be derived from CamelCase types",
         ));
     };
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let mut lens_ty_idents = Vec::new();
+    let mut phantom_decls = Vec::new();
+    let mut phantom_inits = Vec::new();
+
+    for gp in input.generics.params.iter() {
+        if let GenericParam::Type(TypeParam { ident, .. }) = gp {
+            lens_ty_idents.push(quote! {#ident});
+            phantom_decls.push(quote! {std::marker::PhantomData<*const #ident>});
+            phantom_inits.push(quote! {std::marker::PhantomData});
+        }
+    }
+
+    let lens_ty_generics = quote! {
+        <#(#lens_ty_idents),*>
+    };
 
     // Define lens types for each field
     let defs = fields.iter().filter(|f| !f.attrs.ignore).map(|f| {
@@ -70,14 +87,20 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
             "Lens for the field `{}` on [`{1}`](super::{1})",
             field_name, ty
         );
+
         quote! {
             #[doc = #docs]
             #[allow(non_camel_case_types)]
             #[derive(Debug, Copy, Clone)]
-            pub struct #field_name;
+            pub struct #field_name#lens_ty_generics(#(#phantom_decls),*);
+
+            impl #lens_ty_generics #field_name#lens_ty_generics{
+                pub const fn new()->Self{
+                    Self(#(#phantom_inits),*)
+                }
+            }
         }
     });
-    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     let used_params: HashSet<String> = input
         .generics
@@ -107,7 +130,8 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
         let field_ty = &f.ty;
 
         quote! {
-            impl #impl_generics druid::Lens<#ty#ty_generics, #field_ty> for #twizzled_name::#field_name #where_clause {
+
+            impl #impl_generics druid::Lens<#ty#ty_generics, #field_ty> for #twizzled_name::#field_name#lens_ty_generics #where_clause {
                 fn with<#val_ty_par, #func_ty_par: FnOnce(&#field_ty) -> #val_ty_par>(&self, data: &#ty#ty_generics, f: #func_ty_par) -> #val_ty_par {
                     f(&data.#field_name)
                 }
@@ -125,7 +149,7 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
 
         quote! {
             /// Lens for the corresponding field
-            pub const #lens_field_name: #twizzled_name::#field_name = #twizzled_name::#field_name;
+            pub const #lens_field_name: #twizzled_name::#field_name#lens_ty_generics = #twizzled_name::#field_name::new();
         }
     });
 

--- a/druid-derive/tests/lens_generic.rs
+++ b/druid-derive/tests/lens_generic.rs
@@ -1,4 +1,4 @@
-use druid::Lens;
+use druid::{Lens, LensExt};
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
@@ -108,7 +108,8 @@ fn where_clause() {
 
 #[derive(Lens)]
 struct ReservedParams<F, V> {
-    f: F, // We were using V and F as method params
+    f: F,
+    // We were using V and F as method params
     v: V,
 }
 
@@ -120,4 +121,47 @@ fn reserved() {
     };
     let val = ReservedParams::<u64, String>::f.with(&rp, |val| *val);
     assert_eq!(rp.f, val);
+}
+
+#[derive(Lens)]
+struct Outer<T> {
+    middle: Middle,
+    t: T,
+}
+
+#[derive(Lens)]
+struct Middle {
+    internal: usize,
+}
+
+#[test]
+fn then_inference() {
+    let outer = Outer {
+        t: -9i32,
+        middle: Middle { internal: 89 },
+    };
+
+    let lens = Outer::<i32>::middle.then(Middle::internal);
+    let val = lens.with(&outer, |val| *val);
+    assert_eq!(outer.middle.internal, val);
+
+    let outer = Outer {
+        t: Middle { internal: 12 },
+        middle: Middle { internal: 567 },
+    };
+
+    let lens = Outer::<Middle>::t.then(Middle::internal);
+    let val = lens.with(&outer, |val| *val);
+    assert_eq!(outer.t.internal, val);
+
+    let lt_wrapper = LifetimeWrapper {
+        x: Middle { internal: 45 },
+        phantom_a: Default::default(),
+    };
+
+    let lens = LifetimeWrapper::<'static, Middle>::x.then(Middle::internal);
+    let val = lens.with(&lt_wrapper, |val| *val);
+    assert_eq!(lt_wrapper.x.internal, val);
+
+    //let outer = Outer
 }

--- a/druid/src/widget/tabs.rs
+++ b/druid/src/widget/tabs.rs
@@ -279,10 +279,7 @@ impl<TP: TabsPolicy> TabBar<TP> {
             let label = data
                 .policy
                 .tab_label(key.clone(), info, &data.inner)
-                // TODO: Type inference fails here because both sides of the lens are dependent on
-                // associated types of the policy. Needs changes to lens derivation to embed PhantomData of the (relevant?) type params)
-                // of the lensed types into the lens, so type inference has something to grab hold of
-                .lens::<TabsState<TP>, tabs_state_derived_lenses::inner>(TabsState::<TP>::inner)
+                .lens(TabsState::<TP>::inner)
                 .padding(Insets::uniform_xy(9., 5.));
 
             if can_close {
@@ -718,7 +715,7 @@ impl<TP> TabsScopePolicy<TP> {
 impl<TP: TabsPolicy> ScopePolicy for TabsScopePolicy<TP> {
     type In = TP::Input;
     type State = TabsState<TP>;
-    type Transfer = LensScopeTransfer<tabs_state_derived_lenses::inner, Self::In, Self::State>;
+    type Transfer = LensScopeTransfer<tabs_state_derived_lenses::inner<TP>, Self::In, Self::State>;
 
     fn create(self, inner: &Self::In) -> (Self::State, Self::Transfer) {
         (


### PR DESCRIPTION
This gives type inference something to grab hold of when chaining
LensExt methods or using WidgetExt::lens.
It removes the need for providing annoying and hard to work out type arguments to some method calls (removed one in Tabs).

This changes generated lenses from unit structs to field structs to hold PhantomDatas, so construction is more involved. It also adds generic parameters to these structs, so their types are changed. 
A new method wasn't generated and used for the const fields in the targets impl, as lifetime parameters on const functions are unstable. 
