### PR TITLE
Always clear invalid regions if performing layout

### DIFF
--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -318,8 +318,8 @@ impl<T: Data> Window<T> {
             for rect in self.invalid.rects() {
                 self.handle.invalidate_rect(*rect);
             }
-            self.invalid.clear();
         }
+        self.invalid.clear();
     }
 
     #[cfg(test)]


### PR DESCRIPTION
It has taken me a large number of hours to decide on this particular
one-line fix, and I'm still not 100% sure what's going on.

That said, the logic now feels more correct: if we're invalidating
everything then that necessarily means we're invalidating whatever
rects were in the list, and we can ignore them.

More concretely, I think this was a bug; by leaving the invalid
rects in place, a subsequent call to `invalidate_and_finalize` would
see the left over rects and invalidate again, unnecessarily.

I do *not* know why this bug caused (or was a factor in) #1593.

My best guess is that there was a change to how macOS handles
setNeedsDisplayInRect: when it is called from viewWillDraw:; my
guess is that if you call this method after having previously called
setNeedsDisplay: it will assume that the new rect is more accurate
than the previous blanket invalidation, and will only redraw the
new rect.

I'm not convinced of this explanation, though. In particular,
it looks like our drawRect call is still being passed the expected
rect, the pixels just end up not the ones we expect.

Okay, here's my *revised* theory; the additional invalidation
is triggering a second paint call before the frame deadline, and
so the initial paint work, which covered the entire window, is
discarded; the second paint call does not update the regions
that weren't explicitly invalidated, and so we end up failing
to repaint portions of the view.

I think that might be it.

---- 
review:

I think the actual manifestation of the bug that motivated this change is os dependent; I've only seen it on macOS 10.15.x. I think it should be possible to bench check the logic, though, and some println debugging shows, at least in my case, that I'm now doing one less paint call.