### PR TITLE
Add some tracing and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ fn main() -> Result<(), PlatformError> {
     let main_window = WindowDesc::new(ui_builder());
     let data = 0_u32;
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(data)
 }
 

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -592,7 +592,7 @@ impl WindowBuilder {
                             Some(Vec2::new(delta_x, delta_y))
                         }
                         e => {
-                            eprintln!(
+                            warn!(
                                 "Warning: the Druid widget got some whacky scroll direction {:?}",
                                 e
                             );

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -52,10 +52,8 @@ image-all = ["image", "svg", "png", "jpeg", "jpeg_rayon", "gif", "bmp", "ico", "
 druid-shell = { version = "0.7.0", default-features = false, path = "../druid-shell" }
 druid-derive = { version = "0.4.0", path = "../druid-derive" }
 
-log = "0.4.11"
-tracing = { version = "0.1.22", features = ["log"] }
-simple_logger = { version = "1.9.0", default-features = false }
-tracing-subscriber = { version = "0.2.15" }
+tracing = { version = "0.1.22" }
+tracing-subscriber = { version = "0.2.15", features = ["fmt", "ansi"], default-features = false }
 fluent-bundle = "0.12.0"
 fluent-langneg = "0.13.0"
 fluent-syntax = "0.9.3"
@@ -73,7 +71,6 @@ usvg = { version = "0.12.0", optional = true }
 harfbuzz-sys = { version = "0.4.0", optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
-console_log = { version = "0.2.0" }
 tracing-wasm = { version = "0.1.0" }
 console_error_panic_hook = { version = "0.1.6" }
 

--- a/druid/examples/anim.rs
+++ b/druid/examples/anim.rs
@@ -86,7 +86,7 @@ pub fn main() {
             .with_placeholder("You spin me right round..."),
     );
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(())
         .expect("launch failed");
 }

--- a/druid/examples/async_event.rs
+++ b/druid/examples/async_event.rs
@@ -48,7 +48,7 @@ pub fn main() {
     thread::spawn(move || generate_colors(event_sink));
 
     launcher
-        .use_env_tracing()
+        .log_to_console()
         .launch(Color::BLACK)
         .expect("launch failed");
 }

--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -256,7 +256,7 @@ pub fn main() {
         in_num: false,
     };
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(calc_state)
         .expect("launch failed");
 }

--- a/druid/examples/cursor.rs
+++ b/druid/examples/cursor.rs
@@ -120,7 +120,7 @@ pub fn main() {
         custom_desc,
     };
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(data)
         .expect("launch failed");
 }

--- a/druid/examples/custom_widget.rs
+++ b/druid/examples/custom_widget.rs
@@ -153,7 +153,7 @@ impl Widget<String> for CustomWidget {
 pub fn main() {
     let window = WindowDesc::new(CustomWidget {}).title(LocalizedString::new("Fancy Colors"));
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .log_to_console()
         .launch("Druid + Piet".to_string())
         .expect("launch failed");
 }

--- a/druid/examples/either.rs
+++ b/druid/examples/either.rs
@@ -47,7 +47,7 @@ fn ui_builder() -> impl Widget<AppState> {
 pub fn main() {
     let main_window = WindowDesc::new(ui_builder()).title("Switcheroo");
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(AppState::default())
         .expect("launch failed");
 }

--- a/druid/examples/event_viewer.rs
+++ b/druid/examples/event_viewer.rs
@@ -333,7 +333,7 @@ pub fn main() {
 
     //start the application
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .log_to_console()
         .configure_env(|env, _| {
             env.set(theme::UI_FONT, FontDescriptor::default().with_size(12.0));
             env.set(theme::LABEL_COLOR, TEXT_COLOR);

--- a/druid/examples/flex.rs
+++ b/druid/examples/flex.rs
@@ -341,7 +341,7 @@ pub fn main() {
     };
 
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(AppState { demo_state, params })
         .expect("Failed to launch application");
 }

--- a/druid/examples/game_of_life.rs
+++ b/druid/examples/game_of_life.rs
@@ -434,7 +434,7 @@ pub fn main() {
     }
 
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(AppData {
             grid,
             drawing: false,

--- a/druid/examples/hello.rs
+++ b/druid/examples/hello.rs
@@ -40,7 +40,7 @@ pub fn main() {
 
     // start the application. Here we pass in the application state.
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(initial_state)
         .expect("Failed to launch application");
 }

--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -46,7 +46,7 @@ pub fn main() {
         counter_two: 0,
     };
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(data)
         .expect("launch failed");
 }

--- a/druid/examples/image.rs
+++ b/druid/examples/image.rs
@@ -219,7 +219,7 @@ pub fn main() {
     };
 
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(state)
         .expect("Failed to launch application");
 }

--- a/druid/examples/invalidation.rs
+++ b/druid/examples/invalidation.rs
@@ -32,7 +32,7 @@ pub fn main() {
         circles: Vector::new(),
     };
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(state)
         .expect("launch failed");
 }

--- a/druid/examples/layout.rs
+++ b/druid/examples/layout.rs
@@ -69,7 +69,7 @@ pub fn main() {
     let window = WindowDesc::new(build_app()).title("Very flexible");
 
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(0)
         .expect("launch failed");
 }

--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -42,7 +42,7 @@ pub fn main() {
         right,
     };
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(data)
         .expect("launch failed");
 }

--- a/druid/examples/markdown_preview.rs
+++ b/druid/examples/markdown_preview.rs
@@ -77,7 +77,7 @@ pub fn main() {
 
     // start the application
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(initial_state)
         .expect("Failed to launch application");
 }

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -48,7 +48,7 @@ pub fn main() {
         .delegate(Delegate {
             windows: Vec::new(),
         })
-        .use_env_tracing()
+        .log_to_console()
         .launch(State::default())
         .expect("launch failed");
 }

--- a/druid/examples/open_save.rs
+++ b/druid/examples/open_save.rs
@@ -28,7 +28,7 @@ pub fn main() {
     let data = "Type here.".to_owned();
     AppLauncher::with_window(main_window)
         .delegate(Delegate)
-        .use_env_tracing()
+        .log_to_console()
         .launch(data)
         .expect("launch failed");
 }

--- a/druid/examples/panels.rs
+++ b/druid/examples/panels.rs
@@ -95,7 +95,7 @@ pub fn main() -> Result<(), PlatformError> {
     let main_window = WindowDesc::new(build_app())
         .title(LocalizedString::new("panels-demo-window-title").with_placeholder("Fancy Boxes!"));
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(())?;
 
     Ok(())

--- a/druid/examples/scroll.rs
+++ b/druid/examples/scroll.rs
@@ -25,7 +25,7 @@ pub fn main() {
     let window = WindowDesc::new(build_widget())
         .title(LocalizedString::new("scroll-demo-window-title").with_placeholder("Scroll demo"));
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(0u32)
         .expect("launch failed");
 }

--- a/druid/examples/scroll_colors.rs
+++ b/druid/examples/scroll_colors.rs
@@ -47,7 +47,7 @@ pub fn main() {
     );
     let data = 0_u32;
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(data)
         .expect("launch failed");
 }

--- a/druid/examples/split_demo.rs
+++ b/druid/examples/split_demo.rs
@@ -80,7 +80,7 @@ pub fn main() {
     let window = WindowDesc::new(build_app())
         .title(LocalizedString::new("split-demo-window-title").with_placeholder("Split Demo"));
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(0u32)
         .expect("launch failed");
 }

--- a/druid/examples/styled_text.rs
+++ b/druid/examples/styled_text.rs
@@ -58,7 +58,7 @@ pub fn main() -> Result<(), PlatformError> {
     };
 
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(data)?;
 
     Ok(())

--- a/druid/examples/sub_window.rs
+++ b/druid/examples/sub_window.rs
@@ -60,7 +60,7 @@ pub fn main() {
 
     // start the application
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(initial_state)
         .expect("Failed to launch application");
 }

--- a/druid/examples/svg.rs
+++ b/druid/examples/svg.rs
@@ -26,7 +26,7 @@ pub fn main() {
         .title(LocalizedString::new("svg-demo-window-title").with_placeholder("Rawr!"));
     let data = 0_u32;
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(data)
         .expect("launch failed");
 }

--- a/druid/examples/switches.rs
+++ b/druid/examples/switches.rs
@@ -70,7 +70,7 @@ pub fn main() {
     let window = WindowDesc::new(build_widget())
         .title(LocalizedString::new("switch-demo-window-title").with_placeholder("Switch Demo"));
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(DemoState {
             value: true,
             stepper_value: 1.0,

--- a/druid/examples/tabs.rs
+++ b/druid/examples/tabs.rs
@@ -89,7 +89,7 @@ pub fn main() {
 
     // start the application
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(initial_state)
         .expect("Failed to launch application");
 }

--- a/druid/examples/text.rs
+++ b/druid/examples/text.rs
@@ -100,7 +100,7 @@ pub fn main() {
 
     // start the application
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(initial_state)
         .expect("Failed to launch application");
 }

--- a/druid/examples/timer.rs
+++ b/druid/examples/timer.rs
@@ -125,7 +125,7 @@ pub fn main() {
     .title(LocalizedString::new("timer-demo-window-title").with_placeholder("Look at it go!"));
 
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(0u32)
         .expect("launch failed");
 }

--- a/druid/examples/transparency.rs
+++ b/druid/examples/transparency.rs
@@ -55,7 +55,7 @@ pub fn main() {
         .title("Transparent background");
 
     AppLauncher::with_window(window)
-        .use_env_tracing()
+        .log_to_console()
         .launch("Druid + Piet".to_string())
         .expect("launch failed");
 }

--- a/druid/examples/value_formatting/src/main.rs
+++ b/druid/examples/value_formatting/src/main.rs
@@ -50,7 +50,7 @@ pub fn main() {
     };
 
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(data)
         .expect("launch failed");
 }

--- a/druid/examples/view_switcher.rs
+++ b/druid/examples/view_switcher.rs
@@ -30,7 +30,7 @@ pub fn main() {
         current_text: "Edit me!".to_string(),
     };
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(data)
         .expect("launch failed");
 }

--- a/druid/examples/widget_gallery.rs
+++ b/druid/examples/widget_gallery.rs
@@ -61,7 +61,7 @@ pub fn main() {
         editable_text: "edit me!".into(),
     };
     AppLauncher::with_window(main_window)
-        .use_env_tracing()
+        .log_to_console()
         .launch(data)
         .expect("launch failed");
 }

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -183,7 +183,7 @@ impl<T: Data> AppLauncher<T> {
             let filter_layer = tracing_subscriber::filter::LevelFilter::DEBUG;
             let fmt_layer = tracing_subscriber::fmt::layer()
                 // Display target (eg "my_crate::some_mod::submod") with logs
-                .with_target(false);
+                .with_target(true);
 
             tracing_subscriber::registry()
                 .with(filter_layer)

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -162,16 +162,9 @@ impl<T: Data> AppLauncher<T> {
     /// # Panics
     ///
     /// Panics if the logger fails to initialize.
-    #[deprecated(since = "0.7.0", note = "Use use_env_tracing instead")]
+    #[deprecated(since = "0.7.0", note = "Use log_to_console instead")]
     pub fn use_simple_logger(self) -> Self {
-        #[cfg(not(target_arch = "wasm32"))]
-        simple_logger::SimpleLogger::new()
-            .with_level(log::LevelFilter::Debug)
-            .init()
-            .expect("Failed to initialize logger.");
-        #[cfg(target_arch = "wasm32")]
-        console_log::init_with_level(log::Level::Debug).expect("Failed to initialize logger.");
-        self
+        self.log_to_console()
     }
 
     /// Initialize a minimal tracing subscriber with DEBUG max level for printing logs out to
@@ -183,7 +176,7 @@ impl<T: Data> AppLauncher<T> {
     /// # Panics
     ///
     /// Panics if the subscriber fails to initialize.
-    pub fn use_env_tracing(self) -> Self {
+    pub fn log_to_console(self) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         {
             use tracing_subscriber::prelude::*;

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -187,10 +187,10 @@ impl<T: Data> AppLauncher<T> {
         #[cfg(not(target_arch = "wasm32"))]
         {
             use tracing_subscriber::prelude::*;
-            let fmt_layer = tracing_subscriber::fmt::layer().with_target(true);
-            let filter_layer = tracing_subscriber::EnvFilter::try_from_default_env()
-                .or_else(|_| tracing_subscriber::EnvFilter::try_new("debug"))
-                .expect("Failed to initialize tracing subscriber");
+            let filter_layer = tracing_subscriber::filter::LevelFilter::DEBUG;
+            let fmt_layer = tracing_subscriber::fmt::layer()
+                // Display target (eg "my_crate::some_mod::submod") with logs
+                .with_target(false);
 
             tracing_subscriber::registry()
                 .with(filter_layer)

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -168,7 +168,7 @@ impl<T: Data> AppLauncher<T> {
     }
 
     /// Initialize a minimal tracing subscriber with DEBUG max level for printing logs out to
-    /// stderr, controlled by ENV variables.
+    /// stderr.
     ///
     /// This is meant for quick-and-dirty debugging. If you want more serious trace handling,
     /// it's probably better to implement it yourself.
@@ -191,7 +191,7 @@ impl<T: Data> AppLauncher<T> {
                 .init();
         }
         // Note - tracing-wasm might not work in headless Node.js. Probably doesn't matter anyway,
-        // because wasm targets will virtually always be browsers.
+        // because this is a GUI framework, so wasm targets will virtually always be browsers.
         #[cfg(target_arch = "wasm32")]
         {
             console_error_panic_hook::set_once();

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -20,6 +20,7 @@ use std::{
     ops::{Deref, DerefMut},
     time::Duration,
 };
+use tracing::{error, trace, warn};
 
 use crate::core::{CommandQueue, CursorChange, FocusChange, WidgetState};
 use crate::env::KeyLike;
@@ -81,8 +82,8 @@ pub struct EventCtx<'a, 'b> {
 /// [`register_child`]: #method.register_child
 /// [`LifeCycle::WidgetAdded`]: enum.LifeCycle.html#variant.WidgetAdded
 pub struct LifeCycleCtx<'a, 'b> {
-    pub(crate) widget_state: &'a mut WidgetState,
     pub(crate) state: &'a mut ContextState<'b>,
+    pub(crate) widget_state: &'a mut WidgetState,
 }
 
 /// A mutable context provided to data update methods of widgets.
@@ -287,6 +288,7 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, {
     /// [`hot`]: EventCtx::is_hot
     /// [`active`]: EventCtx::is_active
     pub fn set_cursor(&mut self, cursor: &Cursor) {
+        trace!("set_cursor {:?}", cursor);
         self.widget_state.cursor_change = CursorChange::Set(cursor.clone());
     }
 
@@ -301,6 +303,7 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, {
     /// [`hot`]: EventCtx::is_hot
     /// [`active`]: EventCtx::is_active
     pub fn override_cursor(&mut self, cursor: &Cursor) {
+        trace!("override_cursor {:?}", cursor);
         self.widget_state.cursor_change = CursorChange::Override(cursor.clone());
     }
 
@@ -311,6 +314,7 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, {
     /// [`override_cursor`]: EventCtx::override_cursor
     /// [`set_cursor`]: EventCtx::set_cursor
     pub fn clear_cursor(&mut self) {
+        trace!("clear_cursor");
         self.widget_state.cursor_change = CursorChange::Default;
     }
 });
@@ -324,6 +328,7 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
     /// [`request_paint_rect`]: #method.request_paint_rect
     /// [`paint_rect`]: struct.WidgetPod.html#method.paint_rect
     pub fn request_paint(&mut self) {
+        trace!("request_paint");
         self.widget_state.invalid.set_rect(
             self.widget_state.paint_rect() - self.widget_state.layout_rect().origin().to_vec2(),
         );
@@ -334,6 +339,7 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
     ///
     /// [`paint`]: trait.Widget.html#tymethod.paint
     pub fn request_paint_rect(&mut self, rect: Rect) {
+        trace!("request_paint_rect {}", rect);
         self.widget_state.invalid.add_rect(rect);
     }
 
@@ -348,11 +354,13 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
     ///
     /// [`layout`]: trait.Widget.html#tymethod.layout
     pub fn request_layout(&mut self) {
+        trace!("request_layout");
         self.widget_state.needs_layout = true;
     }
 
     /// Request an animation frame.
     pub fn request_anim_frame(&mut self) {
+        trace!("request_anim_frame");
         self.widget_state.request_anim = true;
     }
 
@@ -360,6 +368,7 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
     ///
     /// Widgets must call this method after adding a new child.
     pub fn children_changed(&mut self) {
+        trace!("children_changed");
         self.widget_state.children_changed = true;
         self.request_layout();
     }
@@ -369,6 +378,7 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
     ///
     /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
     pub fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {
+        trace!("set_menu");
         self.state.set_menu(menu);
     }
 
@@ -388,6 +398,7 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
         data: U,
         env: Env,
     ) -> WindowId {
+        trace!("new_sub_window");
         let req = SubWindowDesc::new(self.widget_id(), window_config, widget, data, env);
         let window_id = req.window_id;
         self.widget_state
@@ -416,6 +427,7 @@ impl_context_method!(
         /// [`Command`]: struct.Command.html
         /// [`update`]: trait.Widget.html#tymethod.update
         pub fn submit_command(&mut self, cmd: impl Into<Command>) {
+            trace!("submit_command");
             self.state.submit_command(cmd.into())
         }
 
@@ -424,6 +436,7 @@ impl_context_method!(
         ///
         /// [`ExtEventSink`]: struct.ExtEventSink.html
         pub fn get_external_handle(&self) -> ExtEventSink {
+            trace!("get_external_handle");
             self.state.ext_handle.clone()
         }
 
@@ -432,6 +445,7 @@ impl_context_method!(
         /// The return value is a token, which can be used to associate the
         /// request with the event.
         pub fn request_timer(&mut self, deadline: Duration) -> TimerToken {
+            trace!("request_timer deadline={:?}", deadline);
             self.state.request_timer(&mut self.widget_state, deadline)
         }
     }
@@ -462,6 +476,7 @@ impl EventCtx<'_, '_> {
     ///
     /// [`Selector`]: crate::Selector
     pub fn submit_notification(&mut self, note: impl Into<Command>) {
+        trace!("submit_notification");
         let note = note.into().into_notification(self.widget_state.id);
         self.notifications.push_back(note);
     }
@@ -470,6 +485,7 @@ impl EventCtx<'_, '_> {
     ///
     /// See [`EventCtx::is_active`](struct.EventCtx.html#method.is_active).
     pub fn set_active(&mut self, active: bool) {
+        trace!("set_active({})", active);
         self.widget_state.is_active = active;
         // TODO: plumb mouse grab through to platform (through druid-shell)
     }
@@ -479,6 +495,7 @@ impl EventCtx<'_, '_> {
     ///
     /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
     pub fn new_window<T: Any>(&mut self, desc: WindowDesc<T>) {
+        trace!("new_window");
         if self.state.root_app_data_type == TypeId::of::<T>() {
             self.submit_command(
                 commands::NEW_WINDOW
@@ -495,6 +512,7 @@ impl EventCtx<'_, '_> {
     ///
     /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
     pub fn show_context_menu<T: Any>(&mut self, menu: ContextMenu<T>) {
+        trace!("show_context_menu");
         if self.state.root_app_data_type == TypeId::of::<T>() {
             self.submit_command(
                 commands::SHOW_CONTEXT_MENU
@@ -511,6 +529,7 @@ impl EventCtx<'_, '_> {
     /// Set the event as "handled", which stops its propagation to other
     /// widgets.
     pub fn set_handled(&mut self) {
+        trace!("set_handled");
         self.is_handled = true;
     }
 
@@ -529,6 +548,7 @@ impl EventCtx<'_, '_> {
     ///
     /// [`is_focused`]: struct.EventCtx.html#method.is_focused
     pub fn request_focus(&mut self) {
+        trace!("request_focus");
         // We need to send the request even if we're currently focused,
         // because we may have a sibling widget that already requested focus
         // and we have no way of knowing that yet. We need to override that
@@ -543,6 +563,7 @@ impl EventCtx<'_, '_> {
     ///
     /// [`is_focused`]: struct.EventCtx.html#method.is_focused
     pub fn set_focus(&mut self, target: WidgetId) {
+        trace!("set_focus target={:?}", target);
         self.widget_state.request_focus = Some(FocusChange::Focus(target));
     }
 
@@ -554,10 +575,11 @@ impl EventCtx<'_, '_> {
     ///
     /// [`is_focused`]: struct.EventCtx.html#method.is_focused
     pub fn focus_next(&mut self) {
+        trace!("focus_next");
         if self.is_focused() {
             self.widget_state.request_focus = Some(FocusChange::Next);
         } else {
-            tracing::warn!("focus_next can only be called by the currently focused widget");
+            warn!("focus_next can only be called by the currently focused widget");
         }
     }
 
@@ -569,10 +591,11 @@ impl EventCtx<'_, '_> {
     ///
     /// [`is_focused`]: struct.EventCtx.html#method.is_focused
     pub fn focus_prev(&mut self) {
+        trace!("focus_prev");
         if self.is_focused() {
             self.widget_state.request_focus = Some(FocusChange::Previous);
         } else {
-            tracing::warn!("focus_prev can only be called by the currently focused widget");
+            warn!("focus_prev can only be called by the currently focused widget");
         }
     }
 
@@ -584,10 +607,11 @@ impl EventCtx<'_, '_> {
     ///
     /// [`is_focused`]: struct.EventCtx.html#method.is_focused
     pub fn resign_focus(&mut self) {
+        trace!("resign_focus");
         if self.is_focused() {
             self.widget_state.request_focus = Some(FocusChange::Resign);
         } else {
-            tracing::warn!(
+            warn!(
                 "resign_focus can only be called by the currently focused widget ({:?})",
                 self.widget_id()
             );
@@ -604,6 +628,7 @@ impl EventCtx<'_, '_> {
     /// method, consider whether it might be better to refactor to be more idiomatic, in
     /// particular to make that data available in the app state.
     pub fn request_update(&mut self) {
+        trace!("request_update");
         self.widget_state.request_update = true;
     }
 }
@@ -655,6 +680,7 @@ impl LifeCycleCtx<'_, '_> {
     /// In general, you should not need to call this method; it is handled by
     /// the `WidgetPod`.
     pub fn register_child(&mut self, child_id: WidgetId) {
+        trace!("register_child id={:?}", child_id);
         self.widget_state.children.add(&child_id);
     }
 
@@ -667,6 +693,7 @@ impl LifeCycleCtx<'_, '_> {
     /// [`LifeCycle::WidgetAdded`]: enum.Lifecycle.html#variant.WidgetAdded
     /// [`EventCtx::is_focused`]: struct.EventCtx.html#method.is_focused
     pub fn register_for_focus(&mut self) {
+        trace!("register_for_focus");
         self.widget_state.focus_chain.push(self.widget_id());
     }
 }
@@ -684,7 +711,9 @@ impl LayoutCtx<'_, '_> {
     /// [`Insets`]: struct.Insets.html
     /// [`WidgetPod::paint_insets`]: struct.WidgetPod.html#method.paint_insets
     pub fn set_paint_insets(&mut self, insets: impl Into<Insets>) {
-        self.widget_state.paint_insets = insets.into().nonnegative();
+        let insets = insets.into();
+        trace!("set_paint_insets {:?}", insets);
+        self.widget_state.paint_insets = insets.nonnegative();
     }
 
     /// Set an explicit baseline position for this widget.
@@ -697,6 +726,7 @@ impl LayoutCtx<'_, '_> {
     /// The provided value should be the distance from the *bottom* of the
     /// widget to the baseline.
     pub fn set_baseline_offset(&mut self, baseline: f64) {
+        trace!("set_baseline_offset {}", baseline);
         self.widget_state.baseline_offset = baseline
     }
 }
@@ -763,14 +793,14 @@ impl PaintCtx<'_, '_, '_> {
     /// ```
     pub fn with_save(&mut self, f: impl FnOnce(&mut PaintCtx)) {
         if let Err(e) = self.render_ctx.save() {
-            tracing::error!("Failed to save RenderContext: '{}'", e);
+            error!("Failed to save RenderContext: '{}'", e);
             return;
         }
 
         f(self);
 
         if let Err(e) = self.render_ctx.restore() {
-            tracing::error!("Failed to restore RenderContext: '{}'", e);
+            error!("Failed to restore RenderContext: '{}'", e);
         }
     }
 
@@ -811,11 +841,13 @@ impl<'a> ContextState<'a> {
     }
 
     fn submit_command(&mut self, command: Command) {
+        trace!("submit_command");
         self.command_queue
             .push_back(command.default_to(self.window_id.into()));
     }
 
     fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {
+        trace!("set_menu");
         if self.root_app_data_type == TypeId::of::<T>() {
             self.submit_command(
                 commands::SET_MENU
@@ -828,6 +860,7 @@ impl<'a> ContextState<'a> {
     }
 
     fn request_timer(&self, widget_state: &mut WidgetState, deadline: Duration) -> TimerToken {
+        trace!("request_timer deadline={:?}", deadline);
         let timer_token = self.window.request_timer(deadline);
         widget_state.add_timer(timer_token);
         timer_token

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -15,6 +15,7 @@
 //! The fundamental druid types.
 
 use std::collections::{HashMap, VecDeque};
+use tracing::{trace, warn};
 
 use crate::bloom::Bloom;
 use crate::command::sys::{CLOSE_WINDOW, SUB_WINDOW_HOST_TO_PARENT, SUB_WINDOW_PARENT_TO_HOST};
@@ -226,7 +227,7 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
     /// [`set_origin`]: WidgetPod::set_origin
     pub fn set_layout_rect(&mut self, ctx: &mut LayoutCtx, data: &T, env: &Env, layout_rect: Rect) {
         if layout_rect.size() != self.state.size {
-            tracing::warn!("set_layout_rect passed different size than returned by layout method");
+            warn!("set_layout_rect passed different size than returned by layout method");
         }
         self.set_origin(ctx, data, env, layout_rect.origin());
     }
@@ -571,11 +572,11 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
     fn log_layout_issues(&self, size: Size) {
         if size.width.is_infinite() {
             let name = self.widget().type_name();
-            tracing::warn!("Widget `{}` has an infinite width.", name);
+            warn!("Widget `{}` has an infinite width.", name);
         }
         if size.height.is_infinite() {
             let name = self.widget().type_name();
-            tracing::warn!("Widget `{}` has an infinite height.", name);
+            warn!("Widget `{}` has an infinite height.", name);
         }
     }
 
@@ -615,7 +616,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
 
         // log if we seem not to be laid out when we should be
         if self.state.is_expecting_set_origin_call && !event.should_propagate_to_hidden() {
-            tracing::warn!(
+            warn!(
                 "{:?} received an event ({:?}) without having been laid out. \
                 This likely indicates a missed call to set_layout_rect.",
                 ctx.widget_id(),
@@ -813,6 +814,8 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
 
             // we try to handle the notifications that occured below us in the tree
             self.send_notifications(ctx, &mut notifications, data, env);
+        } else {
+            trace!("event wasn't propagated to {:?}", self.state.id);
         }
 
         // Always merge even if not needed, because merging is idempotent and gives us simpler code.
@@ -861,7 +864,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         }
 
         if !inner_ctx.notifications.is_empty() {
-            tracing::warn!(
+            warn!(
                 "A Notification was submitted while handling another \
             notification; the submitted notification will be ignored."
             );
@@ -941,6 +944,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             },
             LifeCycle::WidgetAdded => {
                 assert!(self.old_data.is_none());
+                trace!("Received LifeCycle::WidgetAdded");
 
                 self.old_data = Some(data.clone());
                 self.env = Some(env.clone());
@@ -1005,7 +1009,10 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
     pub fn update(&mut self, ctx: &mut UpdateCtx, data: &T, env: &Env) {
         if !self.state.request_update {
             match (self.old_data.as_ref(), self.env.as_ref()) {
-                (Some(d), Some(e)) if d.same(data) && e.same(env) => return,
+                (Some(d), Some(e)) if d.same(data) && e.same(env) => {
+                    trace!("data and env are unchanged, returning early.");
+                    return;
+                }
                 (Some(_), None) => self.env = Some(env.clone()),
                 (None, _) => {
                     debug_panic!(
@@ -1120,6 +1127,11 @@ impl WidgetState {
     ///
     /// This method is idempotent and can be called multiple times.
     fn merge_up(&mut self, child_state: &mut WidgetState) {
+        trace!(
+            "merge_up self.id={:?} child.id={:?}",
+            self.id,
+            child_state.id
+        );
         let clip = self
             .layout_rect()
             .with_origin(Point::ORIGIN)

--- a/druid/src/sub_window.rs
+++ b/druid/src/sub_window.rs
@@ -97,9 +97,12 @@ impl<U, W: Widget<U>> SubWindowHost<U, W> {
     }
 }
 
-// TODO
 impl<U: Data, W: Widget<U>> Widget<()> for SubWindowHost<U, W> {
-    #[instrument(name = "Button", level = "trace", skip(self, ctx, event, _data, _env))]
+    #[instrument(
+        name = "SubWindowHost",
+        level = "trace",
+        skip(self, ctx, event, _data, _env)
+    )]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, _data: &mut (), _env: &Env) {
         match event {
             Event::Command(cmd) if cmd.is(SUB_WINDOW_PARENT_TO_HOST) => {
@@ -133,13 +136,17 @@ impl<U: Data, W: Widget<U>> Widget<()> for SubWindowHost<U, W> {
         }
     }
 
-    #[instrument(name = "Button", level = "trace", skip(self, ctx, event, _data, _env))]
+    #[instrument(
+        name = "SubWindowHost",
+        level = "trace",
+        skip(self, ctx, event, _data, _env)
+    )]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &(), _env: &Env) {
         self.child.lifecycle(ctx, event, &self.data, &self.env)
     }
 
     #[instrument(
-        name = "Button",
+        name = "SubWindowHost",
         level = "trace",
         skip(self, ctx, _old_data, _data, _env)
     )]
@@ -149,7 +156,11 @@ impl<U: Data, W: Widget<U>> Widget<()> for SubWindowHost<U, W> {
         }
     }
 
-    #[instrument(name = "Button", level = "trace", skip(self, ctx, bc, _data, _env))]
+    #[instrument(
+        name = "SubWindowHost",
+        level = "trace",
+        skip(self, ctx, bc, _data, _env)
+    )]
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, _data: &(), _env: &Env) -> Size {
         let size = self.child.layout(ctx, bc, &self.data, &self.env);
         self.child.set_layout_rect(
@@ -161,7 +172,7 @@ impl<U: Data, W: Widget<U>> Widget<()> for SubWindowHost<U, W> {
         size
     }
 
-    #[instrument(name = "Button", level = "trace", skip(self, ctx, _data, _env))]
+    #[instrument(name = "SubWindowHost", level = "trace", skip(self, ctx, _data, _env))]
     fn paint(&mut self, ctx: &mut PaintCtx, _data: &(), _env: &Env) {
         self.child.paint_raw(ctx, &self.data, &self.env);
     }

--- a/druid/src/sub_window.rs
+++ b/druid/src/sub_window.rs
@@ -23,7 +23,7 @@ use crate::{
 use druid_shell::Error;
 use std::any::Any;
 use std::ops::Deref;
-
+use tracing::{instrument, warn};
 // We can't have any type arguments here, as both ends would need to know them
 // ahead of time in order to instantiate correctly.
 // So we erase everything to ()
@@ -97,7 +97,9 @@ impl<U, W: Widget<U>> SubWindowHost<U, W> {
     }
 }
 
+// TODO
 impl<U: Data, W: Widget<U>> Widget<()> for SubWindowHost<U, W> {
+    #[instrument(name = "Button", level = "trace", skip(self, ctx, event, _data, _env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, _data: &mut (), _env: &Env) {
         match event {
             Event::Command(cmd) if cmd.is(SUB_WINDOW_PARENT_TO_HOST) => {
@@ -107,7 +109,7 @@ impl<U: Data, W: Widget<U>> Widget<()> for SubWindowHost<U, W> {
                         self.data = dc.deref().clone();
                         ctx.request_update();
                     } else {
-                        tracing::warn!("Received a sub window parent to host command that could not be unwrapped. \
+                        warn!("Received a sub window parent to host command that could not be unwrapped. \
                         This could mean that the sub window you requested and the enclosing widget pod that you opened it from do not share a common data type. \
                         Make sure you have a widget pod between your requesting widget and any lenses." )
                     }
@@ -131,16 +133,23 @@ impl<U: Data, W: Widget<U>> Widget<()> for SubWindowHost<U, W> {
         }
     }
 
+    #[instrument(name = "Button", level = "trace", skip(self, ctx, event, _data, _env))]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &(), _env: &Env) {
         self.child.lifecycle(ctx, event, &self.data, &self.env)
     }
 
+    #[instrument(
+        name = "Button",
+        level = "trace",
+        skip(self, ctx, _old_data, _data, _env)
+    )]
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &(), _data: &(), _env: &Env) {
         if ctx.has_requested_update() {
             self.child.update(ctx, &self.data, &self.env);
         }
     }
 
+    #[instrument(name = "Button", level = "trace", skip(self, ctx, bc, _data, _env))]
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, _data: &(), _env: &Env) -> Size {
         let size = self.child.layout(ctx, bc, &self.data, &self.env);
         self.child.set_layout_rect(
@@ -152,6 +161,7 @@ impl<U: Data, W: Widget<U>> Widget<()> for SubWindowHost<U, W> {
         size
     }
 
+    #[instrument(name = "Button", level = "trace", skip(self, ctx, _data, _env))]
     fn paint(&mut self, ctx: &mut PaintCtx, _data: &(), _env: &Env) {
         self.child.paint_raw(ctx, &self.data, &self.env);
     }

--- a/druid/src/widget/added.rs
+++ b/druid/src/widget/added.rs
@@ -19,6 +19,7 @@
 
 use crate::widget::Controller;
 use crate::{Data, Env, LifeCycleCtx, Widget};
+use tracing::{instrument, trace};
 
 /// This [`Controller`] widget responds to [`LifeCycle::WidgetAdded`] event
 /// with the provided closure. Pass this and a child widget to [`ControllerHost`]
@@ -46,6 +47,11 @@ impl<T: Data, W: Widget<T>> Added<T, W> {
 }
 
 impl<T: Data, W: Widget<T>> Controller<T, W> for Added<T, W> {
+    #[instrument(
+        name = "Added",
+        level = "trace",
+        skip(self, child, ctx, event, data, env)
+    )]
     fn lifecycle(
         &mut self,
         child: &mut W,
@@ -55,6 +61,7 @@ impl<T: Data, W: Widget<T>> Controller<T, W> for Added<T, W> {
         env: &Env,
     ) {
         if let crate::LifeCycle::WidgetAdded = event {
+            trace!("Widget added");
             (self.action)(child, ctx, data, env);
         }
         child.lifecycle(ctx, event, data, env)

--- a/druid/src/widget/align.rs
+++ b/druid/src/widget/align.rs
@@ -16,6 +16,7 @@
 
 use crate::widget::prelude::*;
 use crate::{Data, Rect, Size, UnitPoint, WidgetPod};
+use tracing::{instrument, trace};
 
 /// A widget that aligns its child.
 pub struct Align<T> {
@@ -77,19 +78,24 @@ impl<T> Align<T> {
 }
 
 impl<T: Data> Widget<T> for Align<T> {
+    #[instrument(name = "Align", level = "trace", skip(self, ctx, event, data, env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         self.child.event(ctx, event, data, env)
     }
 
+    #[instrument(name = "Align", level = "trace", skip(self, ctx, event, data, env))]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         self.child.lifecycle(ctx, event, data, env)
     }
 
+    #[instrument(name = "Align", level = "trace", skip(self, ctx, _old_data, data, env))]
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
         self.child.update(ctx, data, env);
     }
 
+    #[instrument(name = "Align", level = "trace", skip(self, ctx, bc, data, env))]
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
+        trace!("Layout constraints: {:?}", bc);
         bc.debug_check("Align");
 
         let size = self.child.layout(ctx, &bc.loosen(), data, env);
@@ -122,9 +128,16 @@ impl<T: Data> Widget<T> for Align<T> {
 
         let my_insets = self.child.compute_parent_paint_insets(my_size);
         ctx.set_paint_insets(my_insets);
+        trace!(
+            "Computed layout: origin={}, size={}, insets={:?}",
+            origin,
+            my_size,
+            my_insets
+        );
         my_size
     }
 
+    #[instrument(name = "Align", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         self.child.paint(ctx, data, env);
     }

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -18,6 +18,7 @@ use crate::kurbo::{BezPath, Size};
 use crate::piet::{LineCap, LineJoin, LinearGradient, RenderContext, StrokeStyle, UnitPoint};
 use crate::theme;
 use crate::widget::{prelude::*, Label, LabelText};
+use tracing::{instrument, trace};
 
 /// A checkbox that toggles a `bool`.
 pub struct Checkbox {
@@ -39,11 +40,13 @@ impl Checkbox {
 }
 
 impl Widget<bool> for Checkbox {
+    #[instrument(name = "CheckBox", level = "trace", skip(self, ctx, event, data, _env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut bool, _env: &Env) {
         match event {
             Event::MouseDown(_) => {
                 ctx.set_active(true);
                 ctx.request_paint();
+                trace!("Checkbox {:?} pressed", ctx.widget_id());
             }
             Event::MouseUp(_) => {
                 if ctx.is_active() {
@@ -51,8 +54,10 @@ impl Widget<bool> for Checkbox {
                     if ctx.is_hot() {
                         if *data {
                             *data = false;
+                            trace!("Checkbox {:?} released - unchecked", ctx.widget_id());
                         } else {
                             *data = true;
+                            trace!("Checkbox {:?} released - checked", ctx.widget_id());
                         }
                     }
                     ctx.request_paint();
@@ -62,6 +67,7 @@ impl Widget<bool> for Checkbox {
         }
     }
 
+    #[instrument(name = "CheckBox", level = "trace", skip(self, ctx, event, data, env))]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &bool, env: &Env) {
         self.child_label.lifecycle(ctx, event, data, env);
         if let LifeCycle::HotChanged(_) = event {
@@ -69,11 +75,17 @@ impl Widget<bool> for Checkbox {
         }
     }
 
+    #[instrument(
+        name = "CheckBox",
+        level = "trace",
+        skip(self, ctx, old_data, data, env)
+    )]
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &bool, data: &bool, env: &Env) {
         self.child_label.update(ctx, old_data, data, env);
         ctx.request_paint();
     }
 
+    #[instrument(name = "CheckBox", level = "trace", skip(self, ctx, bc, data, env))]
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &bool, env: &Env) -> Size {
         bc.debug_check("Checkbox");
         let x_padding = env.get(theme::WIDGET_CONTROL_COMPONENT_PADDING);
@@ -87,9 +99,11 @@ impl Widget<bool> for Checkbox {
         let our_size = bc.constrain(desired_size);
         let baseline = self.child_label.baseline_offset() + (our_size.height - label_size.height);
         ctx.set_baseline_offset(baseline);
+        trace!("Computed layout: size={}, baseline={}", our_size, baseline);
         our_size
     }
 
+    #[instrument(name = "CheckBox", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &bool, env: &Env) {
         let size = env.get(theme::BASIC_WIDGET_HEIGHT);
         let x_padding = env.get(theme::WIDGET_CONTROL_COMPONENT_PADDING);

--- a/druid/src/widget/click.rs
+++ b/druid/src/widget/click.rs
@@ -18,6 +18,7 @@
 
 use crate::widget::Controller;
 use crate::{Data, Env, Event, EventCtx, LifeCycle, LifeCycleCtx, MouseButton, Widget};
+use tracing::{instrument, trace};
 
 /// A clickable [`Controller`] widget. Pass this and a child widget to a
 /// [`ControllerHost`] to make the child interactive. More conveniently, this is
@@ -50,12 +51,18 @@ impl<T: Data> Click<T> {
 }
 
 impl<T: Data, W: Widget<T>> Controller<T, W> for Click<T> {
+    #[instrument(
+        name = "Click",
+        level = "trace",
+        skip(self, child, ctx, event, data, env)
+    )]
     fn event(&mut self, child: &mut W, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         match event {
             Event::MouseDown(mouse_event) => {
                 if mouse_event.button == MouseButton::Left {
                     ctx.set_active(true);
                     ctx.request_paint();
+                    trace!("Widget {:?} pressed", ctx.widget_id());
                 }
             }
             Event::MouseUp(mouse_event) => {
@@ -65,6 +72,7 @@ impl<T: Data, W: Widget<T>> Controller<T, W> for Click<T> {
                         (self.action)(ctx, data, env);
                     }
                     ctx.request_paint();
+                    trace!("Widget {:?} released", ctx.widget_id());
                 }
             }
             _ => {}
@@ -73,6 +81,11 @@ impl<T: Data, W: Widget<T>> Controller<T, W> for Click<T> {
         child.event(ctx, event, data, env);
     }
 
+    #[instrument(
+        name = "Click",
+        level = "trace",
+        skip(self, child, ctx, event, data, env)
+    )]
     fn lifecycle(
         &mut self,
         child: &mut W,

--- a/druid/src/widget/either.rs
+++ b/druid/src/widget/either.rs
@@ -16,6 +16,7 @@
 
 use crate::widget::prelude::*;
 use crate::{Data, Point, WidgetPod};
+use tracing::instrument;
 
 /// A widget that switches between two possible child views.
 pub struct Either<T> {
@@ -45,6 +46,7 @@ impl<T> Either<T> {
 }
 
 impl<T: Data> Widget<T> for Either<T> {
+    #[instrument(name = "Either", level = "trace", skip(self, ctx, event, data, env), fields(branch = self.current))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if event.should_propagate_to_hidden() {
             self.true_branch.event(ctx, event, data, env);
@@ -54,6 +56,7 @@ impl<T: Data> Widget<T> for Either<T> {
         }
     }
 
+    #[instrument(name = "Either", level = "trace", skip(self, ctx, event, data, env), fields(branch = self.current))]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         if let LifeCycle::WidgetAdded = event {
             self.current = (self.closure)(data, env);
@@ -67,6 +70,7 @@ impl<T: Data> Widget<T> for Either<T> {
         }
     }
 
+    #[instrument(name = "Either", level = "trace", skip(self, ctx, _old_data, data, env), fields(branch = self.current))]
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
         let current = (self.closure)(data, env);
         if current != self.current {
@@ -76,6 +80,7 @@ impl<T: Data> Widget<T> for Either<T> {
         self.current_widget().update(ctx, data, env)
     }
 
+    #[instrument(name = "Either", level = "trace", skip(self, ctx, bc, data, env), fields(branch = self.current))]
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         let current_widget = self.current_widget();
         let size = current_widget.layout(ctx, bc, data, env);
@@ -84,6 +89,7 @@ impl<T: Data> Widget<T> for Either<T> {
         size
     }
 
+    #[instrument(name = "Either", level = "trace", skip(self, ctx, data, env), fields(branch = self.current))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         self.current_widget().paint(ctx, data, env)
     }

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -17,6 +17,7 @@
 use crate::widget::prelude::*;
 use crate::widget::WidgetWrapper;
 use crate::{Data, Point, WidgetPod};
+use tracing::instrument;
 
 /// A widget that accepts a closure to update the environment for its child.
 pub struct EnvScope<T, W> {
@@ -57,6 +58,7 @@ impl<T, W: Widget<T>> EnvScope<T, W> {
 }
 
 impl<T: Data, W: Widget<T>> Widget<T> for EnvScope<T, W> {
+    #[instrument(name = "EnvScope", level = "trace", skip(self, ctx, event, data, env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         let mut new_env = env.clone();
         (self.f)(&mut new_env, &data);
@@ -64,12 +66,18 @@ impl<T: Data, W: Widget<T>> Widget<T> for EnvScope<T, W> {
         self.child.event(ctx, event, data, &new_env)
     }
 
+    #[instrument(name = "EnvScope", level = "trace", skip(self, ctx, event, data, env))]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         let mut new_env = env.clone();
         (self.f)(&mut new_env, &data);
         self.child.lifecycle(ctx, event, data, &new_env)
     }
 
+    #[instrument(
+        name = "EnvScope",
+        level = "trace",
+        skip(self, ctx, _old_data, data, env)
+    )]
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
         let mut new_env = env.clone();
         (self.f)(&mut new_env, &data);
@@ -77,6 +85,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for EnvScope<T, W> {
         self.child.update(ctx, data, &new_env);
     }
 
+    #[instrument(name = "EnvScope", level = "trace", skip(self, ctx, bc, data, env))]
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         bc.debug_check("EnvScope");
 
@@ -88,6 +97,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for EnvScope<T, W> {
         size
     }
 
+    #[instrument(name = "EnvScope", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         let mut new_env = env.clone();
         (self.f)(&mut new_env, &data);

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -17,6 +17,7 @@
 use crate::kurbo::common::FloatExt;
 use crate::widget::prelude::*;
 use crate::{Data, KeyOrValue, Point, Rect, WidgetPod};
+use tracing::{instrument, trace};
 
 /// A container with either horizontal or vertical layout.
 ///
@@ -587,24 +588,28 @@ impl<T: Data> Flex<T> {
 }
 
 impl<T: Data> Widget<T> for Flex<T> {
+    #[instrument(name = "Flex", level = "trace", skip(self, ctx, event, data, env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         for child in self.children.iter_mut().filter_map(|x| x.widget_mut()) {
             child.event(ctx, event, data, env);
         }
     }
 
+    #[instrument(name = "Flex", level = "trace", skip(self, ctx, event, data, env))]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         for child in self.children.iter_mut().filter_map(|x| x.widget_mut()) {
             child.lifecycle(ctx, event, data, env);
         }
     }
 
+    #[instrument(name = "Flex", level = "trace", skip(self, ctx, _old_data, data, env))]
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
         for child in self.children.iter_mut().filter_map(|x| x.widget_mut()) {
             child.update(ctx, data, env);
         }
     }
 
+    #[instrument(name = "Flex", level = "trace", skip(self, ctx, bc, data, env))]
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         bc.debug_check("Flex");
         // we loosen our constraints when passing to children.
@@ -799,9 +804,15 @@ impl<T: Data> Widget<T> for Flex<T> {
         };
 
         ctx.set_baseline_offset(baseline_offset);
+        trace!(
+            "Computed layout: size={}, baseline_offset={}",
+            my_size,
+            baseline_offset
+        );
         my_size
     }
 
+    #[instrument(name = "Flex", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         for child in self.children.iter_mut().filter_map(|x| x.widget_mut()) {
             child.paint(ctx, data, env);

--- a/druid/src/widget/identity_wrapper.rs
+++ b/druid/src/widget/identity_wrapper.rs
@@ -18,6 +18,7 @@ use crate::kurbo::Size;
 use crate::widget::prelude::*;
 use crate::widget::WidgetWrapper;
 use crate::Data;
+use tracing::instrument;
 
 /// A wrapper that adds an identity to an otherwise anonymous widget.
 pub struct IdentityWrapper<W> {
@@ -33,22 +34,43 @@ impl<W> IdentityWrapper<W> {
 }
 
 impl<T: Data, W: Widget<T>> Widget<T> for IdentityWrapper<W> {
+    #[instrument(
+        name = "IdentityWrapper",
+        level = "trace",
+        skip(self, ctx, event, data, env)
+    )]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         self.inner.event(ctx, event, data, env);
     }
 
+    #[instrument(
+        name = "IdentityWrapper",
+        level = "trace",
+        skip(self, ctx, event, data, env)
+    )]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         self.inner.lifecycle(ctx, event, data, env)
     }
 
+    #[instrument(
+        name = "IdentityWrapper",
+        level = "trace",
+        skip(self, ctx, old_data, data, env)
+    )]
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
         self.inner.update(ctx, old_data, data, env);
     }
 
+    #[instrument(
+        name = "IdentityWrapper",
+        level = "trace",
+        skip(self, ctx, bc, data, env)
+    )]
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         self.inner.layout(ctx, bc, data, env)
     }
 
+    #[instrument(name = "IdentityWrapper", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         self.inner.paint(ctx, data, env);
     }

--- a/druid/src/widget/image.rs
+++ b/druid/src/widget/image.rs
@@ -22,6 +22,7 @@ use crate::{
     widget::prelude::*,
     Data,
 };
+use tracing::{instrument, trace};
 
 /// A widget that renders a bitmap Image.
 ///
@@ -164,12 +165,24 @@ impl Image {
 }
 
 impl<T: Data> Widget<T> for Image {
+    #[instrument(name = "Image", level = "trace", skip(self, _ctx, _event, _data, _env))]
     fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut T, _env: &Env) {}
 
+    #[instrument(name = "Image", level = "trace", skip(self, _ctx, _event, _data, _env))]
     fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &T, _env: &Env) {}
 
+    #[instrument(
+        name = "Image",
+        level = "trace",
+        skip(self, _ctx, _old_data, _data, _env)
+    )]
     fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: &T, _data: &T, _env: &Env) {}
 
+    #[instrument(
+        name = "Image",
+        level = "trace",
+        skip(self, _layout_ctx, bc, _data, _env)
+    )]
     fn layout(
         &mut self,
         _layout_ctx: &mut LayoutCtx,
@@ -184,7 +197,7 @@ impl<T: Data> Widget<T> for Image {
         // the image.
         let max = bc.max();
         let image_size = self.image_data.size();
-        if bc.is_width_bounded() && !bc.is_height_bounded() {
+        let size = if bc.is_width_bounded() && !bc.is_height_bounded() {
             let ratio = max.width / image_size.width;
             Size::new(max.width, ratio * image_size.height)
         } else if bc.is_height_bounded() && !bc.is_width_bounded() {
@@ -192,9 +205,12 @@ impl<T: Data> Widget<T> for Image {
             Size::new(ratio * image_size.width, max.height)
         } else {
             bc.constrain(self.image_data.size())
-        }
+        };
+        trace!("Computed size: {}", size);
+        size
     }
 
+    #[instrument(name = "Image", level = "trace", skip(self, ctx, _data, _env))]
     fn paint(&mut self, ctx: &mut PaintCtx, _data: &T, _env: &Env) {
         let offset_matrix = self.fill.affine_to_fill(ctx.size(), self.image_data.size());
 

--- a/druid/src/widget/invalidation.rs
+++ b/druid/src/widget/invalidation.rs
@@ -14,6 +14,7 @@
 
 use crate::widget::prelude::*;
 use crate::Data;
+use tracing::instrument;
 
 /// A widget that draws semi-transparent rectangles of changing colors to help debug invalidation
 /// regions.
@@ -35,22 +36,47 @@ impl<T: Data, W: Widget<T>> DebugInvalidation<T, W> {
 }
 
 impl<T: Data, W: Widget<T>> Widget<T> for DebugInvalidation<T, W> {
+    #[instrument(
+        name = "DebugInvalidation",
+        level = "trace",
+        skip(self, ctx, event, data, env)
+    )]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         self.inner.event(ctx, event, data, env);
     }
 
+    #[instrument(
+        name = "DebugInvalidation",
+        level = "trace",
+        skip(self, ctx, event, data, env)
+    )]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         self.inner.lifecycle(ctx, event, data, env)
     }
 
+    #[instrument(
+        name = "DebugInvalidation",
+        level = "trace",
+        skip(self, ctx, old_data, data, env)
+    )]
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
         self.inner.update(ctx, old_data, data, env);
     }
 
+    #[instrument(
+        name = "DebugInvalidation",
+        level = "trace",
+        skip(self, ctx, bc, data, env)
+    )]
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         self.inner.layout(ctx, bc, data, env)
     }
 
+    #[instrument(
+        name = "DebugInvalidation",
+        level = "trace",
+        skip(self, ctx, data, env)
+    )]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         self.inner.paint(ctx, data, env);
 

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -321,7 +321,7 @@ impl<S: Data, T: Data> ListIter<(S, T)> for (S, Arc<VecDeque<T>>) {
 }
 
 impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
-    #[instrument(name = "Widget", level = "trace", skip(self, ctx, event, data, env))]
+    #[instrument(name = "List", level = "trace", skip(self, ctx, event, data, env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         let mut children = self.children.iter_mut();
         data.for_each_mut(|child_data, _| {
@@ -331,7 +331,7 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
         });
     }
 
-    #[instrument(name = "Widget", level = "trace", skip(self, ctx, event, data, env))]
+    #[instrument(name = "List", level = "trace", skip(self, ctx, event, data, env))]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         if let LifeCycle::WidgetAdded = event {
             if self.update_child_count(data, env) {
@@ -347,11 +347,7 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
         });
     }
 
-    #[instrument(
-        name = "Widget",
-        level = "trace",
-        skip(self, ctx, _old_data, data, env)
-    )]
+    #[instrument(name = "List", level = "trace", skip(self, ctx, _old_data, data, env))]
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
         // we send update to children first, before adding or removing children;
         // this way we avoid sending update to newly added children, at the cost
@@ -368,7 +364,7 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
         }
     }
 
-    #[instrument(name = "Widget", level = "trace", skip(self, ctx, bc, data, env))]
+    #[instrument(name = "List", level = "trace", skip(self, ctx, bc, data, env))]
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         let axis = self.axis;
         let spacing = self.spacing.resolve(env);
@@ -402,7 +398,7 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
         my_size
     }
 
-    #[instrument(name = "Widget", level = "trace", skip(self, ctx, data, env))]
+    #[instrument(name = "List", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         let mut children = self.children.iter_mut();
         data.for_each(|child_data, _| {

--- a/druid/src/widget/maybe.rs
+++ b/druid/src/widget/maybe.rs
@@ -160,7 +160,7 @@ impl<T> MaybeWidget<T> {
         match self {
             Self::Some(widget) => Some(f(widget)),
             Self::None(_) => {
-                log::warn!("`MaybeWidget::with_some` called on `None` value");
+                tracing::warn!("`MaybeWidget::with_some` called on `None` value");
                 None
             }
         }
@@ -174,7 +174,7 @@ impl<T> MaybeWidget<T> {
         match self {
             Self::None(widget) => Some(f(widget)),
             Self::Some(_) => {
-                log::warn!("`MaybeWidget::with_none` called on `Some` value");
+                tracing::warn!("`MaybeWidget::with_none` called on `Some` value");
                 None
             }
         }

--- a/druid/src/widget/maybe.rs
+++ b/druid/src/widget/maybe.rs
@@ -160,7 +160,7 @@ impl<T> MaybeWidget<T> {
         match self {
             Self::Some(widget) => Some(f(widget)),
             Self::None(_) => {
-                tracing::warn!("`MaybeWidget::with_some` called on `None` value");
+                tracing::trace!("`MaybeWidget::with_some` called on `None` value");
                 None
             }
         }
@@ -174,7 +174,7 @@ impl<T> MaybeWidget<T> {
         match self {
             Self::None(widget) => Some(f(widget)),
             Self::Some(_) => {
-                tracing::warn!("`MaybeWidget::with_none` called on `Some` value");
+                tracing::trace!("`MaybeWidget::with_none` called on `Some` value");
                 None
             }
         }

--- a/druid/src/widget/padding.rs
+++ b/druid/src/widget/padding.rs
@@ -17,6 +17,8 @@
 use crate::widget::{prelude::*, WidgetWrapper};
 use crate::{Data, Insets, Point, WidgetPod};
 
+use tracing::{instrument, trace};
+
 /// A widget that just adds padding around its child.
 pub struct Padding<T, W> {
     left: f64,
@@ -74,18 +76,26 @@ impl<T, W> WidgetWrapper for Padding<T, W> {
 }
 
 impl<T: Data, W: Widget<T>> Widget<T> for Padding<T, W> {
+    #[instrument(name = "Padding", level = "trace", skip(self, ctx, event, data, env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         self.child.event(ctx, event, data, env)
     }
 
+    #[instrument(name = "Padding", level = "trace", skip(self, ctx, event, data, env))]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         self.child.lifecycle(ctx, event, data, env)
     }
 
+    #[instrument(
+        name = "Padding",
+        level = "trace",
+        skip(self, ctx, _old_data, data, env)
+    )]
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
         self.child.update(ctx, data, env);
     }
 
+    #[instrument(name = "Padding", level = "trace", skip(self, ctx, bc, data, env))]
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         bc.debug_check("Padding");
 
@@ -100,9 +110,11 @@ impl<T: Data, W: Widget<T>> Widget<T> for Padding<T, W> {
         let my_size = Size::new(size.width + hpad, size.height + vpad);
         let my_insets = self.child.compute_parent_paint_insets(my_size);
         ctx.set_paint_insets(my_insets);
+        trace!("Computed layout: size={}, insets={:?}", my_size, my_insets);
         my_size
     }
 
+    #[instrument(name = "Padding", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         self.child.paint(ctx, data, env);
     }

--- a/druid/src/widget/painter.rs
+++ b/druid/src/widget/painter.rs
@@ -15,6 +15,7 @@
 use crate::piet::{FixedGradient, LinearGradient, PaintBrush, RadialGradient};
 use crate::widget::prelude::*;
 use crate::{Color, Data, Key};
+use tracing::instrument;
 
 /// A widget that only handles painting.
 ///
@@ -125,14 +126,17 @@ impl<T: Data> BackgroundBrush<T> {
 impl<T: Data> Widget<T> for Painter<T> {
     fn event(&mut self, _: &mut EventCtx, _: &Event, _: &mut T, _: &Env) {}
     fn lifecycle(&mut self, _: &mut LifeCycleCtx, _: &LifeCycle, _: &T, _: &Env) {}
-    fn update(&mut self, ctx: &mut UpdateCtx, old: &T, new: &T, _: &Env) {
-        if !old.same(new) {
+    #[instrument(name = "Painter", level = "trace", skip(self, ctx, old_data, data))]
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, _: &Env) {
+        if !old_data.same(data) {
             ctx.request_paint();
         }
     }
+    #[instrument(name = "Painter", level = "trace", skip(self, _ctx, bc))]
     fn layout(&mut self, _ctx: &mut LayoutCtx, bc: &BoxConstraints, _: &T, _: &Env) -> Size {
         bc.max()
     }
+    #[instrument(name = "Painter", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         (self.0)(ctx, data, env)
     }

--- a/druid/src/widget/parse.rs
+++ b/druid/src/widget/parse.rs
@@ -15,6 +15,7 @@
 use std::fmt::Display;
 use std::mem;
 use std::str::FromStr;
+use tracing::instrument;
 
 use crate::widget::prelude::*;
 use crate::Data;
@@ -36,11 +37,13 @@ impl<T> Parse<T> {
 }
 
 impl<T: FromStr + Display + Data, W: Widget<String>> Widget<Option<T>> for Parse<W> {
+    #[instrument(name = "Parse", level = "trace", skip(self, ctx, event, data, env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut Option<T>, env: &Env) {
         self.widget.event(ctx, event, &mut self.state, env);
         *data = self.state.parse().ok();
     }
 
+    #[instrument(name = "Parse", level = "trace", skip(self, ctx, event, data, env))]
     fn lifecycle(
         &mut self,
         ctx: &mut LifeCycleCtx,
@@ -56,6 +59,7 @@ impl<T: FromStr + Display + Data, W: Widget<String>> Widget<Option<T>> for Parse
         self.widget.lifecycle(ctx, event, &self.state, env)
     }
 
+    #[instrument(name = "Parse", level = "trace", skip(self, ctx, _old_data, data, env))]
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &Option<T>, data: &Option<T>, env: &Env) {
         let old = match *data {
             None => return, // Don't clobber the input
@@ -64,6 +68,7 @@ impl<T: FromStr + Display + Data, W: Widget<String>> Widget<Option<T>> for Parse
         self.widget.update(ctx, &old, &self.state, env)
     }
 
+    #[instrument(name = "Parse", level = "trace", skip(self, ctx, bc, _data, env))]
     fn layout(
         &mut self,
         ctx: &mut LayoutCtx,
@@ -74,8 +79,9 @@ impl<T: FromStr + Display + Data, W: Widget<String>> Widget<Option<T>> for Parse
         self.widget.layout(ctx, bc, &self.state, env)
     }
 
-    fn paint(&mut self, paint: &mut PaintCtx, _data: &Option<T>, env: &Env) {
-        self.widget.paint(paint, &self.state, env)
+    #[instrument(name = "Parse", level = "trace", skip(self, ctx, _data, env))]
+    fn paint(&mut self, ctx: &mut PaintCtx, _data: &Option<T>, env: &Env) {
+        self.widget.paint(ctx, &self.state, env)
     }
 
     fn id(&self) -> Option<WidgetId> {

--- a/druid/src/widget/progress_bar.rs
+++ b/druid/src/widget/progress_bar.rs
@@ -16,6 +16,7 @@
 
 use crate::widget::prelude::*;
 use crate::{theme, LinearGradient, Point, Rect, UnitPoint};
+use tracing::instrument;
 
 /// A progress bar, displaying a numeric progress value.
 ///
@@ -31,14 +32,34 @@ impl ProgressBar {
 }
 
 impl Widget<f64> for ProgressBar {
+    #[instrument(
+        name = "ProgressBar",
+        level = "trace",
+        skip(self, _ctx, _event, _data, _env)
+    )]
     fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut f64, _env: &Env) {}
 
+    #[instrument(
+        name = "ProgressBar",
+        level = "trace",
+        skip(self, _ctx, _event, _data, _env)
+    )]
     fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &f64, _env: &Env) {}
 
+    #[instrument(
+        name = "ProgressBar",
+        level = "trace",
+        skip(self, ctx, _old_data, _data, _env)
+    )]
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &f64, _data: &f64, _env: &Env) {
         ctx.request_paint();
     }
 
+    #[instrument(
+        name = "ProgressBar",
+        level = "trace",
+        skip(self, _layout_ctx, bc, _data, env)
+    )]
     fn layout(
         &mut self,
         _layout_ctx: &mut LayoutCtx,
@@ -53,6 +74,7 @@ impl Widget<f64> for ProgressBar {
         ))
     }
 
