### PR TITLE
Change simple code in book

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ You can find its changes [documented below](#070---2021-01-01).
 
 ### Docs
 
-- Fix example code in `Get started with Druid` chapter of book ([#1697] by [@ccqpein])
+- Fix example code in `Get started with Druid` chapter of book ([#1698] by [@ccqpein])
 
 ### Examples
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -443,6 +443,7 @@ Last release without a changelog :(
 [@SecondFlight]: https://github.com/SecondFlight
 [@lord]: https://github.com/lord
 [@Lejero]: https://github.com/Lejero
+[@ccqpein]: https://github.com/ccqpein
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611
@@ -659,6 +660,7 @@ Last release without a changelog :(
 [#1660]: https://github.com/linebender/druid/pull/1660
 [#1662]: https://github.com/linebender/druid/pull/1662
 [#1677]: https://github.com/linebender/druid/pull/1677
+[#1698]: https://github.com/linebender/druid/pull/1698
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ You can find its changes [documented below](#070---2021-01-01).
 
 ### Docs
 
+- Fix example code in `Get started with Druid` chapter of book ([#1697] by [@ccqpein])
+
 ### Examples
 
 ### Maintenance

--- a/docs/src/get_started.md
+++ b/docs/src/get_started.md
@@ -26,7 +26,7 @@ fn build_ui() -> impl Widget<()> {
 }
 
 fn main() -> Result<(), PlatformError> {
-    AppLauncher::with_window(WindowDesc::new(build_ui)).launch(())?;
+    AppLauncher::with_window(WindowDesc::new(build_ui())).launch(())?;
     Ok(())
 }
 ```


### PR DESCRIPTION
In `Get started with Druid` of book, the simple code:

```rust
fn main() -> Result<(), PlatformError> {
    AppLauncher::with_window(WindowDesc::new(build_ui)).launch(())?;
    Ok(())
}
```

doesn't pass the compiler.  Change it to:

```rust
fn main() -> Result<(), PlatformError> {
    AppLauncher::with_window(WindowDesc::new(build_ui())).launch(())?;
    Ok(())
}
```

will work