### PR TITLE
Unify druid & druid-shell Movement types

### DIFF
--- a/druid-shell/src/text.rs
+++ b/druid-shell/src/text.rs
@@ -611,6 +611,25 @@ pub enum Direction {
     Downstream,
 }
 
+impl Direction {
+    /// Returns `true` if this direction is byte-wise backwards for
+    /// the provided [`WritingDirection`].
+    ///
+    /// The provided direction *must not be* `WritingDirection::Natural`.
+    pub fn is_upstream_for_direction(self, direction: WritingDirection) -> bool {
+        assert!(
+            !matches!(direction, WritingDirection::Natural),
+            "writing direction must be resolved"
+        );
+        match self {
+            Direction::Upstream => true,
+            Direction::Downstream => false,
+            Direction::Left => matches!(direction, WritingDirection::LeftToRight),
+            Direction::Right => matches!(direction, WritingDirection::RightToLeft),
+        }
+    }
+}
+
 /// Distinguishes between two visually distinct locations with the same byte
 /// index.
 ///

--- a/druid/src/text/input_component.rs
+++ b/druid/src/text/input_component.rs
@@ -564,14 +564,12 @@ impl<T: TextStorage + EditableText> EditSession<T> {
     fn do_action(&mut self, buffer: &mut T, action: ImeAction) {
         match action {
             ImeAction::Move(movement) => {
-                let sel =
-                    crate::text::movement(movement.into(), self.selection, &self.layout, false);
+                let sel = crate::text::movement(movement, self.selection, &self.layout, false);
                 self.external_selection_change = Some(sel);
                 self.scroll_to_selection_end(false);
             }
             ImeAction::MoveSelecting(movement) => {
-                let sel =
-                    crate::text::movement(movement.into(), self.selection, &self.layout, true);
+                let sel = crate::text::movement(movement, self.selection, &self.layout, true);
                 self.external_selection_change = Some(sel);
                 self.scroll_to_selection_end(false);
             }
@@ -583,8 +581,7 @@ impl<T: TextStorage + EditableText> EditSession<T> {
             //tracing::warn!("Line/Word selection actions are not implemented");
             //}
             ImeAction::Delete(movement) if self.selection.is_caret() => {
-                let movement: Movement = movement.into();
-                if movement == Movement::Left {
+                if movement == Movement::Grapheme(druid_shell::text::Direction::Upstream) {
                     self.backspace(buffer);
                 } else {
                     let to_delete =


### PR DESCRIPTION
This deletes the old Movement enum in druid, and moves to using
druid-shell for everything.

more progress on #1652 