### PR TITLE
Convenience traits for code generic over contexts.

### DIFF
--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -45,6 +45,16 @@ macro_rules! impl_context_method {
     };
 }
 
+macro_rules! impl_context_trait{
+    ($tr:ty => $ty:ty,  { $($method:item)+ } ) => {
+        impl $tr for $ty { $($method)+ }
+    };
+    ($tr:ty => $ty:ty, $($more:ty),+, { $($method:item)+ } ) => {
+        impl_context_trait!($tr => $ty, { $($method)+ });
+        impl_context_trait!($tr => $($more),+, { $($method)+ });
+    };
+}
+
 /// Static state that is shared between most contexts.
 pub(crate) struct ContextState<'a> {
     pub(crate) command_queue: &'a mut CommandQueue,
@@ -166,6 +176,42 @@ impl_context_method!(
     }
 );
 
+/// Convenience trait for code generic over contexts. Methods provided by all contexts.
+pub trait AnyCtx {
+    /// get the `WidgetId` of the current widget.
+    fn widget_id(&self) -> WidgetId;
+
+    /// Returns a reference to the current `WindowHandle`.
+    fn window(&self) -> &WindowHandle;
+
+    /// Get the `WindowId` of the current window.
+    fn window_id(&self) -> WindowId;
+
+    /// Get an object which can create text layouts.
+    fn text(&mut self) -> &mut PietText;
+}
+
+impl_context_trait!(
+   AnyCtx => EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>,PaintCtx<'_, '_, '_>, LayoutCtx<'_, '_>,
+   {
+        fn widget_id(&self) -> WidgetId {
+            Self::widget_id(self)
+        }
+
+        fn window(&self) -> &WindowHandle {
+            Self::window(self)
+        }
+
+        fn window_id(&self) -> WindowId {
+            Self::window_id(self)
+        }
+
+        fn text(&mut self) -> &mut PietText {
+            Self::text(self)
+        }
+   }
+);
+
 // methods on everyone but layoutctx
 impl_context_method!(
     EventCtx<'_, '_>,
@@ -276,6 +322,79 @@ impl_context_method!(
     }
 );
 
+/// Convenience trait for code generic over contexts. Methods providing layout information: available on all but LayoutCtx.
+pub trait LaidOutCtx {
+    /// The layout size.
+    ///
+    /// ['size']: EventCtx::size
+    fn size(&self) -> Size;
+    /// The origin of the widget in window coordinates. See ['window_origin']
+    ///
+    /// [window_origin]: EventCtx::window_origin
+    fn window_origin(&self) -> Point;
+    /// Convert a point from the widget's coordinate space to the window's. See ['to_window']
+    ///
+    /// [to_window]: EventCtx::to_window
+    fn to_window(&self, widget_point: Point) -> Point;
+    /// Convert a point from the widget's coordinate space to the screen's. See ['to_screen']
+    ///
+    /// ['to_screen']: EventCtx::to_screen
+    fn to_screen(&self, widget_point: Point) -> Point;
+    /// The "hot" status of a widget. See ['is_hot']
+    ///
+    /// ['is_hot']: EventCtx::is_hot
+    fn is_hot(&self) -> bool;
+    /// The active status of a widget. See ['is_active']
+    ///
+    /// ['is_active']: EventCtx::is_active
+    fn is_active(&self) -> bool;
+    /// The focus status of a widget. See ['is_focused']
+    ///
+    /// ['is_focused']: EventCtx::is_focused
+    fn is_focused(&self) -> bool;
+    /// The focus status of a widget or any of its descendents. See ['has_focus']
+    ///
+    /// ['has_focus']: EventCtx::has_focus
+    fn has_focus(&self) -> bool;
+}
+
+impl_context_trait!(
+   LaidOutCtx => EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>,PaintCtx<'_, '_, '_>,
+   {
+        fn size(&self) -> Size{
+            Self::size(self)
+        }
+
+        fn window_origin(&self) -> Point{
+            Self::window_origin(self)
+        }
+
+        fn to_window(&self, widget_point: Point) -> Point{
+            Self::to_window(self, widget_point)
+        }
+
+        fn to_screen(&self, widget_point: Point) -> Point{
+            Self::to_screen(self, widget_point)
+        }
+
+        fn is_hot(&self) -> bool{
+            Self::is_hot(self)
+        }
+
+        fn is_active(&self) -> bool{
+            Self::is_active(self)
+        }
+
+        fn is_focused(&self) -> bool{
+            Self::is_focused(self)
+        }
+
+        fn has_focus(&self) -> bool{
+            Self::has_focus(self)
+        }
+   }
+);
+
 impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, {
     /// Set the cursor icon.
     ///
@@ -316,6 +435,37 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, {
         self.widget_state.cursor_change = CursorChange::Default;
     }
 });
