### PR TITLE
Correctly capture and use stroke properties when rendering SVG paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ You can find its changes [documented below](#070---2021-01-01).
 
 - Fixed docs of derived Lens ([#1523] by [@Maan2003])
 - Use correct fill rule when rendering SVG paths ([#1606] by [@SecondFlight])
+- Correctly capture and use stroke properties when rendering SVG paths ([#1647] by [@SecondFlight])
 
 ### Visual
 
@@ -635,6 +636,7 @@ Last release without a changelog :(
 [#1634]: https://github.com/linebender/druid/pull/1634
 [#1635]: https://github.com/linebender/druid/pull/1635
 [#1641]: https://github.com/linebender/druid/pull/1641
+[#1647]: https://github.com/linebender/druid/pull/1647
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -309,22 +309,22 @@ impl SvgRenderer {
         match &p.stroke {
             Some(stroke) => {
                 let brush = self.brush_from_usvg(&stroke.paint, stroke.opacity, ctx);
-                ctx.stroke_styled(
-                    path,
-                    &*brush,
-                    stroke.width.value(),
-                    &StrokeStyle::new()
-                        .line_join(match stroke.linejoin {
-                            usvg::LineJoin::Miter => LineJoin::Miter,
-                            usvg::LineJoin::Round => LineJoin::Round,
-                            usvg::LineJoin::Bevel => LineJoin::Bevel,
-                        })
-                        .line_cap(match stroke.linecap {
-                            usvg::LineCap::Butt => LineCap::Butt,
-                            usvg::LineCap::Round => LineCap::Round,
-                            usvg::LineCap::Square => LineCap::Square,
-                        }),
-                );
+                let mut stroke_style = StrokeStyle::new()
+                    .line_join(match stroke.linejoin {
+                        usvg::LineJoin::Miter => LineJoin::Miter,
+                        usvg::LineJoin::Round => LineJoin::Round,
+                        usvg::LineJoin::Bevel => LineJoin::Bevel,
+                    })
+                    .line_cap(match stroke.linecap {
+                        usvg::LineCap::Butt => LineCap::Butt,
+                        usvg::LineCap::Round => LineCap::Round,
+                        usvg::LineCap::Square => LineCap::Square,
+                    })
+                    .miter_limit(stroke.miterlimit.value());
+                if let Some(dash_array) = &stroke.dasharray {
+                    stroke_style.set_dash(dash_array.clone(), stroke.dashoffset as f64);
+                }
+                ctx.stroke_styled(path, &*brush, stroke.width.value(), &stroke_style);
             }
             None => {}
         }

--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -19,7 +19,7 @@ use tracing::{instrument, trace};
 
 use crate::{
     kurbo::BezPath,
-    piet::{self, FixedLinearGradient, GradientStop},
+    piet::{self, FixedLinearGradient, GradientStop, LineCap, LineJoin, StrokeStyle},
     widget::common::FillStrat,
     widget::prelude::*,
     Affine, Color, Data, Point, Rect,
@@ -309,7 +309,22 @@ impl SvgRenderer {
         match &p.stroke {
             Some(stroke) => {
                 let brush = self.brush_from_usvg(&stroke.paint, stroke.opacity, ctx);
-                ctx.stroke(path, &*brush, stroke.width.value());
+                ctx.stroke_styled(
+                    path,
+                    &*brush,
+                    stroke.width.value(),
+                    &StrokeStyle::new()
+                        .line_join(match stroke.linejoin {
+                            usvg::LineJoin::Miter => LineJoin::Miter,
+                            usvg::LineJoin::Round => LineJoin::Round,
+                            usvg::LineJoin::Bevel => LineJoin::Bevel,
+                        })
+                        .line_cap(match stroke.linecap {
+                            usvg::LineCap::Butt => LineCap::Butt,
+                            usvg::LineCap::Round => LineCap::Round,
+                            usvg::LineCap::Square => LineCap::Square,
+                        }),
+                );
             }
             None => {}
         }


### PR DESCRIPTION
This patch updates the SVG widget to fetch and use properties about stroke style, such as [line cap](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-linecap) and [dash array](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray).

This has not been thoroughly tested since the new properties have a one-to-one mapping with `StrokeStyle` in piet. It has passed a smoke test in a project I'm working on, which has 12 unique SVG icons. Some of these icons also now render correctly where they didn't before.

I'm a little iffy about is the `Vec` clone. I don't think it's avoidable here, but I want to point it out since Druid goes to great lengths to avoid it elsewhere.