### PR TITLE
Allow restarting Application

### DIFF
--- a/druid-shell/src/application.rs
+++ b/druid-shell/src/application.rs
@@ -158,6 +158,10 @@ impl Application {
         });
         // .. and release the main thread
         util::release_main_thread();
+        // .. and mark as done so a new sequence can start
+        APPLICATION_CREATED
+            .compare_exchange(true, false, Ordering::AcqRel, Ordering::Acquire)
+            .expect("Application marked as not created while still running.");
     }
 
     /// Quit the `Application`.


### PR DESCRIPTION
Allow the `Application` to be restarted after it finished running, by
ensuring it releases to false the atomic check for app initialization.

On Windows platform, additionally ensure the window class is only
registered once per process run, as duplicate registration will fail.

This enables writing unit tests for druid-shell, which otherwise cannot
be run in batch. This however still require the use of
`--test-threads=1` to prevent parallel testing, which this change does
not cover.

Bug: #771