### PR TITLE
Add support for transparent titlebar on Mac

### DIFF
--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -33,7 +33,7 @@ use gtk::{AccelGroup, ApplicationWindow, DrawingArea, SettingsExt};
 use tracing::{error, warn};
 
 #[cfg(feature = "raw-win-handle")]
-use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+use raw_window_handle::{unix::XcbHandle, HasRawWindowHandle, RawWindowHandle};
 
 use crate::kurbo::{Insets, Point, Rect, Size, Vec2};
 use crate::piet::{Piet, PietText, RenderContext};

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -220,8 +220,16 @@ impl WindowBuilder {
         self.show_titlebar = show_titlebar;
     }
 
+    pub fn show_title(&mut self, _show_title: bool) {
+        // Ignored
+    }
+
     pub fn set_transparent(&mut self, transparent: bool) {
         self.transparent = transparent;
+    }
+
+    pub fn set_transparent_titlebar(&mut self, _transparent_titlebar: bool) {
+        // Ignored
     }
 
     pub fn set_position(&mut self, position: Point) {

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -371,7 +371,15 @@ impl WindowBuilder {
         // Ignored
     }
 
+    pub fn show_title(&mut self, _show_title: bool) {
+        // Ignored
+    }
+
     pub fn set_transparent(&mut self, _transparent: bool) {
+        // Ignored
+    }
+
+    pub fn set_transparent_titlebar(&mut self, _transparent_titlebar: bool) {
         // Ignored
     }
 
@@ -384,7 +392,7 @@ impl WindowBuilder {
     }
 
     pub fn set_level(&mut self, _level: WindowLevel) {
-        // ignored
+        // Ignored
     }
 
     pub fn set_title<S: Into<String>>(&mut self, title: S) {

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -1276,6 +1276,10 @@ impl WindowBuilder {
         self.show_titlebar = show_titlebar;
     }
 
+    pub fn show_title(&mut self, _show_title: bool) {
+        // Ignored
+    }
+
     pub fn set_transparent(&mut self, transparent: bool) {
         // Transparency and Flip is only supported on Windows 8 and newer and
         // require DComposition
@@ -1287,6 +1291,10 @@ impl WindowBuilder {
                 tracing::warn!("Transparency requires Windows 8 or newer");
             }
         }
+    }
+
+    pub fn set_transparent_titlebar(&mut self, _transparent_titlebar: bool) {
+        // Ignored
     }
 
     pub fn set_title<S: Into<String>>(&mut self, title: S) {

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -139,7 +139,15 @@ impl WindowBuilder {
         warn!("WindowBuilder::show_titlebar is currently unimplemented for X11 platforms.");
     }
 
+    pub fn show_title(&mut self, _show_title: bool) {
+        // Ignored
+    }
+
     pub fn set_transparent(&mut self, _transparent: bool) {
+        // Ignored
+    }
+
+    pub fn set_transparent_titlebar(&mut self, _transparent_titlebar: bool) {
         // Ignored
     }
 

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -494,7 +494,7 @@ impl WindowBuilder {
 
     /// Set whether the titlebar of the window should appear transparent,
     /// letting the window content fill all available space, with the title
-    /// and controls on top of it.
+    /// and controls overlayed.
     pub fn set_transparent_titlebar(&mut self, transparent_titlebar: bool) {
         self.0.set_transparent_titlebar(transparent_titlebar);
     }

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -482,9 +482,21 @@ impl WindowBuilder {
         self.0.show_titlebar(show_titlebar)
     }
 
-    /// Set whether the window background should be transparent
+    /// Set whether the window title text should be visible.
+    pub fn show_title(&mut self, show_title: bool) {
+        self.0.show_title(show_title);
+    }
+
+    /// Set whether the window background should be transparent.
     pub fn set_transparent(&mut self, transparent: bool) {
         self.0.set_transparent(transparent)
+    }
+
+    /// Set whether the titlebar of the window should appear transparent,
+    /// letting the window content fill all available space, with the title
+    /// and controls on top of it.
+    pub fn set_transparent_titlebar(&mut self, transparent_titlebar: bool) {
+        self.0.set_transparent_titlebar(transparent_titlebar);
     }
 
     /// Sets the initial window position in [display points], relative to the origin of the

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -59,7 +59,9 @@ pub struct WindowConfig {
     pub(crate) position: Option<Point>,
     pub(crate) resizable: Option<bool>,
     pub(crate) transparent: Option<bool>,
+    pub(crate) transparent_titlebar: Option<bool>,
     pub(crate) show_titlebar: Option<bool>,
+    pub(crate) show_title: Option<bool>,
     pub(crate) level: Option<WindowLevel>,
     pub(crate) state: Option<WindowState>,
 }
@@ -276,7 +278,9 @@ impl Default for WindowConfig {
             position: None,
             resizable: None,
             show_titlebar: None,
+            show_title: None,
             transparent: None,
+            transparent_titlebar: None,
             level: None,
             state: None,
         }
@@ -348,6 +352,12 @@ impl WindowConfig {
         self
     }
 
+    /// Set whether the window title text should be visible.
+    pub fn show_title(mut self, show_title: bool) -> Self {
+        self.show_title = Some(show_title);
+        self
+    }
+
     /// Sets the window position in virtual screen coordinates.
     /// [`position`] Position in pixels.
     ///
@@ -379,6 +389,14 @@ impl WindowConfig {
         self
     }
 
+    /// Set whether the titlebar of the window should appear transparent,
+    /// letting the window content fill all available space, with the title
+    /// and controls overlayed.
+    pub fn transparent_titlebar(mut self, transparent_titlebar: bool) -> Self {
+        self.transparent_titlebar = Some(transparent_titlebar);
+        self
+    }
+
     /// Apply this window configuration to the passed in WindowBuilder
     pub fn apply_to_builder(&self, builder: &mut WindowBuilder) {
         if let Some(resizable) = self.resizable {
@@ -387,6 +405,10 @@ impl WindowConfig {
 
         if let Some(show_titlebar) = self.show_titlebar {
             builder.show_titlebar(show_titlebar);
+        }
+
+        if let Some(show_title) = self.show_title {
+            builder.show_title(show_title);
         }
 
         if let Some(size) = self.size {
@@ -401,6 +423,10 @@ impl WindowConfig {
 
         if let Some(transparent) = self.transparent {
             builder.set_transparent(transparent);
+        }
+
+        if let Some(transparent_titlebar) = self.transparent_titlebar {
+            builder.set_transparent_titlebar(transparent_titlebar);
         }
 
         if let Some(level) = self.level {
@@ -550,11 +576,25 @@ impl<T: Data> WindowDesc<T> {
         self
     }
 
+    /// Builder-style method to set whether this window's title text is visible.
+    pub fn show_title(mut self, show_title: bool) -> Self {
+        self.config = self.config.show_title(show_title);
+        self
+    }
+
     /// Builder-style method to set whether this window's background should be
     /// transparent.
     pub fn transparent(mut self, transparent: bool) -> Self {
         self.config = self.config.transparent(transparent);
         self.pending = self.pending.transparent(transparent);
+        self
+    }
+
+    /// Builder-style method to set set whether the titlebar of the window should
+    /// appear transparent, letting the window content fill all available space,
+    /// with the title and controls overlayed.
+    pub fn transparent_titlebar(mut self, transparent_titlebar: bool) -> Self {
+        self.config = self.config.transparent_titlebar(transparent_titlebar);
         self
     }
 


### PR DESCRIPTION
Adds two `WindowBuilder` methods, `show_title` and `set_transparent_titlebar`.

When used together, only the window controls are left:

![image](https://user-images.githubusercontent.com/1055497/113858176-b9f16300-97a3-11eb-96fd-7de07791de0a.png)
