### PR TITLE
Handle standard text keyboard shortcuts without menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ You can find its changes [documented below](#070---2021-01-01).
 
 ### Fixed
 - `Notification`s will not be delivered to the widget that sends them ([#1640] by [@cmyr])
+- `TextBox` can handle standard keyboard shortcuts without needing menus ([#1660] by [@cmyr])
 
 
 - Fixed docs of derived Lens ([#1523] by [@Maan2003])
@@ -649,6 +650,7 @@ Last release without a changelog :(
 [#1640]: https://github.com/linebender/druid/pull/1640
 [#1641]: https://github.com/linebender/druid/pull/1641
 [#1647]: https://github.com/linebender/druid/pull/1647
+[#1660]: https://github.com/linebender/druid/pull/1660
 [#1662]: https://github.com/linebender/druid/pull/1662
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -319,6 +319,9 @@ pub mod sys {
     /// Redo.
     pub const REDO: Selector = Selector::new("druid-builtin.menu-redo");
 
+    /// Select all.
+    pub const SELECT_ALL: Selector = Selector::new("druid-builtin.menu-select-all");
+
     /// Text input state has changed, and we need to notify the platform.
     pub(crate) const INVALIDATE_IME: Selector<ImeInvalidation> =
         Selector::new("druid-builtin.invalidate-ime");

--- a/druid/src/text/input_component.rs
+++ b/druid/src/text/input_component.rs
@@ -202,6 +202,14 @@ impl<T> TextComponent<T> {
         self.lock.get() == ImeLock::None
     }
 
+    /// Returns `true` if the IME is actively composing (or the text is locked.)
+    ///
+    /// When text is composing, you should avoid doing things like modifying the
+    /// selection or copy/pasting text.
+    pub fn is_composing(&self) -> bool {
+        self.can_read() && self.borrow().composition_range.is_some()
+    }
+
     /// Attempt to mutably borrow the inner [`EditSession`].
     ///
     /// # Panics


### PR DESCRIPTION
The textbox will now receive copy/cut/paste/undo/redo/select-all
without a menu being present.

Several of these (select-all, undo/redo) do not currently have
implementations, but we will at least get the commands.

- progress on #1652
- closes #1030