+
+/// Convenience trait for code generic over contexts. Methods for contexts that allow cursor manipulation.
+pub trait CursorCtx {
+    /// Set the cursor icon. See ['set_cursor']
+    ///
+    /// ['set_cursor']: EventCtx::set_cursor
+    fn set_cursor(&mut self, cursor: &Cursor);
+    /// Override the cursor icon. See ['override_cursor']
+    ///
+    /// ['override_cursor']: EventCtx::override_cursor
+    fn override_cursor(&mut self, cursor: &Cursor);
+    /// Set the cursor icon. See ['set_cursor']
+    ///
+    /// ['set_cursor']: EventCtx::set_cursor
+    fn clear_cursor(&mut self);
+}
+
+impl_context_trait!(
+    CursorCtx => EventCtx<'_, '_>, UpdateCtx<'_, '_>,
+    {
+        fn set_cursor(&mut self, cursor: &Cursor){
+            Self::set_cursor(self, cursor)
+        }
+        fn override_cursor(&mut self, cursor: &Cursor){
+            Self::override_cursor(self, cursor)
+        }
+        fn clear_cursor(&mut self){
+            Self::clear_cursor(self)
+        }
+    }
+);
 
 // methods on event, update, and lifecycle
 impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, {
@@ -399,6 +549,79 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
     }
 });
 
+/// Convenience trait for code generic over contexts. Methods to do with requesting other events or actions to occur.
+///
+/// Available on all contexts but PaintCtx and LayoutCtx
+pub trait RequestCtx {
+    /// Request a [`paint`] pass. See ['request_paint']
+    ///
+    /// ['request_paint']: EventCtx::request_paint
+    fn request_paint(&mut self);
+    /// Request a [`paint`] pass for redrawing a rectangle. See ['request_paint_rect']
+    ///
+    /// ['request_paint_rect']: EventCtx::request_paint_rect
+    fn request_paint_rect(&mut self, rect: Rect);
+    /// Request a layout pass. See ['request_layout']
+    ///
+    /// ['request_layout']: EventCtx::request_layout
+    fn request_layout(&mut self);
+    /// Request an animation frame. See ['request_anim_frame']
+    ///
+    /// ['request_anim_frame']: EventCtx::request_anim_frame
+    fn request_anim_frame(&mut self);
+    /// Indicate that your children have changed. See ['children_changed']
+    ///
+    /// ['children_changed']: EventCtx::children_changed
+    fn children_changed(&mut self);
+    /// Set the menu of the window containing the current widget. See ['set_menu']
+    ///
+    /// ['set_menu']: EventCtx::set_menu
+    fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>);
+    /// Create a new sub-window. See ['new_sub_window']
+    ///
+    /// ['new_sub_window']: EventCtx::new_sub_window
+    fn new_sub_window<W: Widget<U> + 'static, U: Data>(
+        &mut self,
+        window_config: WindowConfig,
+        widget: W,
+        data: U,
+        env: Env,
+    ) -> WindowId;
+}
+
+impl_context_trait!(
+    RequestCtx => EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>,
+    {
+        fn request_paint(&mut self){
+            Self::request_paint(self)
+        }
+        fn request_paint_rect(&mut self, rect: Rect){
+            Self::request_paint_rect(self, rect)
+        }
+        fn request_layout(&mut self){
+            Self::request_layout(self)
+        }
+        fn request_anim_frame(&mut self){
+            Self::request_anim_frame(self)
+        }
+        fn children_changed(&mut self){
+            Self::children_changed(self)
+        }
+        fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>){
+            Self::set_menu(self, menu)
+        }
+        fn new_sub_window<W: Widget<U> + 'static, U: Data>(
+            &mut self,
+            window_config: WindowConfig,
+            widget: W,
+            data: U,
+            env: Env,
+        ) -> WindowId{
+            Self::new_sub_window(self, window_config, widget, data, env)
+        }
+    }
+);
+
 // methods on everyone but paintctx
 impl_context_method!(
     EventCtx<'_, '_>,
@@ -435,6 +658,43 @@ impl_context_method!(
         /// request with the event.
         pub fn request_timer(&mut self, deadline: Duration) -> TimerToken {
             self.state.request_timer(&mut self.widget_state, deadline)
+        }
+    }
+);
+
+/// Convenience trait for code generic over contexts.
+///
+/// Methods to do with commands and timers.
+/// Available to all contexts but PaintCtx.
+pub trait CommandCtx {
+    /// Submit a [`Command`] to be run after this event is handled. See ['submit_command']
+    ///
+    /// ['submit_command']: EventCtx::submit_command
+    fn submit_command(&mut self, cmd: impl Into<Command>);
+    /// Returns an [`ExtEventSink`] for submitting commands from other threads. See ['get_external_handle']
+    ///
+    /// ['get_external_handle']: EventCtx::get_external_handle
+    fn get_external_handle(&self) -> ExtEventSink;
+    /// Request a timer event. See ['request_timer']
+    ///
+    /// ['request_timer']: EventCtx::request_timer
+    fn request_timer(&mut self, deadline: Duration) -> TimerToken;
+}
+
+impl_context_trait!(
+    CommandCtx => EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, LayoutCtx<'_, '_>,
+    {
+
+        fn submit_command(&mut self, cmd: impl Into<Command>) {
+            Self::submit_command(self, cmd)
+        }
+
+        fn get_external_handle(&self) -> ExtEventSink {
+            Self::get_external_handle(self)
+        }
+
+        fn request_timer(&mut self, deadline: Duration) -> TimerToken {
+            Self::request_timer(self, deadline)
         }
     }
 );

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -176,7 +176,7 @@ impl_context_method!(
     }
 );
 