+    #[instrument(name = "ProgressBar", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &f64, env: &Env) {
         let height = env.get(theme::BASIC_WIDGET_HEIGHT);
         let corner_radius = env.get(theme::PROGRESS_BAR_RADIUS);

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -18,6 +18,7 @@ use crate::kurbo::Circle;
 use crate::widget::prelude::*;
 use crate::widget::{CrossAxisAlignment, Flex, Label, LabelText};
 use crate::{theme, Data, LinearGradient, UnitPoint};
+use tracing::{instrument, trace};
 
 const DEFAULT_RADIO_RADIUS: f64 = 7.0;
 const INNER_CIRCLE_RADIUS: f64 = 2.0;
@@ -61,11 +62,13 @@ impl<T: Data> Radio<T> {
 }
 
 impl<T: Data + PartialEq> Widget<T> for Radio<T> {
+    #[instrument(name = "Radio", level = "trace", skip(self, ctx, event, data, _env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, _env: &Env) {
         match event {
             Event::MouseDown(_) => {
                 ctx.set_active(true);
                 ctx.request_paint();
+                trace!("Radio button {:?} pressed", ctx.widget_id());
             }
             Event::MouseUp(_) => {
                 if ctx.is_active() {
@@ -74,12 +77,14 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
                         *data = self.variant.clone();
                     }
                     ctx.request_paint();
+                    trace!("Radio button {:?} released", ctx.widget_id());
                 }
             }
             _ => (),
         }
     }
 
