### PR TITLE
Adding protections for invalid flex parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - Padding is generic over child widget, impls WidgetWrapper ([#1634] by [@cmyr])
 - Menu support was rewritten with support for `Data` ([#1625] by [@jneem])
 - Update to piet v0.4.0 (rich text on linux!) ([#1677] by [@cmyr])
+- Flex values that are less than 0.0 will default to 0.0 and warn in release. It will panic in debug mode. ([#1691] by [@arthmis])
 
 ### Deprecated
 
@@ -441,6 +442,7 @@ Last release without a changelog :(
 [@SecondFlight]: https://github.com/SecondFlight
 [@lord]: https://github.com/lord
 [@Lejero]: https://github.com/Lejero
+[@arthmis]: https://github.com/arthmis
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611
@@ -657,6 +659,7 @@ Last release without a changelog :(
 [#1660]: https://github.com/linebender/druid/pull/1660
 [#1662]: https://github.com/linebender/druid/pull/1662
 [#1677]: https://github.com/linebender/druid/pull/1677
+[#1691]: https://github.com/linebender/druid/pull/1691
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -338,7 +338,6 @@ impl FlexParams {
     /// can pass an `f64` to any of the functions that take `FlexParams`.
     ///
     /// By default, the widget uses the alignment of its parent [`Flex`] container.
-    /// If the provided flex value is 0.0 or less, the flex value will default to 1.0.
     ///
     ///
     /// [`Flex`]: Flex

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -1081,22 +1081,8 @@ mod tests {
         assert_eq!(vec(a, 38., 5), vec![4., 7., 8., 8., 7., 4.]);
         assert_eq!(vec(a, 39., 5), vec![4., 8., 7., 8., 8., 4.]);
     }
-    #[test]
-    #[cfg(not(debug_assertions))]
-    fn test_invalid_flex_params() {
-        use float_cmp::approx_eq;
-        let params = FlexParams::new(0.0, None);
-        approx_eq!(f64, params.flex, 1.0, ulps = 2);
-
-        let params = FlexParams::new(-0.0, None);
-        approx_eq!(f64, params.flex, 1.0, ulps = 2);
-
-        let params = FlexParams::new(-1.0, None);
-        approx_eq!(f64, params.flex, 1.0, ulps = 2);
-    }
 
     #[test]
-    #[cfg(debug_assertions)]
     #[should_panic]
     fn test_invalid_flex_params() {
         use float_cmp::approx_eq;

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -429,7 +429,7 @@ impl<T: Data> Flex<T> {
     ///
     /// Convenient for assembling a group of widgets in a single expression.
     pub fn with_child(mut self, child: impl Widget<T> + 'static) -> Self {
-        self.add_flex_child(child, 0.0);
+        self.add_child(child);
         self
     }
 
@@ -1086,6 +1086,7 @@ mod tests {
         assert_eq!(vec(a, 39., 5), vec![4., 8., 7., 8., 8., 4.]);
     }
     #[test]
+    #[should_panic]
     fn test_invalid_flex_params() {
         use float_cmp::approx_eq;
         let params = FlexParams::new(0.0, None);

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -1086,14 +1086,8 @@ mod tests {
         assert_eq!(vec(a, 39., 5), vec![4., 8., 7., 8., 8., 4.]);
     }
     #[test]
-    // #[should_panic]
     #[cfg(not(debug_assertions))]
     fn test_invalid_flex_params() {
-        // if cfg!(debug_assertions) {
-        //     println!("Debugging enabled");
-        // } else {
-        //     println!("Debugging disabled");
-        // }
         use float_cmp::approx_eq;
         let params = FlexParams::new(0.0, None);
         approx_eq!(f64, params.flex, 1.0, ulps = 2);

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -1086,6 +1086,27 @@ mod tests {
         assert_eq!(vec(a, 39., 5), vec![4., 8., 7., 8., 8., 4.]);
     }
     #[test]
+    // #[should_panic]
+    #[cfg(not(debug_assertions))]
+    fn test_invalid_flex_params() {
+        // if cfg!(debug_assertions) {
+        //     println!("Debugging enabled");
+        // } else {
+        //     println!("Debugging disabled");
+        // }
+        use float_cmp::approx_eq;
+        let params = FlexParams::new(0.0, None);
+        approx_eq!(f64, params.flex, 1.0, ulps = 2);
+
+        let params = FlexParams::new(-0.0, None);
+        approx_eq!(f64, params.flex, 1.0, ulps = 2);
+
+        let params = FlexParams::new(-1.0, None);
+        approx_eq!(f64, params.flex, 1.0, ulps = 2);
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
     #[should_panic]
     fn test_invalid_flex_params() {
         use float_cmp::approx_eq;

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -338,10 +338,6 @@ impl FlexParams {
     /// can pass an `f64` to any of the functions that take `FlexParams`.
     ///
     /// By default, the widget uses the alignment of its parent [`Flex`] container.
-    ///
-    ///
-    /// [`Flex`]: Flex
-    /// [`CrossAxisAlignment`]: CrossAxisAlignment
     pub fn new(flex: f64, alignment: impl Into<Option<CrossAxisAlignment>>) -> Self {
         if flex <= 0.0 {
             debug_panic!("Flex value should be > 0.0. Flex given was: {}", flex);
@@ -543,8 +539,8 @@ impl<T: Data> Flex<T> {
     /// my_row.add_flex_child(Slider::new(), FlexParams::new(1.0, CrossAxisAlignment::End));
     /// ```
     ///
-    /// [`FlexParams`]: FlexParams
     /// [`with_flex_child`]: Flex::with_flex_child
+    #[instrument(name = "Flex", level = "trace", skip(self, child, params))]
     pub fn add_flex_child(
         &mut self,
         child: impl Widget<T> + 'static,
@@ -558,7 +554,7 @@ impl<T: Data> Flex<T> {
                 flex: params.flex,
             }
         } else {
-            tracing::warn!("Flex value should be > 0.0. To add a non-flex child use the add_child or with_child methods. See the Flex docs for more information: https://docs.rs/druid/0.7.0/druid/widget/struct.Flex.html");
+            tracing::warn!("Flex value should be > 0.0. To add a non-flex child use the add_child or with_child methods.\nSee the docs for more information: https://docs.rs/druid/0.7.0/druid/widget/struct.Flex.html");
             Child::Fixed {
                 widget: WidgetPod::new(Box::new(child)),
                 alignment: None,

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -540,7 +540,6 @@ impl<T: Data> Flex<T> {
     /// ```
     ///
     /// [`with_flex_child`]: Flex::with_flex_child
-    #[instrument(name = "Flex", level = "trace", skip(self, child, params))]
     pub fn add_flex_child(
         &mut self,
         child: impl Widget<T> + 'static,

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -344,16 +344,16 @@ impl FlexParams {
     /// [`Flex`]: crate::widget::Flex
     /// [`CrossAxisAlignment`]: crate::widget::CrossAxisAlignment
     pub fn new(flex: f64, alignment: impl Into<Option<CrossAxisAlignment>>) -> Self {
-        let flex = if flex <= 0.0 {
+        let flex = if flex > 0.0 {
+            flex
+        } else {
             debug_assert!(
-                flex <= 0.0,
+                flex > 0.0,
                 "flex value should not be less than equal to 0.0. Flex given was: {}",
                 flex
             );
             tracing::warn!("Provided flex value was less than equal to 0.0: {}", flex);
             1.0
-        } else {
-            flex
         };
 
         FlexParams {
@@ -599,7 +599,9 @@ impl<T: Data> Flex<T> {
 
     /// Add an empty spacer widget with a specific `flex` factor.
     pub fn add_flex_spacer(&mut self, flex: f64) {
-        let flex = if flex < 0.0 {
+        let flex = if flex >= 0.0 {
+            flex
+        } else {
             debug_assert!(
                 flex >= 0.0,
                 "flex value for space should be greater than equal to 0, received: {}",
@@ -607,8 +609,6 @@ impl<T: Data> Flex<T> {
             );
             tracing::warn!("Provided flex value was less than 0: {}", flex);
             0.0
-        } else {
-            flex
         };
         let new_child = Child::FlexedSpacer(flex, 0.0);
         self.children.push(new_child);
@@ -680,14 +680,14 @@ impl<T: Data> Widget<T> for Flex<T> {
                 }
                 Child::FixedSpacer(kv, calculated_siz) => {
                     *calculated_siz = kv.resolve(env);
-                    *calculated_siz = if *calculated_siz < 0.0 {
+                    *calculated_siz = if *calculated_siz >= 0.0 {
+                        *calculated_siz
+                    } else {
                         tracing::warn!(
                             "Length provided to fixed spacer was les than 0: {}",
                             *calculated_siz
                         );
                         0.0
-                    } else {
-                        *calculated_siz
                     };
                     major_non_flex += *calculated_siz;
                 }


### PR DESCRIPTION
Ok, not sure if there are better ways to clamp a value above a certain threshold. Also, is it fine to do the tests like that? I had to do it that way otherwise the test fails in release and passes debug. 