### PR TITLE
GTK Shell: Manually get/set textual data in clipboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ You can find its changes [documented below](#070---2021-01-01).
 ### Fixed
 - `Notification`s will not be delivered to the widget that sends them ([#1640] by [@cmyr])
 - `TextBox` can handle standard keyboard shortcuts without needing menus ([#1660] by [@cmyr])
+- GTK Shell: Prevent mangling of newline characters in clipboard ([#1695] by [@ForLoveOfCats])
 
 
 - Fixed docs of derived Lens ([#1523] by [@Maan2003])
@@ -661,6 +662,7 @@ Last release without a changelog :(
 [#1662]: https://github.com/linebender/druid/pull/1662
 [#1677]: https://github.com/linebender/druid/pull/1677
 [#1698]: https://github.com/linebender/druid/pull/1698
+[#1695]: https://github.com/linebender/druid/pull/1695
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0


### PR DESCRIPTION
Fixes #981

~~It seems that newlines were not being mangled on the outbound direction, only on the inbound.~~ By manually retrieving the text and converting to a string we avoid GTK from performing that behavior when getting clipboard contents. This also appears to work on Wayland in both Plasma 5 KWin and Weston.

Verification that this behaves correctly on X11 and Wayland would be appreciated :)