### PR TITLE
Resolve ISO_Left_Tab key to tab

### DIFF
--- a/druid-shell/src/platform/gtk/keycodes.rs
+++ b/druid-shell/src/platform/gtk/keycodes.rs
@@ -26,7 +26,7 @@ pub fn raw_key_to_key(raw: RawKey) -> Option<Key> {
     Some(match raw {
         Escape => Key::Escape,
         BackSpace => Key::Backspace,
-        Tab => Key::Tab,
+        Tab | ISO_Left_Tab => Key::Tab,
         Return => Key::Enter,
         Control_L | Control_R => Key::Control,
         Alt_L | Alt_R => Key::Alt,


### PR DESCRIPTION
This is sent by gtk when tab is pressed with shift down.

- closes #1595

@xarvic, this should fix your problem, you're welcome to double-check though!