+    #[instrument(name = "Radio", level = "trace", skip(self, ctx, event, data, env))]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         self.child_label.lifecycle(ctx, event, data, env);
         if let LifeCycle::HotChanged(_) = event {
@@ -87,6 +92,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
         }
     }
 
+    #[instrument(name = "Radio", level = "trace", skip(self, ctx, old_data, data, env))]
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
         self.child_label.update(ctx, old_data, data, env);
         if !old_data.same(data) {
@@ -94,6 +100,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
         }
     }
 
+    #[instrument(name = "Radio", level = "trace", skip(self, ctx, bc, data, env))]
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         bc.debug_check("Radio");
 
@@ -105,9 +112,12 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
             label_size.width + radio_diam + x_padding,
             radio_diam.max(label_size.height),
         );
-        bc.constrain(desired_size)
+        let size = bc.constrain(desired_size);
+        trace!("Computed size: {}", size);
+        size
     }
 
+    #[instrument(name = "Radio", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         let size = env.get(theme::BASIC_WIDGET_HEIGHT);
         let x_padding = env.get(theme::WIDGET_CONTROL_COMPONENT_PADDING);

--- a/druid/src/widget/scope.rs
+++ b/druid/src/widget/scope.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use crate::widget::prelude::*;
 use crate::widget::WidgetWrapper;
 use crate::{Data, Lens, Point, WidgetPod};
