### PR TITLE
Add missing derived lens documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -442,6 +442,7 @@ Last release without a changelog :(
 [@SecondFlight]: https://github.com/SecondFlight
 [@lord]: https://github.com/lord
 [@Lejero]: https://github.com/Lejero
+[@lidin]: https://github.com/lidin
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611
@@ -658,6 +659,7 @@ Last release without a changelog :(
 [#1660]: https://github.com/linebender/druid/pull/1660
 [#1662]: https://github.com/linebender/druid/pull/1662
 [#1677]: https://github.com/linebender/druid/pull/1677
+[#1696]: https://github.com/linebender/druid/pull/1696
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - `Notification`s can be submitted while handling other `Notification`s ([#1640] by [@cmyr])
 - Added ListIter implementations for OrdMap ([#1641] by [@Lejero])
 - `Padding` can now use `Key<Insets>` ([#1662] by [@cmyr])
+- Added missing documentation on derived lens items ([#1696] by [@lidin])
 
 ### Changed
 

--- a/druid-derive/src/lens.rs
+++ b/druid-derive/src/lens.rs
@@ -89,7 +89,7 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
         );
 
         let fn_docs = format!(
-            "Creates a new lens for the field `{}` on [`{1}`](super::{1}).",
+            "Creates a new lens for the field `{}` on [`{1}`](super::{1}). Use [`{1}::{0}`](super::{1}::{0}) instead.",
             field_name, ty
         );
 

--- a/druid-derive/src/lens.rs
+++ b/druid-derive/src/lens.rs
@@ -83,18 +83,24 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
     // Define lens types for each field
     let defs = fields.iter().filter(|f| !f.attrs.ignore).map(|f| {
         let field_name = &f.ident.unwrap_named();
-        let docs = format!(
-            "Lens for the field `{}` on [`{1}`](super::{1})",
+        let struct_docs = format!(
+            "Lens for the field `{}` on [`{1}`](super::{1}).",
+            field_name, ty
+        );
+
+        let fn_docs = format!(
+            "Creates a new lens for the field `{}` on [`{1}`](super::{1}).",
             field_name, ty
         );
 
         quote! {
-            #[doc = #docs]
+            #[doc = #struct_docs]
             #[allow(non_camel_case_types)]
             #[derive(Debug, Copy, Clone)]
             pub struct #field_name#lens_ty_generics(#(#phantom_decls),*);
 
             impl #lens_ty_generics #field_name#lens_ty_generics{
+                #[doc = #fn_docs]
                 pub const fn new()->Self{
                     Self(#(#phantom_inits),*)
                 }
@@ -148,12 +154,15 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
         let lens_field_name = f.attrs.lens_name_override.as_ref().unwrap_or(&field_name);
 
         quote! {
-            /// Lens for the corresponding field
+            /// Lens for the corresponding field.
             pub const #lens_field_name: #twizzled_name::#field_name#lens_ty_generics = #twizzled_name::#field_name::new();
         }
     });
 
+    let mod_docs = format!("Derived lenses for [`{}`].", ty);
+
     let expanded = quote! {
+        #[doc = #mod_docs]
         pub mod #twizzled_name {
             #(#defs)*
         }

--- a/druid-derive/src/lens.rs
+++ b/druid-derive/src/lens.rs
@@ -84,13 +84,16 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
     let defs = fields.iter().filter(|f| !f.attrs.ignore).map(|f| {
         let field_name = &f.ident.unwrap_named();
         let struct_docs = format!(
-            "Lens for the field `{}` on [`{1}`](super::{1}).",
-            field_name, ty
+            "Lens for the field `{field}` on [`{ty}`](super::{ty}).",
+            field = field_name,
+            ty = ty,
         );
 
         let fn_docs = format!(
-            "Creates a new lens for the field `{}` on [`{1}`](super::{1}). Use [`{1}::{0}`](super::{1}::{0}) instead.",
-            field_name, ty
+            "Creates a new lens for the field `{field}` on [`{ty}`](super::{ty}). \
+            Use [`{ty}::{field}`](super::{ty}::{field}) instead.",
+            field = field_name,
+            ty = ty,
         );
 
         quote! {


### PR DESCRIPTION
If you enable `warn(missing_docs)` lint when deriving `Lens` on a type, it will detect missing documentation on the `#ty_derived_lenses` module, as well as the `fn new()` associated function on the lenses. This PR fixes that by adding the missing documentation.