-/// Convenience trait for code generic over contexts. Methods provided by all contexts.
+/// Convenience trait for methods available on all contexts.
 pub trait AnyCtx {
     /// get the `WidgetId` of the current widget.
     fn widget_id(&self) -> WidgetId;
@@ -322,39 +322,43 @@ impl_context_method!(
     }
 );
 
-/// Convenience trait for code generic over contexts. Methods providing layout information: available on all but LayoutCtx.
+/// Convenience trait for methods related to geometry and window position, available after [`layout`].
+///
+/// These methods are available on [`EventCtx`], [`LifeCycleCtx`], [`UpdateCtx`], and [`PaintCtx`].
+///
+/// [`layout`]: Widget::layout
 pub trait LaidOutCtx {
-    /// The layout size.
+    /// The layout size. See [`size`].
     ///
-    /// ['size']: EventCtx::size
+    /// [`size`]: EventCtx::size
     fn size(&self) -> Size;
-    /// The origin of the widget in window coordinates. See ['window_origin']
+    /// The origin of the widget in window coordinates. See [`window_origin`].
     ///
-    /// [window_origin]: EventCtx::window_origin
+    /// [`window_origin`]: EventCtx::window_origin
     fn window_origin(&self) -> Point;
-    /// Convert a point from the widget's coordinate space to the window's. See ['to_window']
+    /// Convert a point from the widget's coordinate space to the window's. See [`to_window`].
     ///
-    /// [to_window]: EventCtx::to_window
+    /// [`to_window`]: EventCtx::to_window
     fn to_window(&self, widget_point: Point) -> Point;
-    /// Convert a point from the widget's coordinate space to the screen's. See ['to_screen']
+    /// Convert a point from the widget's coordinate space to the screen's. See [`to_screen`].
     ///
-    /// ['to_screen']: EventCtx::to_screen
+    /// [`to_screen`]: EventCtx::to_screen
     fn to_screen(&self, widget_point: Point) -> Point;
-    /// The "hot" status of a widget. See ['is_hot']
+    /// The "hot" status of a widget. See [`is_hot`].
     ///
-    /// ['is_hot']: EventCtx::is_hot
+    /// [`is_hot`]: EventCtx::is_hot
     fn is_hot(&self) -> bool;
-    /// The active status of a widget. See ['is_active']
+    /// The active status of a widget. See [`is_active`]
     ///
-    /// ['is_active']: EventCtx::is_active
+    /// [`is_active`]: EventCtx::is_active
     fn is_active(&self) -> bool;
-    /// The focus status of a widget. See ['is_focused']
+    /// The focus status of a widget. See [`is_focused`].
     ///
-    /// ['is_focused']: EventCtx::is_focused
+    /// [`is_focused`]: EventCtx::is_focused
     fn is_focused(&self) -> bool;
-    /// The focus status of a widget or any of its descendents. See ['has_focus']
+    /// The focus status of a widget or any of its descendents. See [`has_focus`].
     ///
-    /// ['has_focus']: EventCtx::has_focus
+    /// [`has_focus`]: EventCtx::has_focus
     fn has_focus(&self) -> bool;
 }
 