+use tracing::instrument;
 
 /// A policy that controls how a [`Scope`] will interact with its surrounding
 /// application data. Specifically, how to create an initial State from the
@@ -270,20 +271,24 @@ impl<In: Data, State: Data, F: Fn(In) -> State, L: Lens<State, In>, W: Widget<St
 }
 
 impl<SP: ScopePolicy, W: Widget<SP::State>> Widget<SP::In> for Scope<SP, W> {
+    #[instrument(name = "Scope", level = "trace", skip(self, ctx, event, data, env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut SP::In, env: &Env) {
         self.with_state(data, |state, inner| inner.event(ctx, event, state, env));
         self.write_back_input(data);
         ctx.request_update()
     }
 
+    #[instrument(name = "Scope", level = "trace", skip(self, ctx, event, data, env))]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &SP::In, env: &Env) {
         self.with_state(data, |state, inner| inner.lifecycle(ctx, event, state, env));
     }
 
+    #[instrument(name = "Scope", level = "trace", skip(self, ctx, _old_data, data, env))]
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &SP::In, data: &SP::In, env: &Env) {
         self.with_state(data, |state, inner| inner.update(ctx, state, env));
     }
 
+    #[instrument(name = "Scope", level = "trace", skip(self, ctx, bc, data, env))]
     fn layout(
         &mut self,
         ctx: &mut LayoutCtx,
@@ -298,6 +303,7 @@ impl<SP: ScopePolicy, W: Widget<SP::State>> Widget<SP::In> for Scope<SP, W> {
         })
     }
 
