### PR TITLE
Notification fixups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - Shell: IME API and macOS IME implementation ([#1619] by [@lord])
 - Scroll::content_must_fill and a few other new Scroll methods ([#1635] by [@cmyr])
 - New `TextBox` widget with IME integration ([#1636] by [@cmyr])
+- `Notification`s can be submitted while handling other `Notification`s ([#1640] by [@cmyr])
 - Added ListIter implementations for OrdMap ([#1641] by [@Lejero])
 
 ### Changed
@@ -39,6 +40,8 @@ You can find its changes [documented below](#070---2021-01-01).
 ### Removed
 
 ### Fixed
+- `Notification`s will not be delivered to the widget that sends them ([#1640] by [@cmyr])
+
 
 - Fixed docs of derived Lens ([#1523] by [@Maan2003])
 - Use correct fill rule when rendering SVG paths ([#1606] by [@SecondFlight])
@@ -638,6 +641,7 @@ Last release without a changelog :(
 [#1634]: https://github.com/linebender/druid/pull/1634
 [#1635]: https://github.com/linebender/druid/pull/1635
 [#1636]: https://github.com/linebender/druid/pull/1636
+[#1640]: https://github.com/linebender/druid/pull/1640
 [#1641]: https://github.com/linebender/druid/pull/1641
 [#1647]: https://github.com/linebender/druid/pull/1647
 


### PR DESCRIPTION
Two small fixes:

- notifications submitted while handling a `Notification` are now allowed
- notifications are no longer sent to the widget that originated them

cc @Maan2003 does this fix that issue for you?