### PR TITLE
fixes #1690 (WindowState::Maximized on macOS doesn't lay out widgets …

### DIFF
--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -294,6 +294,9 @@ impl WindowBuilder {
                 handle.set_level(level)
             }
 
+            // set_window_state above could have invalidated the frame size
+            let frame = NSView::frame(content_view);
+
             (*view_state).handler.connect(&handle.clone().into());
             (*view_state).handler.scale(Scale::default());
             (*view_state)


### PR DESCRIPTION
…properly at startup).