+    #[instrument(name = "Scope", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &SP::In, env: &Env) {
         self.with_state(data, |state, inner| inner.paint_raw(ctx, state, env));
     }

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -17,6 +17,7 @@
 use crate::widget::prelude::*;
 use crate::widget::{Axis, ClipBox};
 use crate::{scroll_component::*, Data, Rect, Vec2};
+use tracing::{instrument, trace};
 
 /// A container that scrolls its contents.
 ///
@@ -166,6 +167,7 @@ impl<T, W> Scroll<T, W> {
 }
 
 impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
+    #[instrument(name = "Scroll", level = "trace", skip(self, ctx, event, data, env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         let scroll_component = &mut self.scroll_component;
         self.clip.with_port(|port| {
@@ -180,15 +182,18 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
         });
     }
 
+    #[instrument(name = "Scroll", level = "trace", skip(self, ctx, event, data, env))]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         self.scroll_component.lifecycle(ctx, event, env);
         self.clip.lifecycle(ctx, event, data, env);
     }
 
+    #[instrument(name = "Scroll", level = "trace", skip(self, ctx, old_data, data, env))]
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
         self.clip.update(ctx, old_data, data, env);
     }
 
+    #[instrument(name = "Scroll", level = "trace", skip(self, ctx, bc, data, env))]
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         bc.debug_check("Scroll");
 
