### PR TITLE
Touch support WIP

### DIFF
--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -69,7 +69,7 @@ pub use error::Error;
 pub use hotkey::{HotKey, RawMods, SysMods};
 pub use keyboard::{Code, IntoKey, KbKey, KeyEvent, KeyState, Location, Modifiers};
 pub use menu::Menu;
-pub use mouse::{Cursor, CursorDesc, MouseButton, MouseButtons, MouseEvent};
+pub use mouse::{Cursor, CursorDesc, MouseButton, MouseButtons, MouseEvent, PointerType};
 pub use region::Region;
 pub use scale::{Scalable, Scale, ScaledArea};
 pub use screen::{Monitor, Screen};

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -59,6 +59,7 @@ mod platform;
 mod region;
 mod scale;
 mod screen;
+mod touch;
 mod window;
 
 pub use application::{AppHandler, Application};
@@ -73,6 +74,7 @@ pub use mouse::{Cursor, CursorDesc, MouseButton, MouseButtons, MouseEvent, Point
 pub use region::Region;
 pub use scale::{Scalable, Scale, ScaledArea};
 pub use screen::{Monitor, Screen};
+pub use touch::{TouchEvent, TouchSequenceId};
 pub use window::{
     FileDialogToken, IdleHandle, IdleToken, TimerToken, WinHandler, WindowBuilder, WindowHandle,
     WindowLevel, WindowState,

--- a/druid-shell/src/mouse.rs
+++ b/druid-shell/src/mouse.rs
@@ -24,6 +24,7 @@ use crate::Modifiers;
 pub enum PointerType {
     None,
     Mouse,
+    Touch,
     Stylus,
     Unknown,
 }

--- a/druid-shell/src/mouse.rs
+++ b/druid-shell/src/mouse.rs
@@ -19,6 +19,15 @@ use crate::piet::ImageBuf;
 use crate::platform;
 use crate::Modifiers;
 
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PointerType {
+    None,
+    Mouse,
+    Stylus,
+    Unknown,
+}
+
 /// Information about the mouse event.
 ///
 /// Every mouse event can have a new position. There is no guarantee of
@@ -54,6 +63,8 @@ pub struct MouseEvent {
     ///
     /// [WheelEvent]: https://w3c.github.io/uievents/#event-type-wheel
     pub wheel_delta: Vec2,
+
+    pub pointer_type: PointerType,
 }
 
 /// An indicator of which mouse button was pressed.

--- a/druid-shell/src/touch.rs
+++ b/druid-shell/src/touch.rs
@@ -1,0 +1,32 @@
+// Copyright 2019 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Common types for representing touch events
+
+use crate::kurbo::Point;
+use crate::Modifiers;
+use crate::platform;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TouchEvent {
+    pub pos: Point,
+    pub mods: Modifiers,
+    pub focus: bool,
+    pub sequence_id: Option<TouchSequenceId>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TouchSequenceId {
+    Value(platform::window::TouchSequenceId)
+}

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -25,6 +25,7 @@ use crate::keyboard::KeyEvent;
 use crate::kurbo::{Point, Rect, Size};
 use crate::menu::Menu;
 use crate::mouse::{Cursor, CursorDesc, MouseEvent};
+use crate::touch::TouchEvent;
 use crate::platform::window as platform;
 use crate::region::Region;
 use crate::scale::Scale;
@@ -558,6 +559,11 @@ pub trait WinHandler {
 
     /// Get a reference to the handler state. Used mostly by idle handlers.
     fn as_any(&mut self) -> &mut dyn Any;
+
+    #[allow(unused_variables)]
+    fn touch_begin(&mut self, event: &TouchEvent) {}
+    fn touch_end(&mut self, event: &TouchEvent) {}
+    fn touch_update(&mut self, event: &TouchEvent) {}
 }
 
 impl From<platform::WindowHandle> for WindowHandle {

--- a/druid/examples/scroll.rs
+++ b/druid/examples/scroll.rs
@@ -35,7 +35,7 @@ fn build_widget() -> impl Widget<u32> {
     for i in 0..30 {
         col.add_child(Padding::new(3.0, OverPainter(i)));
     }
-    Scroll::new(col)
+    Padding::new(2.0, Scroll::new(col))
 }
 
 /// A widget that paints outside of its bounds.

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -30,6 +30,7 @@ use crate::{
     Notification, Point, Rect, SingleUse, Size, Target, TimerToken, WidgetId, WindowDesc,
     WindowHandle, WindowId,
 };
+use crate::touch::TouchEvent;
 
 /// A macro for implementing methods on multiple contexts.
 ///
@@ -560,6 +561,9 @@ impl EventCtx<'_, '_> {
     /// particular to make that data available in the app state.
     pub fn request_update(&mut self) {
         self.widget_state.request_update = true;
+    }
+
+    pub fn track_touch_events(&mut self, event: &TouchEvent) {
     }
 }
 

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -19,6 +19,7 @@ use crate::kurbo::{Rect, Shape, Size, Vec2};
 use druid_shell::{Clipboard, KeyEvent, TimerToken};
 
 use crate::mouse::MouseEvent;
+use crate::touch::TouchEvent;
 use crate::{Command, Notification, WidgetId};
 
 /// An event, propagated downwards during event flow.
@@ -168,6 +169,10 @@ pub enum Event {
     ///
     /// [`WidgetPod`]: struct.WidgetPod.html
     Internal(InternalEvent),
+
+    TouchBegin(TouchEvent),
+    TouchUpdate(TouchEvent),
+    TouchEnd(TouchEvent),
 }
 
 /// Internal events used by druid inside [`WidgetPod`].
@@ -366,7 +371,10 @@ impl Event {
             | Event::KeyDown(_)
             | Event::KeyUp(_)
             | Event::Paste(_)
-            | Event::Zoom(_) => false,
+            | Event::Zoom(_)
+            | Event::TouchBegin(_)
+            | Event::TouchEnd(_)
+            | Event::TouchUpdate(_) => false,
         }
     }
 }

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -169,6 +169,7 @@ pub mod scroll_component;
 mod tests;
 pub mod text;
 pub mod theme;
+pub mod touch;
 pub mod widget;
 mod win_handler;
 mod window;

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -186,7 +186,7 @@ pub use shell::keyboard_types;
 pub use shell::{
     Application, Clipboard, ClipboardFormat, Code, Cursor, CursorDesc, Error as PlatformError,
     FileInfo, FileSpec, FormatId, HotKey, KbKey, KeyEvent, Location, Modifiers, Monitor,
-    MouseButton, MouseButtons, RawMods, Region, Scalable, Scale, Screen, SysMods, TimerToken,
+    MouseButton, MouseButtons, PointerType, RawMods, Region, Scalable, Scale, Screen, SysMods, TimerToken,
     WindowHandle, WindowState,
 };
 

--- a/druid/src/mouse.rs
+++ b/druid/src/mouse.rs
@@ -15,7 +15,7 @@
 //! The mousey bits
 
 use crate::kurbo::{Point, Vec2};
-use crate::{Cursor, Data, Modifiers, MouseButton, MouseButtons};
+use crate::{Cursor, Data, Modifiers, MouseButton, MouseButtons, PointerType};
 
 /// The state of the mouse for a click, mouse-up, move, or wheel event.
 ///
@@ -69,6 +69,8 @@ pub struct MouseEvent {
     ///
     /// [WheelEvent]: https://w3c.github.io/uievents/#event-type-wheel
     pub wheel_delta: Vec2,
+
+    pub pointer_type: PointerType,
 }
 
 impl From<druid_shell::MouseEvent> for MouseEvent {
@@ -81,6 +83,7 @@ impl From<druid_shell::MouseEvent> for MouseEvent {
             focus,
             button,
             wheel_delta,
+            pointer_type,
         } = src;
         MouseEvent {
             pos,
@@ -91,6 +94,7 @@ impl From<druid_shell::MouseEvent> for MouseEvent {
             focus,
             button,
             wheel_delta,
+            pointer_type,
         }
     }
 }

--- a/druid/src/touch.rs
+++ b/druid/src/touch.rs
@@ -1,0 +1,146 @@
+// Copyright 2019 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Structs for touch events
+
+use std::time::Duration;
+use std::collections::VecDeque;
+use crate::kurbo::Point;
+
+use crate::Modifiers;
+pub use crate::shell::TouchSequenceId;
+
+use crate::{Env, Event, EventCtx, TimerToken, MouseButton, MouseButtons, MouseEvent, PointerType, Vec2};
+
+#[derive(Debug, Clone)]
+pub struct TouchEvent {
+    pub pos: Point,
+    pub window_pos: Point,
+    pub mods: Modifiers,
+    pub focus: bool,
+    pub sequence_id: Option<TouchSequenceId>,
+}
+
+impl From<druid_shell::TouchEvent> for TouchEvent {
+    fn from(src: druid_shell::TouchEvent) -> TouchEvent {
+        let druid_shell::TouchEvent {
+            pos,
+            mods,
+            focus,
+            sequence_id,
+        } = src;
+        TouchEvent {
+            pos,
+            window_pos: pos,
+            mods,
+            focus,
+            sequence_id,
+        }
+    }
+}
+
+const TOUCH_IS_CLICK: Duration = Duration::from_millis(100);
+
+#[derive(Debug, Clone)]
+pub struct TouchProcessor {
+    timer_token: TimerToken,
+    event_count: u32,
+    touch_ended: bool,
+    touch_begin: Option<TouchEvent>,
+    processed_events: VecDeque<Event>,
+    is_dragging: bool,
+}
+
+impl TouchProcessor {
+    pub fn new() -> TouchProcessor {
+        TouchProcessor {
+            timer_token: TimerToken::INVALID,
+            event_count: 0,
+            touch_ended: false,
+            touch_begin: None,
+            processed_events: VecDeque::new(),
+            is_dragging: false,
+        }
+    }
+
+    pub fn handle(&mut self, ctx: &mut EventCtx, event: &Event, env: &Env) {
+        match event {
+            Event::TouchBegin(touch_event) => {
+                // TODO: track sequence
+                self.touch_ended = false;
+                self.event_count = 0;
+                self.touch_begin = Some(touch_event.clone());
+                self.timer_token = ctx.request_timer(TOUCH_IS_CLICK);
+                self.is_dragging = false;
+            },
+            Event::TouchUpdate(touch_event) => {
+                self.event_count += 1;
+
+                if self.is_dragging {
+                    self.processed_events.push_back(Event::Wheel(MouseEvent {
+                        pos: touch_event.pos,
+                        window_pos: touch_event.window_pos,
+                        button: MouseButton::None,
+                        buttons: MouseButtons::new(),
+                        mods: touch_event.mods,
+                        count: 0,
+                        focus: touch_event.focus,
+                        wheel_delta: self.touch_begin.as_ref().unwrap().pos - touch_event.pos,
+                        pointer_type: PointerType::Touch,
+                    }));
+
+                    self.touch_begin = Some(touch_event.clone());
+                }
+            },
+            Event::TouchEnd(_) => {
+                self.touch_ended = true;
+            },
+            Event::Timer(token) => {
+                if token == &self.timer_token {
+                    self.is_dragging = !self.touch_ended;
+                    if self.touch_ended {
+                        let touch_event = self.touch_begin.as_ref().unwrap();
+                        self.processed_events.push_back(Event::MouseDown(MouseEvent {
+                            pos: touch_event.pos,
+                            window_pos: touch_event.window_pos,
+                            button: MouseButton::Left,
+                            buttons: MouseButtons::new(),
+                            mods: touch_event.mods,
+                            count: 0,
+                            focus: touch_event.focus,
+                            wheel_delta: Vec2::ZERO,
+                            pointer_type: PointerType::Touch,
+                        }));
+                        self.processed_events.push_back(Event::MouseUp(MouseEvent {
+                            pos: touch_event.pos,
+                            window_pos: touch_event.window_pos,
+                            button: MouseButton::Left,
+                            buttons: MouseButtons::new(),
+                            mods: touch_event.mods,
+                            count: 0,
+                            focus: touch_event.focus,
+                            wheel_delta: Vec2::ZERO,
+                            pointer_type: PointerType::Touch,
+                        }));
+                    }
+                }
+            },
+            _ => {},
+        }
+    }
+
+    pub fn processed_events(&mut self) -> VecDeque<Event> {
+        std::mem::replace(&mut self.processed_events, VecDeque::new())
+    }
+}

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -22,7 +22,7 @@ use std::rc::Rc;
 use crate::kurbo::Size;
 use crate::piet::Piet;
 use crate::shell::{
-    Application, FileDialogToken, FileInfo, IdleToken, MouseEvent, Region, Scale, WinHandler,
+    Application, FileDialogToken, FileInfo, IdleToken, MouseEvent, TouchEvent, Region, Scale, WinHandler,
     WindowHandle,
 };
 
@@ -830,6 +830,21 @@ impl<T: Data> WinHandler for DruidHandler<T> {
     fn mouse_leave(&mut self) {
         self.app_state
             .do_window_event(Event::Internal(InternalEvent::MouseLeave), self.window_id);
+    }
+
+    fn touch_begin(&mut self, event: &TouchEvent) {
+        let event = Event::TouchBegin(event.clone().into());
+        self.app_state.do_window_event(event, self.window_id);
+    }
+
+    fn touch_end(&mut self, event: &TouchEvent) {
+        let event = Event::TouchEnd(event.clone().into());
+        self.app_state.do_window_event(event, self.window_id);
+    }
+
+    fn touch_update(&mut self, event: &TouchEvent) {
+        let event = Event::TouchUpdate(event.clone().into());
+        self.app_state.do_window_event(event, self.window_id);
     }
 
     fn key_down(&mut self, event: KeyEvent) -> bool {


### PR DESCRIPTION
Hello, as I need touch support in an application I'm developing with druid, I'm opening this draft with the changes I made to hack a very early  touch support.

The code is not ready for review or inclusion, but it can be a first base for discussion or experimentation. Please feel free to chime in if you are interested in this.

Current code limitations:
1) Only linux (gtk) support. I may try to write to windows backend in the future, but I don't own a mac.
2) Touch events (TouchBegin/TouchUpdate/TouchEnd) are propagated by WidgetPod's. Inside WidgetPod, an instance of `TouchProcessor` is created that tries to convert touch events to standard mouse events. A mechanism to permit widgets to by-pass the processor is needed, I'm trying to think of something.
3) Limitation: touch events conversion is only done inside WidgetPod's, so some lightweight widgets won't have it. This is way I slightly modified the scroll example.
4) Current logic for converting events is hacky to say the least. Mouse click and on finger scroll (pan) are supported.
5) I still don't know what the best way is to push synthesized events back into the event loop.

Every platform has gesture recognition utilities (e.g. gtk's GtkGesture), but I think having druid implement its own platform-independent logic would be a plus?