### PR TITLE
Add inactive selection color, tweak selection colors

### DIFF
--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -41,7 +41,12 @@ pub const BUTTON_BORDER_WIDTH: Key<f64> =
     Key::new("org.linebender.druid.theme.button_border_width");
 pub const BORDER_DARK: Key<Color> = Key::new("org.linebender.druid.theme.border_dark");
 pub const BORDER_LIGHT: Key<Color> = Key::new("org.linebender.druid.theme.border_light");
-pub const SELECTION_COLOR: Key<Color> = Key::new("org.linebender.druid.theme.selection_color");
+#[deprecated(since = "0.8.0", note = "use SELECTED_TEXT_BACKGROUND_COLOR instead")]
+pub const SELECTION_COLOR: Key<Color> = SELECTED_TEXT_BACKGROUND_COLOR;
+pub const SELECTED_TEXT_BACKGROUND_COLOR: Key<Color> =
+    Key::new("org.linebender.druid.theme.selection_color");
+pub const SELECTED_TEXT_INACTIVE_BACKGROUND_COLOR: Key<Color> =
+    Key::new("org.linebender.druid.theme.selection_color_inactive");
 pub const SELECTION_TEXT_COLOR: Key<Color> =
     Key::new("org.linebender.druid.theme.selection_text_color");
 pub const CURSOR_COLOR: Key<Color> = Key::new("org.linebender.druid.theme.cursor_color");
@@ -114,7 +119,11 @@ pub(crate) fn add_to_env(env: Env) -> Env {
         .adding(BUTTON_BORDER_WIDTH, 2.)
         .adding(BORDER_DARK, Color::rgb8(0x3a, 0x3a, 0x3a))
         .adding(BORDER_LIGHT, Color::rgb8(0xa1, 0xa1, 0xa1))
-        .adding(SELECTION_COLOR, Color::rgb8(0xf3, 0x00, 0x21))
+        .adding(
+            SELECTED_TEXT_BACKGROUND_COLOR,
+            Color::rgb8(0x43, 0x70, 0xA8),
+        )
+        .adding(SELECTED_TEXT_INACTIVE_BACKGROUND_COLOR, Color::grey8(0x74))
         .adding(SELECTION_TEXT_COLOR, Color::rgb8(0x00, 0x00, 0x00))
         .adding(CURSOR_COLOR, Color::WHITE)
         .adding(TEXT_SIZE_NORMAL, 15.0)

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -429,6 +429,7 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
                     let _ = self.text_mut().borrow_mut().set_selection(selection);
                     ctx.invalidate_text_input(druid_shell::text::Event::SelectionChanged);
                 }
+                self.inner.wrapped_mut().child_mut().has_focus = true;
                 self.reset_cursor_blink(ctx.request_timer(CURSOR_BLINK_DURATION));
                 self.was_focused_from_click = false;
                 ctx.request_paint();
@@ -440,6 +441,7 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
                     let _ = self.text_mut().borrow_mut().set_selection(selection);
                     ctx.invalidate_text_input(druid_shell::text::Event::SelectionChanged);
                 }
+                self.inner.wrapped_mut().child_mut().has_focus = false;
                 self.cursor_timer = TimerToken::INVALID;
                 self.was_focused_from_click = false;
                 ctx.request_paint();


### PR DESCRIPTION
This patch changes the selection color to *not* red, and adds
a new SELECTED_TEXT_INACTIVE_BACKGROUND_COLOR theme item; it
also now draws the selection with that color when the text is
not focused.

This requires a bit of a hack because of how focus is working
in the textbox; the TextBox has focus, not the InputComponent,
but the InputComponent is responsible for drawing the selection
rects, so we need to explicitly pass down changes in focus state.

C'est la vie.

This also renames SELECTION_COLOR to SELECTED_TEXT_BACKGROUND_COLOR,
for clarity & symmetry.



https://user-images.githubusercontent.com/3330916/111514971-a6188b00-8728-11eb-982b-a87778a16118.mov

- more progress on #1652 