### PR TITLE
Cleaning tracing deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ fn main() -> Result<(), PlatformError> {
     let main_window = WindowDesc::new(ui_builder());
     let data = 0_u32;
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(data)
 }
 

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -43,7 +43,9 @@ hdr = ["piet-common/hdr"]
 piet-common = "=0.3.2"
 kurbo = "0.7.1"
 
-tracing = "0.1.22"
+# tracing with log feature does NOT require an impl of any log facade.
+# Because druid-shell is used by druid which has an impl of log facade. (simple_logger)
+tracing = { version = "0.1.24", features = ["log"] }
 lazy_static = "1.4.0"
 time = "0.2.16"
 cfg-if = "1.0.0"
@@ -101,5 +103,7 @@ features = ["Window", "MouseEvent", "CssStyleDeclaration", "WheelEvent", "KeyEve
 [dev-dependencies]
 piet-common = { version = "=0.3.2", features = ["png"] }
 static_assertions = "1.1.0"
-test-env-log = { version = "0.2.5", features = ["trace"], default-features = false }
-tracing-subscriber = "0.2.15"
+
+# env_logger is used by test-env-log's log feature.
+env_logger = "*"
+test-env-log = { version = "0.2.5", features = ["log"], default-features = false }

--- a/druid-shell/examples/invalidate.rs
+++ b/druid-shell/examples/invalidate.rs
@@ -102,7 +102,7 @@ impl WinHandler for InvalidateTest {
 }
 
 fn main() {
-    let _ = env_logger::builder().is_test(true).try_init();
+    let _ = env_logger::builder().try_init();
     let app = Application::new().unwrap();
     let mut builder = WindowBuilder::new(app.clone());
     let inv_test = InvalidateTest {

--- a/druid-shell/examples/invalidate.rs
+++ b/druid-shell/examples/invalidate.rs
@@ -102,7 +102,7 @@ impl WinHandler for InvalidateTest {
 }
 
 fn main() {
-    tracing_subscriber::fmt().init();
+    let _ = env_logger::builder().is_test(true).try_init();
     let app = Application::new().unwrap();
     let mut builder = WindowBuilder::new(app.clone());
     let inv_test = InvalidateTest {

--- a/druid-shell/examples/perftest.rs
+++ b/druid-shell/examples/perftest.rs
@@ -136,7 +136,7 @@ impl WinHandler for PerfTest {
 }
 
 fn main() {
-    let _ = env_logger::builder().is_test(true).try_init();
+    let _ = env_logger::builder().try_init();
     let app = Application::new().unwrap();
     let mut builder = WindowBuilder::new(app.clone());
     let perf_test = PerfTest {

--- a/druid-shell/examples/perftest.rs
+++ b/druid-shell/examples/perftest.rs
@@ -136,7 +136,7 @@ impl WinHandler for PerfTest {
 }
 
 fn main() {
-    tracing_subscriber::fmt().init();
+    let _ = env_logger::builder().is_test(true).try_init();
     let app = Application::new().unwrap();
     let mut builder = WindowBuilder::new(app.clone());
     let perf_test = PerfTest {

--- a/druid-shell/examples/quit.rs
+++ b/druid-shell/examples/quit.rs
@@ -67,7 +67,7 @@ impl WinHandler for QuitState {
 }
 
 fn main() {
-    let _ = env_logger::builder().is_test(true).try_init();
+    let _ = env_logger::builder().try_init();
     let app = Application::new().unwrap();
     let mut file_menu = Menu::new();
     file_menu.add_item(

--- a/druid-shell/examples/quit.rs
+++ b/druid-shell/examples/quit.rs
@@ -67,7 +67,7 @@ impl WinHandler for QuitState {
 }
 
 fn main() {
-    tracing_subscriber::fmt().init();
+    let _ = env_logger::builder().is_test(true).try_init();
     let app = Application::new().unwrap();
     let mut file_menu = Menu::new();
     file_menu.add_item(

--- a/druid-shell/examples/shello.rs
+++ b/druid-shell/examples/shello.rs
@@ -122,7 +122,7 @@ impl WinHandler for HelloState {
 }
 
 fn main() {
-    tracing_subscriber::fmt().init();
+    let _ = env_logger::builder().is_test(true).try_init();
     let mut file_menu = Menu::new();
     file_menu.add_item(
         0x100,

--- a/druid-shell/examples/shello.rs
+++ b/druid-shell/examples/shello.rs
@@ -122,7 +122,7 @@ impl WinHandler for HelloState {
 }
 
 fn main() {
-    let _ = env_logger::builder().is_test(true).try_init();
+    let _ = env_logger::builder().try_init();
     let mut file_menu = Menu::new();
     file_menu.add_item(
         0x100,

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -52,10 +52,8 @@ image-all = ["image", "svg", "png", "jpeg", "jpeg_rayon", "gif", "bmp", "ico", "
 druid-shell = { version = "0.7.0", default-features = false, path = "../druid-shell" }
 druid-derive = { version = "0.4.0", path = "../druid-derive" }
 
-log = "0.4.11"
-tracing = { version = "0.1.22", features = ["log"] }
+tracing = { version = "0.1.24", features = ["log"] }
 simple_logger = { version = "1.9.0", default-features = false }
-tracing-subscriber = { version = "0.2.15" }
 fluent-bundle = "0.12.0"
 fluent-langneg = "0.13.0"
 fluent-syntax = "0.9.3"
@@ -74,8 +72,6 @@ harfbuzz-sys = { version = "0.4.0", optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 console_log = { version = "0.2.0" }
-tracing-wasm = { version = "0.1.0" }
-console_error_panic_hook = { version = "0.1.6" }
 
 [dev-dependencies]
 float-cmp = { version = "0.8.0", features = ["std"], default-features = false }
@@ -83,7 +79,10 @@ float-cmp = { version = "0.8.0", features = ["std"], default-features = false }
 tempfile = "=3.1.0"
 piet-common = { version = "=0.3.2", features = ["png"] }
 pulldown-cmark = { version = "0.8", default-features = false }
-test-env-log = { version = "0.2.5", features = ["trace"], default-features = false }
+
+# env_logger is used by test-env-log's log feature.
+env_logger = "*"
+test-env-log = { version = "0.2.5", features = ["log"], default-features = false }
 
 [[example]]
 name = "cursor"

--- a/druid/examples/anim.rs
+++ b/druid/examples/anim.rs
@@ -86,7 +86,7 @@ pub fn main() {
             .with_placeholder("You spin me right round..."),
     );
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(())
         .expect("launch failed");
 }

--- a/druid/examples/async_event.rs
+++ b/druid/examples/async_event.rs
@@ -48,7 +48,7 @@ pub fn main() {
     thread::spawn(move || generate_colors(event_sink));
 
     launcher
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(Color::BLACK)
         .expect("launch failed");
 }

--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -256,7 +256,7 @@ pub fn main() {
         in_num: false,
     };
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(calc_state)
         .expect("launch failed");
 }

--- a/druid/examples/cursor.rs
+++ b/druid/examples/cursor.rs
@@ -119,7 +119,7 @@ pub fn main() {
         custom_desc,
     };
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(data)
         .expect("launch failed");
 }

--- a/druid/examples/custom_widget.rs
+++ b/druid/examples/custom_widget.rs
@@ -153,7 +153,7 @@ impl Widget<String> for CustomWidget {
 pub fn main() {
     let window = WindowDesc::new(CustomWidget {}).title(LocalizedString::new("Fancy Colors"));
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch("Druid + Piet".to_string())
         .expect("launch failed");
 }

--- a/druid/examples/either.rs
+++ b/druid/examples/either.rs
@@ -47,7 +47,7 @@ fn ui_builder() -> impl Widget<AppState> {
 pub fn main() {
     let main_window = WindowDesc::new(ui_builder()).title("Switcheroo");
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(AppState::default())
         .expect("launch failed");
 }

--- a/druid/examples/event_viewer.rs
+++ b/druid/examples/event_viewer.rs
@@ -333,7 +333,7 @@ pub fn main() {
 
     //start the application
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .use_simple_logger()
         .configure_env(|env, _| {
             env.set(theme::UI_FONT, FontDescriptor::default().with_size(12.0));
             env.set(theme::LABEL_COLOR, TEXT_COLOR);

--- a/druid/examples/flex.rs
+++ b/druid/examples/flex.rs
@@ -341,7 +341,7 @@ pub fn main() {
     };
 
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(AppState { demo_state, params })
         .expect("Failed to launch application");
 }

--- a/druid/examples/game_of_life.rs
+++ b/druid/examples/game_of_life.rs
@@ -434,7 +434,7 @@ pub fn main() {
     }
 
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(AppData {
             grid,
             drawing: false,

--- a/druid/examples/hello.rs
+++ b/druid/examples/hello.rs
@@ -40,7 +40,7 @@ pub fn main() {
 
     // start the application. Here we pass in the application state.
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(initial_state)
         .expect("Failed to launch application");
 }

--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -46,7 +46,7 @@ pub fn main() {
         counter_two: 0,
     };
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(data)
         .expect("launch failed");
 }

--- a/druid/examples/image.rs
+++ b/druid/examples/image.rs
@@ -219,7 +219,7 @@ pub fn main() {
     };
 
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(state)
         .expect("Failed to launch application");
 }

--- a/druid/examples/invalidation.rs
+++ b/druid/examples/invalidation.rs
@@ -32,7 +32,7 @@ pub fn main() {
         circles: Vector::new(),
     };
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(state)
         .expect("launch failed");
 }

--- a/druid/examples/layout.rs
+++ b/druid/examples/layout.rs
@@ -69,7 +69,7 @@ pub fn main() {
     let window = WindowDesc::new(build_app()).title("Very flexible");
 
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(0)
         .expect("launch failed");
 }

--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -42,7 +42,7 @@ pub fn main() {
         right,
     };
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(data)
         .expect("launch failed");
 }

--- a/druid/examples/markdown_preview.rs
+++ b/druid/examples/markdown_preview.rs
@@ -77,7 +77,7 @@ pub fn main() {
 
     // start the application
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(initial_state)
         .expect("Failed to launch application");
 }

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -48,7 +48,7 @@ pub fn main() {
         .delegate(Delegate {
             windows: Vec::new(),
         })
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(State::default())
         .expect("launch failed");
 }

--- a/druid/examples/open_save.rs
+++ b/druid/examples/open_save.rs
@@ -28,7 +28,7 @@ pub fn main() {
     let data = "Type here.".to_owned();
     AppLauncher::with_window(main_window)
         .delegate(Delegate)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(data)
         .expect("launch failed");
 }

--- a/druid/examples/panels.rs
+++ b/druid/examples/panels.rs
@@ -95,7 +95,7 @@ pub fn main() -> Result<(), PlatformError> {
     let main_window = WindowDesc::new(build_app())
         .title(LocalizedString::new("panels-demo-window-title").with_placeholder("Fancy Boxes!"));
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(())?;
 
     Ok(())

--- a/druid/examples/scroll.rs
+++ b/druid/examples/scroll.rs
@@ -25,7 +25,7 @@ pub fn main() {
     let window = WindowDesc::new(build_widget())
         .title(LocalizedString::new("scroll-demo-window-title").with_placeholder("Scroll demo"));
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(0u32)
         .expect("launch failed");
 }

--- a/druid/examples/scroll_colors.rs
+++ b/druid/examples/scroll_colors.rs
@@ -47,7 +47,7 @@ pub fn main() {
     );
     let data = 0_u32;
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(data)
         .expect("launch failed");
 }

--- a/druid/examples/split_demo.rs
+++ b/druid/examples/split_demo.rs
@@ -80,7 +80,7 @@ pub fn main() {
     let window = WindowDesc::new(build_app())
         .title(LocalizedString::new("split-demo-window-title").with_placeholder("Split Demo"));
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(0u32)
         .expect("launch failed");
 }

--- a/druid/examples/styled_text.rs
+++ b/druid/examples/styled_text.rs
@@ -58,7 +58,7 @@ pub fn main() -> Result<(), PlatformError> {
     };
 
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(data)?;
 
     Ok(())

--- a/druid/examples/sub_window.rs
+++ b/druid/examples/sub_window.rs
@@ -60,7 +60,7 @@ pub fn main() {
 
     // start the application
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(initial_state)
         .expect("Failed to launch application");
 }

--- a/druid/examples/svg.rs
+++ b/druid/examples/svg.rs
@@ -26,7 +26,7 @@ pub fn main() {
         .title(LocalizedString::new("svg-demo-window-title").with_placeholder("Rawr!"));
     let data = 0_u32;
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(data)
         .expect("launch failed");
 }

--- a/druid/examples/switches.rs
+++ b/druid/examples/switches.rs
@@ -70,7 +70,7 @@ pub fn main() {
     let window = WindowDesc::new(build_widget())
         .title(LocalizedString::new("switch-demo-window-title").with_placeholder("Switch Demo"));
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(DemoState {
             value: true,
             stepper_value: 1.0,

--- a/druid/examples/tabs.rs
+++ b/druid/examples/tabs.rs
@@ -89,7 +89,7 @@ pub fn main() {
 
     // start the application
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(initial_state)
         .expect("Failed to launch application");
 }

--- a/druid/examples/text.rs
+++ b/druid/examples/text.rs
@@ -100,7 +100,7 @@ pub fn main() {
 
     // start the application
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(initial_state)
         .expect("Failed to launch application");
 }

--- a/druid/examples/timer.rs
+++ b/druid/examples/timer.rs
@@ -125,7 +125,7 @@ pub fn main() {
     .title(LocalizedString::new("timer-demo-window-title").with_placeholder("Look at it go!"));
 
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(0u32)
         .expect("launch failed");
 }

--- a/druid/examples/transparency.rs
+++ b/druid/examples/transparency.rs
@@ -55,7 +55,7 @@ pub fn main() {
         .title("Transparent background");
 
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch("Druid + Piet".to_string())
         .expect("launch failed");
 }

--- a/druid/examples/value_formatting/src/main.rs
+++ b/druid/examples/value_formatting/src/main.rs
@@ -50,7 +50,7 @@ pub fn main() {
     };
 
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(data)
         .expect("launch failed");
 }

--- a/druid/examples/view_switcher.rs
+++ b/druid/examples/view_switcher.rs
@@ -30,7 +30,7 @@ pub fn main() {
         current_text: "Edit me!".to_string(),
     };
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(data)
         .expect("launch failed");
 }

--- a/druid/examples/web/Cargo.toml
+++ b/druid/examples/web/Cargo.toml
@@ -12,10 +12,9 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 druid = { path="../..", features = ["im", "image", "png"] }
-tracing = "0.1.22"
 wasm-bindgen = "0.2.67"
 console_error_panic_hook = "0.1.6"
-log = "0.4.11"
+tracing = { version = "0.1.24", features = ["log"] }
 instant = { version = "0.1.6", features = ["wasm-bindgen"] }
 
 [target.'cfg(not(target_arch="wasm32"))'.dependencies]

--- a/druid/examples/widget_gallery.rs
+++ b/druid/examples/widget_gallery.rs
@@ -61,7 +61,7 @@ pub fn main() {
         editable_text: "edit me!".into(),
     };
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .use_simple_logger()
         .launch(data)
         .expect("launch failed");
 }

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -162,8 +162,8 @@ impl<T: Data> AppLauncher<T> {
     /// # Panics
     ///
     /// Panics if the logger fails to initialize.
-    #[deprecated(since = "0.7.0", note = "Use use_env_tracing instead")]
     pub fn use_simple_logger(self) -> Self {
+        use tracing::log;
         #[cfg(not(target_arch = "wasm32"))]
         simple_logger::SimpleLogger::new()
             .with_level(log::LevelFilter::Debug)
@@ -171,41 +171,6 @@ impl<T: Data> AppLauncher<T> {
             .expect("Failed to initialize logger.");
         #[cfg(target_arch = "wasm32")]
         console_log::init_with_level(log::Level::Debug).expect("Failed to initialize logger.");
-        self
-    }
-
-    /// Initialize a minimal tracing subscriber with DEBUG max level for printing logs out to
-    /// stderr, controlled by ENV variables.
-    ///
-    /// This is meant for quick-and-dirty debugging. If you want more serious trace handling,
-    /// it's probably better to implement it yourself.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the subscriber fails to initialize.
-    pub fn use_env_tracing(self) -> Self {
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            use tracing_subscriber::prelude::*;
-            let fmt_layer = tracing_subscriber::fmt::layer().with_target(true);
-            let filter_layer = tracing_subscriber::EnvFilter::try_from_default_env()
-                .or_else(|_| tracing_subscriber::EnvFilter::try_new("debug"))
-                .expect("Failed to initialize tracing subscriber");
-
-            tracing_subscriber::registry()
-                .with(filter_layer)
-                .with(fmt_layer)
-                .init();
-        }
-        // Note - tracing-wasm might not work in headless Node.js. Probably doesn't matter anyway,
-        // because wasm targets will virtually always be browsers.
-        #[cfg(target_arch = "wasm32")]
-        {
-            console_error_panic_hook::set_once();
-            // tracing_wasm doesn't let us filter by level, but chrome/firefox devtools can
-            // already do that anyway
-            tracing_wasm::set_as_global_default();
-        }
         self
     }
 

--- a/druid/src/tests/invalidation_tests.rs
+++ b/druid/src/tests/invalidation_tests.rs
@@ -15,7 +15,7 @@
 //! Tests related to propagation of invalid rects.
 
 use float_cmp::approx_eq;
-use test_env_log::test;
+
 
 use super::*;
 

--- a/druid/src/tests/invalidation_tests.rs
+++ b/druid/src/tests/invalidation_tests.rs
@@ -16,7 +16,6 @@
 
 use float_cmp::approx_eq;
 
-
 use super::*;
 
 #[test]

--- a/druid/src/widget/maybe.rs
+++ b/druid/src/widget/maybe.rs
@@ -20,6 +20,7 @@ use druid::{
 };
 
 use druid::widget::SizedBox;
+use tracing::log::warn;
 
 /// A widget that switches between two possible child views, for `Data` that
 /// is `Option<T>`.
@@ -160,7 +161,7 @@ impl<T> MaybeWidget<T> {
         match self {
             Self::Some(widget) => Some(f(widget)),
             Self::None(_) => {
-                log::warn!("`MaybeWidget::with_some` called on `None` value");
+                warn!("`MaybeWidget::with_some` called on `None` value");
                 None
             }
         }
@@ -174,7 +175,7 @@ impl<T> MaybeWidget<T> {
         match self {
             Self::None(widget) => Some(f(widget)),
             Self::Some(_) => {
-                log::warn!("`MaybeWidget::with_none` called on `Some` value");
+                warn!("`MaybeWidget::with_none` called on `Some` value");
                 None
             }
         }


### PR DESCRIPTION
This PR uses `tracing` crate for console logs. It:
* Removes `tracing-subscriber` as a dependency.
* Uses `log` feature of `tracing` to get console logs.

Note on how to add console logs:
* You'll need to use `tracing`'s non-span macros(`debug!()`, `info!()`, etc.). You can use span macros (`debug_span!()`, `info_span!()`, etc.) but your console log will be polluted.

Tests specific notes:
* All tests use `env_logger` instead of `simpler_logger`. This is because `test-env-log` doesnt support `simple_logger`. So to enable console logs while running tests, set env var `RUST_LOG` to a desired log level.
* `env_logger` is initialized differently than `simple_logger`. Check examples.