@@ -205,9 +210,11 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                 .reset_scrollbar_fade(|d| ctx.request_timer(d), env);
         }
 
+        trace!("Computed size: {}", self_size);
         self_size
     }
 
+    #[instrument(name = "Scroll", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         self.clip.paint(ctx, data, env);
         self.scroll_component

--- a/druid/src/widget/sized_box.rs
+++ b/druid/src/widget/sized_box.rs
@@ -15,6 +15,7 @@
 //! A widget with predefined size.
 
 use std::f64::INFINITY;
+use tracing::{instrument, trace, warn};
 
 use crate::widget::prelude::*;
 use crate::Data;
@@ -132,24 +133,32 @@ impl<T> SizedBox<T> {
 }
 
 impl<T: Data> Widget<T> for SizedBox<T> {
+    #[instrument(name = "SizedBox", level = "trace", skip(self, ctx, event, data, env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if let Some(ref mut inner) = self.inner {
             inner.event(ctx, event, data, env);
         }
     }
 
+    #[instrument(name = "SizedBox", level = "trace", skip(self, ctx, event, data, env))]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         if let Some(ref mut inner) = self.inner {
             inner.lifecycle(ctx, event, data, env)
         }
     }
 
+    #[instrument(
+        name = "SizedBox",
+        level = "trace",
+        skip(self, ctx, old_data, data, env)
+    )]
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
         if let Some(ref mut inner) = self.inner {
             inner.update(ctx, old_data, data, env);
         }
     }
 
+    #[instrument(name = "SizedBox", level = "trace", skip(self, ctx, bc, data, env))]
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         bc.debug_check("SizedBox");
 
@@ -159,17 +168,19 @@ impl<T: Data> Widget<T> for SizedBox<T> {
             None => bc.constrain((self.width.unwrap_or(0.0), self.height.unwrap_or(0.0))),
         };
 
+        trace!("Computed size: {}", size);
         if size.width.is_infinite() {
-            tracing::warn!("SizedBox is returning an infinite width.");
+            warn!("SizedBox is returning an infinite width.");
         }
 
         if size.height.is_infinite() {
-            tracing::warn!("SizedBox is returning an infinite height.");
+            warn!("SizedBox is returning an infinite height.");
         }
 
         size
     }
 
+    #[instrument(name = "SizedBox", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         if let Some(ref mut inner) = self.inner {
             inner.paint(ctx, data, env);

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -17,6 +17,7 @@
 use crate::kurbo::{Circle, Shape};
 use crate::widget::prelude::*;
 use crate::{theme, LinearGradient, Point, Rect, UnitPoint};
+use tracing::{instrument, trace};
 
 const TRACK_THICKNESS: f64 = 4.0;
 const BORDER_WIDTH: f64 = 2.0;
@@ -76,6 +77,7 @@ impl Slider {
 }
 
 impl Widget<f64> for Slider {
+    #[instrument(name = "Slider", level = "trace", skip(self, ctx, event, data, env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut f64, env: &Env) {
         let knob_size = env.get(theme::BASIC_WIDGET_HEIGHT);
         let slider_width = ctx.size().width;
@@ -115,21 +117,39 @@ impl Widget<f64> for Slider {
         }
     }
 
+    #[instrument(
+        name = "Slider",
+        level = "trace",
+        skip(self, _ctx, _event, _data, _env)
+    )]
     fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &f64, _env: &Env) {}
 
+    #[instrument(
+        name = "Slider",
+        level = "trace",
+        skip(self, ctx, _old_data, _data, _env)
+    )]
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &f64, _data: &f64, _env: &Env) {
         ctx.request_paint();
     }
 
