### PR TITLE
Don't deliver InternalLifecycle::ParentWindowOrigin to hidden widgets

### DIFF
--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -394,8 +394,25 @@ impl LifeCycle {
     /// (for example the hidden tabs in a tabs widget).
     pub fn should_propagate_to_hidden(&self) -> bool {
         match self {
-            LifeCycle::WidgetAdded | LifeCycle::Internal(_) => true,
+            LifeCycle::Internal(internal) => internal.should_propagate_to_hidden(),
+            LifeCycle::WidgetAdded => true,
             LifeCycle::Size(_) | LifeCycle::HotChanged(_) | LifeCycle::FocusChanged(_) => false,
+        }
+    }
+}
+
+impl InternalLifeCycle {
+    /// Whether this event should be sent to widgets which are currently not visible
+    /// (for example the hidden tabs in a tabs widget).
+    pub fn should_propagate_to_hidden(&self) -> bool {
+        match self {
+            InternalLifeCycle::RouteWidgetAdded | InternalLifeCycle::RouteFocusChanged { .. } => {
+                true
+            }
+            InternalLifeCycle::ParentWindowOrigin => false,
+            #[cfg(test)]
+            InternalLifeCycle::DebugRequestState { .. }
+            | InternalLifeCycle::DebugInspectState(_) => true,
         }
     }
 }


### PR DESCRIPTION
… (e.g in Either). Because they aren't laid out, the needs_layout flag of their widget pod gets merged up and eventually causes over invalidation of the window handle. On macOS 10.15, this is inexplicably segfault worthy.