### PR TITLE
Add a few new methods to Scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - WindowSizePolicy: allow windows to be sized by their content ([#1532] by [@rjwittams])
 - Implemented `Data` for more datatypes from `std` ([#1534] by [@derekdreery])
 - Shell: windows implementation from content_insets ([#1592] by [@HoNile])
+- Scroll::content_must_fill and a few other new Scroll methods ([#1635] by [@cmyr])
 
 ### Changed
 
@@ -625,6 +626,7 @@ Last release without a changelog :(
 [#1596]: https://github.com/linebender/druid/pull/1596
 [#1600]: https://github.com/linebender/druid/pull/1600
 [#1606]: https://github.com/linebender/druid/pull/1606
+[#1635]: https://github.com/linebender/druid/pull/1635
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid/src/widget/clip_box.rs
+++ b/druid/src/widget/clip_box.rs
@@ -121,6 +121,7 @@ pub struct ClipBox<T, W> {
     port: Viewport,
     constrain_horizontal: bool,
     constrain_vertical: bool,
+    must_fill: bool,
 }
 
 impl<T, W> ClipBox<T, W> {
@@ -148,6 +149,16 @@ impl<T, W> ClipBox<T, W> {
     /// [`constrain_vertical`]: struct.ClipBox.html#constrain_vertical
     pub fn constrain_horizontal(mut self, constrain: bool) -> Self {
         self.constrain_horizontal = constrain;
+        self
+    }
+
+    /// Builder-style method to set whether the child must fill the view.
+    ///
+    /// If `false` (the default) there is no minimum constraint on the child's
+    /// size. If `true`, the child is passed the same minimum constraints as
+    /// the `ClipBox`.
+    pub fn content_must_fill(mut self, must_fill: bool) -> Self {
+        self.must_fill = must_fill;
         self
     }
 
@@ -201,6 +212,16 @@ impl<T, W> ClipBox<T, W> {
     pub fn set_constrain_vertical(&mut self, constrain: bool) {
         self.constrain_vertical = constrain;
     }
+
+    /// Set whether the child's size must be greater than or equal the size of
+    /// the `ClipBox`.
+    ///
+    /// See [`content_must_fill`] for more details.
+    ///
+    /// [`content_must_fill`]: ClipBox::content_must_fill
+    pub fn set_content_must_fill(&mut self, must_fill: bool) {
+        self.must_fill = must_fill;
+    }
 }
 
 impl<T, W: Widget<T>> ClipBox<T, W> {
@@ -211,6 +232,7 @@ impl<T, W: Widget<T>> ClipBox<T, W> {
             port: Default::default(),
             constrain_horizontal: false,
             constrain_vertical: false,
+            must_fill: false,
         }
     }
 
@@ -310,8 +332,9 @@ impl<T: Data, W: Widget<T>> Widget<T> for ClipBox<T, W> {
         } else {
             f64::INFINITY
         };
+        let min_child_size = if self.must_fill { bc.min() } else { Size::ZERO };
         let child_bc =
-            BoxConstraints::new(Size::ZERO, Size::new(max_child_width, max_child_height));
+            BoxConstraints::new(min_child_size, Size::new(max_child_width, max_child_height));
 
         let content_size = self.child.layout(ctx, &child_bc, data, env);
         self.port.content_size = content_size;


### PR DESCRIPTION
These make it possible to configure a few more aspects of the
scrollview's behaviour after it is created.

This will be used for upcoming changes to the textbox.


This also relaxes the type constraints required for some methods.

based off of #1630 