@@ -436,19 +440,21 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, {
     }
 });
 
-/// Convenience trait for code generic over contexts. Methods for contexts that allow cursor manipulation.
+/// Convenience trait for cursor manipulation methods available on multiple contexts.
+///
+/// Available on [`EventCtx`] and [`UpdateCtx`].
 pub trait CursorCtx {
-    /// Set the cursor icon. See ['set_cursor']
+    /// Set the cursor icon. See [`set_cursor`].
     ///
     /// ['set_cursor']: EventCtx::set_cursor
     fn set_cursor(&mut self, cursor: &Cursor);
-    /// Override the cursor icon. See ['override_cursor']
+    /// Override the cursor icon. See [`override_cursor`].
     ///
-    /// ['override_cursor']: EventCtx::override_cursor
+    /// [`override_cursor`]: EventCtx::override_cursor
     fn override_cursor(&mut self, cursor: &Cursor);
-    /// Set the cursor icon. See ['set_cursor']
+    /// Clear the cursor icon. See [`clear_cursor`]
     ///
-    /// ['set_cursor']: EventCtx::set_cursor
+    /// [`clear_cursor`]: EventCtx::clear_cursor
     fn clear_cursor(&mut self);
 }
 
@@ -549,37 +555,38 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
     }
 });
 
-/// Convenience trait for code generic over contexts. Methods to do with requesting other events or actions to occur.
+/// Convenience trait for invalidation and request methods available on multiple contexts.
 ///
-/// Available on all contexts but PaintCtx and LayoutCtx
+/// These methods are available on [`EventCtx`], [`LifeCycleCtx`], and [`UpdateCtx`].
 pub trait RequestCtx {
     /// Request a [`paint`] pass. See ['request_paint']
     ///
     /// ['request_paint']: EventCtx::request_paint
     fn request_paint(&mut self);
-    /// Request a [`paint`] pass for redrawing a rectangle. See ['request_paint_rect']
+    /// Request a [`paint`] pass for redrawing a rectangle. See [`request_paint_rect`].
     ///
-    /// ['request_paint_rect']: EventCtx::request_paint_rect
+    /// [`request_paint_rect`]: EventCtx::request_paint_rect
+    /// [`paint`]: Widget::paint
     fn request_paint_rect(&mut self, rect: Rect);
-    /// Request a layout pass. See ['request_layout']
+    /// Request a layout pass. See [`request_layout`].
     ///
-    /// ['request_layout']: EventCtx::request_layout
+    /// [`request_layout`]: EventCtx::request_layout
     fn request_layout(&mut self);
-    /// Request an animation frame. See ['request_anim_frame']
+    /// Request an animation frame. See [`request_anim_frame`].
     ///
-    /// ['request_anim_frame']: EventCtx::request_anim_frame
+    /// [`request_anim_frame`]: EventCtx::request_anim_frame
     fn request_anim_frame(&mut self);
-    /// Indicate that your children have changed. See ['children_changed']
+    /// Indicate that your children have changed. See [`children_changed`].
     ///
-    /// ['children_changed']: EventCtx::children_changed
+    /// [`children_changed`]: EventCtx::children_changed
     fn children_changed(&mut self);
-    /// Set the menu of the window containing the current widget. See ['set_menu']
+    /// Set the menu of the window containing the current widget. See [`set_menu`].
     ///
-    /// ['set_menu']: EventCtx::set_menu
+    /// [`set_menu`]: EventCtx::set_menu
     fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>);