+    #[instrument(name = "Slider", level = "trace", skip(self, ctx, bc, _data, env))]
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, _data: &f64, env: &Env) -> Size {
         bc.debug_check("Slider");
         let height = env.get(theme::BASIC_WIDGET_HEIGHT);
         let width = env.get(theme::WIDE_WIDGET_WIDTH);
         let baseline_offset = (height / 2.0) - TRACK_THICKNESS;
         ctx.set_baseline_offset(baseline_offset);
-        bc.constrain((width, height))
+        let size = bc.constrain((width, height));
+        trace!(
+            "Computed layout: size={}, baseline_offset={:?}",
+            size,
+            baseline_offset
+        );
+        size
     }
 
+    #[instrument(name = "Slider", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &f64, env: &Env) {
         let clamped = self.normalize(*data);
         let rect = ctx.size().to_rect();

--- a/druid/src/widget/spinner.rs
+++ b/druid/src/widget/spinner.rs
@@ -15,6 +15,7 @@
 //! An animated spinner widget.
 
 use std::f64::consts::PI;
+use tracing::{instrument, trace};
 
 use druid::kurbo::Line;
 use druid::widget::prelude::*;
@@ -67,6 +68,7 @@ impl Default for Spinner {
 }
 
 impl<T: Data> Widget<T> for Spinner {
+    #[instrument(name = "Spinner", level = "trace", skip(self, ctx, event, _data, _env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, _data: &mut T, _env: &Env) {
         if let Event::AnimFrame(interval) = event {
             self.t += (*interval as f64) * 1e-9;
@@ -78,6 +80,7 @@ impl<T: Data> Widget<T> for Spinner {
         }
     }
 
+    #[instrument(name = "Spinner", level = "trace", skip(self, ctx, event, _data, _env))]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &T, _env: &Env) {
         if let LifeCycle::WidgetAdded = event {
             ctx.request_anim_frame();
@@ -85,8 +88,18 @@ impl<T: Data> Widget<T> for Spinner {
         }
     }
 
+    #[instrument(
+        name = "Spinner",
+        level = "trace",
+        skip(self, _ctx, _old_data, _data, _env)
+    )]
     fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: &T, _data: &T, _env: &Env) {}
 
+    #[instrument(
+        name = "Spinner",
+        level = "trace",
+        skip(self, _layout_ctx, bc, _data, env)
+    )]
     fn layout(
         &mut self,
         _layout_ctx: &mut LayoutCtx,
@@ -96,16 +109,20 @@ impl<T: Data> Widget<T> for Spinner {
     ) -> Size {
         bc.debug_check("Spinner");
 
-        if bc.is_width_bounded() && bc.is_height_bounded() {
+        let size = if bc.is_width_bounded() && bc.is_height_bounded() {
             bc.max()
         } else {
             bc.constrain(Size::new(
                 env.get(theme::BASIC_WIDGET_HEIGHT),
                 env.get(theme::BASIC_WIDGET_HEIGHT),
             ))
-        }
+        };
+
+        trace!("Computed size: {}", size);
+        size
     }
 
+    #[instrument(name = "Spinner", level = "trace", skip(self, ctx, _data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, _data: &T, env: &Env) {
         let t = self.t;
         let (width, height) = (ctx.size().width, ctx.size().height);

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -18,6 +18,7 @@ use crate::kurbo::Line;
 use crate::widget::flex::Axis;
 use crate::widget::prelude::*;
 use crate::{theme, Color, Cursor, Data, Point, Rect, WidgetPod};
+use tracing::{instrument, trace, warn};
 
 /// A container containing two other widgets, splitting the area either horizontally or vertically.
 pub struct Split<T> {
@@ -265,6 +266,7 @@ impl<T> Split<T> {
 }
 
 impl<T: Data> Widget<T> for Split<T> {
+    #[instrument(name = "Split", level = "trace", skip(self, ctx, event, data, env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if self.child1.is_active() {
             self.child1.event(ctx, event, data, env);
@@ -321,28 +323,31 @@ impl<T: Data> Widget<T> for Split<T> {
         }
     }
 
+    #[instrument(name = "Split", level = "trace", skip(self, ctx, event, data, env))]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         self.child1.lifecycle(ctx, event, data, env);
         self.child2.lifecycle(ctx, event, data, env);
     }
 
+    #[instrument(name = "Split", level = "trace", skip(self, ctx, _old_data, data, env))]
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
         self.child1.update(ctx, &data, env);
         self.child2.update(ctx, &data, env);
     }
 
+    #[instrument(name = "Split", level = "trace", skip(self, ctx, bc, data, env))]
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         bc.debug_check("Split");
 
         match self.split_axis {
             Axis::Horizontal => {
                 if !bc.is_width_bounded() {
-                    tracing::warn!("A Split widget was given an unbounded width to split.")
+                    warn!("A Split widget was given an unbounded width to split.")
                 }
             }
             Axis::Vertical => {
                 if !bc.is_height_bounded() {
-                    tracing::warn!("A Split widget was given an unbounded height to split.")
+                    warn!("A Split widget was given an unbounded height to split.")
                 }
             }
         }
@@ -423,9 +428,11 @@ impl<T: Data> Widget<T> for Split<T> {
         let insets = paint_rect - my_size.to_rect();
         ctx.set_paint_insets(insets);
 
+        trace!("Computed layout: size={}, insets={:?}", my_size, insets);
         my_size
     }
 
+    #[instrument(name = "Split", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         if self.solid {
             self.paint_solid_bar(ctx, env);

--- a/druid/src/widget/stepper.rs
+++ b/druid/src/widget/stepper.rs
@@ -16,6 +16,7 @@
 
 use std::f64::EPSILON;
 use std::time::Duration;
+use tracing::{instrument, trace};
 
 use crate::kurbo::BezPath;
 use crate::piet::{LinearGradient, RenderContext, UnitPoint};
@@ -115,6 +116,7 @@ impl Default for Stepper {
 }
 
 impl Widget<f64> for Stepper {
+    #[instrument(name = "Stepper", level = "trace", skip(self, ctx, _data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, _data: &f64, env: &Env) {
         let stroke_width = 2.0;
         let rounded_rect = ctx
@@ -177,6 +179,11 @@ impl Widget<f64> for Stepper {
         ctx.fill(arrows, &env.get(theme::LABEL_COLOR));
     }
 
+    #[instrument(
+        name = "Stepper",
+        level = "trace",
+        skip(self, _layout_ctx, bc, _data, env)
+    )]
     fn layout(
         &mut self,
         _layout_ctx: &mut LayoutCtx,
@@ -184,12 +191,15 @@ impl Widget<f64> for Stepper {
         _data: &f64,
         env: &Env,
     ) -> Size {
-        bc.constrain(Size::new(
+        let size = bc.constrain(Size::new(
             env.get(theme::BASIC_WIDGET_HEIGHT),
             env.get(theme::BORDERED_WIDGET_HEIGHT),
-        ))
+        ));
+        trace!("Computed size: {}", size);
+        size
     }
 
+    #[instrument(name = "Stepper", level = "trace", skip(self, ctx, event, data, env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut f64, env: &Env) {
         let height = env.get(theme::BORDERED_WIDGET_HEIGHT);
 
@@ -233,6 +243,11 @@ impl Widget<f64> for Stepper {
 
     fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &f64, _env: &Env) {}
 
+    #[instrument(
+        name = "Stepper",
+        level = "trace",
+        skip(self, ctx, old_data, data, _env)
+    )]
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &f64, data: &f64, _env: &Env) {
         if (*data - old_data).abs() > EPSILON {
             ctx.request_paint();

--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -15,6 +15,7 @@
 //! An SVG widget.
 
 use std::{collections::HashMap, error::Error, rc::Rc, str::FromStr, sync::Arc};
+use tracing::{instrument, trace};
 
 use crate::{
     kurbo::BezPath,
@@ -54,12 +55,24 @@ impl Svg {
 }
 
 impl<T: Data> Widget<T> for Svg {
+    #[instrument(name = "Svg", level = "trace", skip(self, _ctx, _event, _data, _env))]
     fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut T, _env: &Env) {}
 
+    #[instrument(name = "Svg", level = "trace", skip(self, _ctx, _event, _data, _env))]
     fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &T, _env: &Env) {}
 
+    #[instrument(
+        name = "Svg",
+        level = "trace",
+        skip(self, _ctx, _old_data, _data, _env)
+    )]
     fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: &T, _data: &T, _env: &Env) {}
 
