### PR TITLE
[win] Fix double-sending of KeyDown event

### DIFF
--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -987,14 +987,13 @@ impl WndProc for MyWndProc {
                                 && (event.key == KbKey::Alt || event.key == KbKey::F10);
                             match event.state {
                                 KeyState::Down => {
-                                    let keydown_handled = s.handler.key_down(event.clone())
-                                        || self.with_window_state(|window_state| {
-                                            simulate_input(
-                                                &mut *s.handler,
-                                                window_state.active_text_input.get(),
-                                                event,
-                                            )
-                                        });
+                                    let keydown_handled = self.with_window_state(|window_state| {
+                                        simulate_input(
+                                            &mut *s.handler,
+                                            window_state.active_text_input.get(),
+                                            event,
+                                        )
+                                    });
                                     if keydown_handled || handle_menu {
                                         return true;
                                     }


### PR DESCRIPTION
We send this as part of `simulate_input`, so we don't need to
also send it directly from the runloop.

- fixes #1642