-    /// Create a new sub-window. See ['new_sub_window']
+    /// Create a new sub-window. See [`new_sub_window`].
     ///
-    /// ['new_sub_window']: EventCtx::new_sub_window
+    /// [`new_sub_window`]: EventCtx::new_sub_window
     fn new_sub_window<W: Widget<U> + 'static, U: Data>(
         &mut self,
         window_config: WindowConfig,
@@ -667,17 +674,17 @@ impl_context_method!(
 /// Methods to do with commands and timers.
 /// Available to all contexts but PaintCtx.
 pub trait CommandCtx {
-    /// Submit a [`Command`] to be run after this event is handled. See ['submit_command']
+    /// Submit a [`Command`] to be run after this event is handled. See [`submit_command`].
     ///
-    /// ['submit_command']: EventCtx::submit_command
+    /// [`submit_command`]: EventCtx::submit_command
     fn submit_command(&mut self, cmd: impl Into<Command>);
-    /// Returns an [`ExtEventSink`] for submitting commands from other threads. See ['get_external_handle']
+    /// Returns an [`ExtEventSink`] for submitting commands from other threads. See ['get_external_handle'].
     ///
-    /// ['get_external_handle']: EventCtx::get_external_handle
+    /// [`get_external_handle`]: EventCtx::get_external_handle
     fn get_external_handle(&self) -> ExtEventSink;
-    /// Request a timer event. See ['request_timer']
+    /// Request a timer event. See [`request_timer`]
     ///
-    /// ['request_timer']: EventCtx::request_timer
+    /// [`request_timer`]: EventCtx::request_timer
     fn request_timer(&mut self, deadline: Duration) -> TimerToken;
 }
 

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -196,7 +196,10 @@ pub use app::{AppLauncher, WindowConfig, WindowDesc, WindowSizePolicy};
 pub use app_delegate::{AppDelegate, DelegateCtx};
 pub use box_constraints::BoxConstraints;
 pub use command::{sys as commands, Command, Notification, Selector, SingleUse, Target};
-pub use contexts::{EventCtx, LayoutCtx, LifeCycleCtx, PaintCtx, UpdateCtx};
+pub use contexts::{
+    AnyCtx, CommandCtx, CursorCtx, EventCtx, LaidOutCtx, LayoutCtx, LifeCycleCtx, PaintCtx,
+    UpdateCtx,
+};
 pub use data::Data;
 pub use dialog::FileDialogOptions;
 pub use env::{Env, Key, KeyOrValue, Value, ValueType, ValueTypeError};


### PR DESCRIPTION
Widgets sometimes have code they wish to call from one or more Widget methods, e.g calling commands, or doing similar things in LifeCycle::WidgetAdded and update(). Currently its required to pass lambdas or wrap various contexts up in order to achieve this. 

This allows abstraction over contexts according to the sets of methods they provide.
It does not remove or remove any inherent methods, just forwards to them from the trait impls. Code that does not need these facilities does not need to import the traits and should remain unaware of them.

Open questions:
- Naming of the traits - LaidOutCtx seems a bit forced... LayoutInfoCtx? RequestCtx will probably make people think of http frameworks. Open to discussion and bikeshedding. Also they could be public in a module rather than the root, e.g druid::context_traits.
- It would probably be possible to have a lot less duplication/risk of things coming out of sync at the expense of (potentially extreme) macro complexity: it would probably mean going a proc macro route to be comprehensible. I didn't want to go down that route if unwarranted.
- There are a bunch of different schemes that could be done here (in terms of where methods live, which direction they are forwarded etc.) This was the one that @cmyr thought (several months back) would be least disruptive and leads to still discoverable docs (via the inherent trait methods). 
-  I avoided copying swathes of docs and just copied the first line and referenced the inherent impl on EventCtx. 