+    #[instrument(
+        name = "Svg",
+        level = "trace",
+        skip(self, _layout_ctx, bc, _data, _env)
+    )]
     fn layout(
         &mut self,
         _layout_ctx: &mut LayoutCtx,
@@ -70,9 +83,12 @@ impl<T: Data> Widget<T> for Svg {
         bc.debug_check("SVG");
         // preferred size comes from the svg
         let size = self.svg_data.size();
-        bc.constrain_aspect_ratio(size.height / size.width, size.width)
+        let constrained_size = bc.constrain_aspect_ratio(size.height / size.width, size.width);
+        trace!("Computed size: {}", constrained_size);
+        constrained_size
     }
 
+    #[instrument(name = "Svg", level = "trace", skip(self, ctx, _data, _env))]
     fn paint(&mut self, ctx: &mut PaintCtx, _data: &T, _env: &Env) {
         let offset_matrix = self.fill.affine_to_fill(ctx.size(), self.svg_data.size());
 
@@ -316,7 +332,7 @@ impl SvgRenderer {
 
         // TODO error handling
         let gradient = FixedLinearGradient { start, end, stops };
-        println!("{} => {:?}", lg.id, gradient);
+        trace!("gradient: {} => {:?}", lg.id, gradient);
         let gradient = ctx.gradient(gradient).unwrap();
         self.defs.add_def(lg.id.clone(), gradient);
     }

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -15,6 +15,7 @@
 //! A toggle switch widget.
 
 use std::time::Duration;
+use tracing::{instrument, trace};
 
 use crate::kurbo::{Circle, Shape};
 use crate::piet::{LinearGradient, RenderContext, UnitPoint};
@@ -87,6 +88,7 @@ impl Switch {
 }
 
 impl Widget<bool> for Switch {
+    #[instrument(name = "Switch", level = "trace", skip(self, ctx, event, data, env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut bool, env: &Env) {
         let switch_height = env.get(theme::BORDERED_WIDGET_HEIGHT);
         let switch_width = switch_height * SWITCH_WIDTH_RATIO;
@@ -155,6 +157,7 @@ impl Widget<bool> for Switch {
         }
     }
 
+    #[instrument(name = "Switch", level = "trace", skip(self, ctx, event, _data, env))]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &bool, env: &Env) {
         if matches!(event, LifeCycle::WidgetAdded) {
             self.on_text.rebuild_if_needed(ctx.text(), env);
@@ -162,6 +165,11 @@ impl Widget<bool> for Switch {
         }
     }
 
+    #[instrument(
+        name = "Switch",
+        level = "trace",
+        skip(self, ctx, old_data, data, _env)
+    )]
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &bool, data: &bool, _env: &Env) {
         if old_data != data {
             self.animation_in_progress = true;
@@ -169,7 +177,14 @@ impl Widget<bool> for Switch {
         }
     }
 
-    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, _: &bool, env: &Env) -> Size {
+    #[instrument(name = "Switch", level = "trace", skip(self, ctx, bc, _data, env))]
+    fn layout(
+        &mut self,
+        ctx: &mut LayoutCtx,
+        bc: &BoxConstraints,
+        _data: &bool,
+        env: &Env,
+    ) -> Size {
         let text_metrics = self.on_text.layout_metrics();
         let height = env.get(theme::BORDERED_WIDGET_HEIGHT);
         let width = height * SWITCH_WIDTH_RATIO;
@@ -178,9 +193,13 @@ impl Widget<bool> for Switch {
         let text_bottom_padding = height - (text_metrics.size.height + label_y);
         let text_baseline_offset = text_metrics.size.height - text_metrics.first_baseline;
         ctx.set_baseline_offset(text_bottom_padding + text_baseline_offset);
-        bc.constrain(Size::new(width, height))
+
+        let size = bc.constrain(Size::new(width, height));
+        trace!("Computed size: {}", size);
+        size
     }
 
+    #[instrument(name = "Switch", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &bool, env: &Env) {
         let switch_height = env.get(theme::BORDERED_WIDGET_HEIGHT);
         let switch_width = switch_height * SWITCH_WIDTH_RATIO;

--- a/druid/src/widget/tabs.rs
+++ b/druid/src/widget/tabs.rs
@@ -20,6 +20,7 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::marker::PhantomData;
 use std::rc::Rc;
+use tracing::{instrument, trace};
 
 use crate::kurbo::{Circle, Line};
 use crate::widget::prelude::*;
@@ -335,6 +336,7 @@ impl<TP: TabsPolicy> TabBar<TP> {
 }
 
 impl<TP: TabsPolicy> Widget<TabsState<TP>> for TabBar<TP> {
+    #[instrument(name = "TabBar", level = "trace", skip(self, ctx, event, data, env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut TabsState<TP>, env: &Env) {
         match event {
             Event::MouseDown(e) => {
@@ -361,6 +363,7 @@ impl<TP: TabsPolicy> Widget<TabsState<TP>> for TabBar<TP> {
         }
     }
 
+    #[instrument(name = "TabBar", level = "trace", skip(self, ctx, event, data, env))]
     fn lifecycle(
         &mut self,
         ctx: &mut LifeCycleCtx,
@@ -379,6 +382,7 @@ impl<TP: TabsPolicy> Widget<TabsState<TP>> for TabBar<TP> {
         }
     }
 
+    #[instrument(name = "TabBar", level = "trace", skip(self, ctx, old_data, data, env))]
     fn update(
         &mut self,
         ctx: &mut UpdateCtx,
@@ -399,6 +403,7 @@ impl<TP: TabsPolicy> Widget<TabsState<TP>> for TabBar<TP> {
         }
     }
 
+    #[instrument(name = "TabBar", level = "trace", skip(self, ctx, bc, data, env))]
     fn layout(
         &mut self,
         ctx: &mut LayoutCtx,
@@ -415,9 +420,12 @@ impl<TP: TabsPolicy> Widget<TabsState<TP>> for TabBar<TP> {
             minor = minor.max(self.axis.minor(size));
         }
         let wanted = self.axis.pack(major.max(self.axis.major(bc.max())), minor);
-        bc.constrain(wanted)
+        let size = bc.constrain(wanted);
+        trace!("Computed size: {}", size);
+        size
     }
 
+    #[instrument(name = "TabBar", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &TabsState<TP>, env: &Env) {
         let hl_thickness = 2.;
         let highlight = env.get(theme::PRIMARY_LIGHT);
@@ -571,6 +579,7 @@ impl<TP: TabsPolicy> TabsBody<TP> {
 }
 
 impl<TP: TabsPolicy> Widget<TabsState<TP>> for TabsBody<TP> {
+    #[instrument(name = "TabsBody", level = "trace", skip(self, ctx, event, data, env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut TabsState<TP>, env: &Env) {
         if event.should_propagate_to_hidden() {
             for child in self.child_pods() {
@@ -591,6 +600,7 @@ impl<TP: TabsPolicy> Widget<TabsState<TP>> for TabsBody<TP> {
         }
     }
 
+    #[instrument(name = "TabsBody", level = "trace", skip(self, ctx, event, data, env))]
     fn lifecycle(
         &mut self,
         ctx: &mut LifeCycleCtx,
@@ -614,6 +624,11 @@ impl<TP: TabsPolicy> Widget<TabsState<TP>> for TabsBody<TP> {
         }
     }
 
+    #[instrument(
+        name = "TabsBody",
+        level = "trace",
+        skip(self, ctx, old_data, data, env)
+    )]
     fn update(
         &mut self,
         ctx: &mut UpdateCtx,
@@ -654,6 +669,7 @@ impl<TP: TabsPolicy> Widget<TabsState<TP>> for TabsBody<TP> {
         }
     }
 
+    #[instrument(name = "TabsBody", level = "trace", skip(self, ctx, bc, data, env))]
     fn layout(
         &mut self,
         ctx: &mut LayoutCtx,
@@ -671,6 +687,7 @@ impl<TP: TabsPolicy> Widget<TabsState<TP>> for TabsBody<TP> {
         bc.max()
     }
 
+    #[instrument(name = "TabsBody", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &TabsState<TP>, env: &Env) {
         if let Some(trans) = &self.transition_state {
             let axis = self.axis;
@@ -940,12 +957,14 @@ impl<TP: TabsPolicy> Tabs<TP> {
 }
 
 impl<TP: TabsPolicy> Widget<TP::Input> for Tabs<TP> {
+    #[instrument(name = "Tabs", level = "trace", skip(self, ctx, event, data, env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut TP::Input, env: &Env) {
         if let TabsContent::Running { scope } = &mut self.content {
             scope.event(ctx, event, data, env);
         }
     }
 
+    #[instrument(name = "Tabs", level = "trace", skip(self, ctx, event, data, env))]
     fn lifecycle(
         &mut self,
         ctx: &mut LifeCycleCtx,
@@ -977,12 +996,14 @@ impl<TP: TabsPolicy> Widget<TP::Input> for Tabs<TP> {
         }
     }
 
+    #[instrument(name = "Tabs", level = "trace", skip(self, ctx, _old_data, data, env))]
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &TP::Input, data: &TP::Input, env: &Env) {
         if let TabsContent::Running { scope } = &mut self.content {
             scope.update(ctx, data, env);
         }
     }
 
+    #[instrument(name = "Tabs", level = "trace", skip(self, ctx, bc, data, env))]
     fn layout(
         &mut self,
         ctx: &mut LayoutCtx,
@@ -999,6 +1020,7 @@ impl<TP: TabsPolicy> Widget<TP::Input> for Tabs<TP> {
         }
     }
 
+    #[instrument(name = "Tabs", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &TP::Input, env: &Env) {
         if let TabsContent::Running { scope } = &mut self.content {
             scope.paint(ctx, data, env)

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -15,6 +15,7 @@
 //! A textbox widget.
 
 use std::time::Duration;
+use tracing::{instrument, trace};
 
 use crate::piet::PietText;
 use crate::text::{
@@ -411,6 +412,7 @@ impl<T: TextStorage + EditableText> TextBox<T> {
 }
 
 impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
+    #[instrument(name = "TextBox", level = "trace", skip(self, ctx, event, data, _env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, _env: &Env) {
         self.suppress_adjust_hscroll = false;
         match event {
@@ -490,6 +492,7 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
         }
     }
 
+    #[instrument(name = "TextBox", level = "trace", skip(self, ctx, event, data, env))]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         match event {
             LifeCycle::WidgetAdded => {
@@ -509,7 +512,12 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
         }
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _: &T, data: &T, env: &Env) {
+    #[instrument(
+        name = "TextBox",
+        level = "trace",
+        skip(self, ctx, _old_data, data, env)
+    )]
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
         self.editor.update(ctx, data, env);
         if !self.suppress_adjust_hscroll && !self.multiline {
             self.update_hscroll(ctx.size().width, env);
@@ -519,6 +527,7 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
         }
     }
 
+    #[instrument(name = "TextBox", level = "trace", skip(self, ctx, bc, data, env))]
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         let width = env.get(theme::WIDE_WIDGET_WIDTH);
         let text_insets = env.get(theme::TEXTBOX_INSETS);
@@ -547,9 +556,15 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
             bottom_padding + (text_metrics.size.height - text_metrics.first_baseline);
         ctx.set_baseline_offset(baseline_off);
 
+        trace!(
+            "Computed layout: size={}, baseline_offset={:?}",
+            size,
+            baseline_off
+        );
         size
     }
 
+    #[instrument(name = "TextBox", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         let size = ctx.size();
         let background_color = env.get(theme::BACKGROUND_LIGHT);
@@ -728,6 +743,11 @@ impl<T: Data> ValueTextBox<T> {
 }
 
 impl<T: Data> Widget<T> for ValueTextBox<T> {
+    #[instrument(
+        name = "ValueTextBox",
+        level = "trace",
+        skip(self, ctx, event, data, env)
+    )]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if matches!(event, Event::Command(cmd) if cmd.is(BEGIN_EDITING)) {
             return self.begin(ctx, data);
@@ -818,6 +838,11 @@ impl<T: Data> Widget<T> for ValueTextBox<T> {
         }
     }
 
+    #[instrument(
+        name = "ValueTextBox",
+        level = "trace",
+        skip(self, ctx, event, data, env)
+    )]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         if let LifeCycle::WidgetAdded = event {
             self.buffer = self.formatter.format(data);
@@ -835,6 +860,11 @@ impl<T: Data> Widget<T> for ValueTextBox<T> {
         }
     }
 
+    #[instrument(
+        name = "ValueTextBox",
+        level = "trace",
+        skip(self, ctx, old_data, data, env)
+    )]
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
         let changed_by_us = self
             .last_known_data
@@ -876,10 +906,16 @@ impl<T: Data> Widget<T> for ValueTextBox<T> {
         }
     }
 
+    #[instrument(
+        name = "ValueTextBox",
+        level = "trace",
+        skip(self, ctx, bc, _data, env)
+    )]
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, _data: &T, env: &Env) -> Size {
         self.inner.layout(ctx, bc, &self.buffer, env)
     }
 
+    #[instrument(name = "ValueTextBox", level = "trace", skip(self, ctx, _data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, _data: &T, env: &Env) {
         self.inner.paint(ctx, &self.buffer, env);
     }

--- a/druid/src/widget/view_switcher.rs
+++ b/druid/src/widget/view_switcher.rs
@@ -16,6 +16,7 @@
 
 use crate::widget::prelude::*;
 use crate::{Data, Point, WidgetPod};
+use tracing::instrument;
 
 /// A widget that can switch dynamically between one of many views depending
 /// on application state.
@@ -55,12 +56,22 @@ impl<T: Data, U: Data> ViewSwitcher<T, U> {
 }
 
 impl<T: Data, U: Data> Widget<T> for ViewSwitcher<T, U> {
+    #[instrument(
+        name = "ViewSwitcher",
+        level = "trace",
+        skip(self, ctx, event, data, env)
+    )]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if let Some(child) = self.active_child.as_mut() {
             child.event(ctx, event, data, env);
         }
     }
 
+    #[instrument(
+        name = "ViewSwitcher",
+        level = "trace",
+        skip(self, ctx, event, data, env)
+    )]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         if let LifeCycle::WidgetAdded = event {
             let child_id = (self.child_picker)(data, env);
@@ -72,6 +83,11 @@ impl<T: Data, U: Data> Widget<T> for ViewSwitcher<T, U> {
         }
     }
 
+    #[instrument(
+        name = "ViewSwitcher",
+        level = "trace",
+        skip(self, ctx, _old_data, data, env)
+    )]
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
         let child_id = (self.child_picker)(data, env);
         // Safe to unwrap because self.active_child_id should not be empty
@@ -85,6 +101,7 @@ impl<T: Data, U: Data> Widget<T> for ViewSwitcher<T, U> {
         }
     }
 
+    #[instrument(name = "ViewSwitcher", level = "trace", skip(self, ctx, bc, data, env))]
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         match self.active_child {
             Some(ref mut child) => {
@@ -96,6 +113,7 @@ impl<T: Data, U: Data> Widget<T> for ViewSwitcher<T, U> {
         }
     }
 
+    #[instrument(name = "ViewSwitcher", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         if let Some(ref mut child) = self.active_child {
             child.paint_raw(ctx, data, env);


### PR DESCRIPTION
Copy-pasting from Zulip:

I'm still using `#[instrument]` because, as I've said earlier, this is far from the biggest compile bottleneck right now; (I'm going to do some tests again to measure the impact it has). Also, while I don't like the syntax instrument has right now (having to add skip(...) everywhere), apparently it's due to be changed in the next version of tracing.

Right now I'm trying to address the use-case that made me want to add more logging: being able to tell when an internal event (warning, something being redrawn, etc) happens and why.

Part of that is adding spans everywhere; since druid, like basically every GUI, uses a variation on the visitor pattern, that means most spans are going be named after the Self type of the function they instrument; except for the root span. For instance, if you have Window::event calling Flex::event calling Button::event, the context chain is going to look like event:Flex:Button.

I feel like I should document that last part somewhere.