### PR TITLE
Export Link type

### DIFF
--- a/druid/src/text/attribute.rs
+++ b/druid/src/text/attribute.rs
@@ -22,8 +22,10 @@ use crate::{Command, Env, FontDescriptor, KeyOrValue};
 /// A clickable range of text with an associated [`Command`].
 #[derive(Debug, Clone)]
 pub struct Link {
-    pub(crate) range: Range<usize>,
-    pub(crate) command: Command,
+    /// The range of text for the link.
+    pub range: Range<usize>,
+    /// A [`Command`] representing the link's payload.
+    pub command: Command,
 }
 
 /// A collection of spans of attributes of various kinds.

--- a/druid/src/text/layout.rs
+++ b/druid/src/text/layout.rs
@@ -17,8 +17,7 @@
 use std::ops::Range;
 use std::rc::Rc;
 
-use super::attribute::Link;
-use super::TextStorage;
+use super::{Link, TextStorage};
 use crate::kurbo::{Line, Point, Rect, Size};
 use crate::piet::{
     Color, PietText, PietTextLayout, Text as _, TextAlignment, TextAttribute, TextLayout as _,

--- a/druid/src/text/mod.rs
+++ b/druid/src/text/mod.rs
@@ -27,7 +27,7 @@ mod rich_text;
 pub mod selection;
 mod storage;
 
-pub use self::attribute::{Attribute, AttributeSpans};
+pub use self::attribute::{Attribute, AttributeSpans, Link};
 pub use self::backspace::offset_for_delete_backwards;
 pub use self::editable_text::{EditableText, EditableTextCursor, StringCursor};
 pub use self::font_descriptor::FontDescriptor;


### PR DESCRIPTION
This type is part of public API and is linked in some doc comments
so it makes sense that the type be accessible.