### PR TITLE
Implement tooltip level on Windows platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,15 @@
 The latest published Druid release is [0.7.0](#070---2021-01-01) which was released on 2021-01-01.
 You can find its changes [documented below](#070---2021-01-01).
 
-# Unreleased
+## Unreleased
 
 ### Highlights
+
 - International text input support (IME) on macOS.
 - Rich text and complex script support on Linux.
 
 ### Added
+
 - Add `scroll()` method in WidgetExt ([#1600] by [@totsteps])
 - `write!` for `RichTextBuilder` ([#1596] by [@Maan2003])
 - Sub windows: Allow opening windows that share state with arbitrary parts of the widget hierarchy ([#1254] by [@rjwittams])
@@ -34,6 +36,7 @@ You can find its changes [documented below](#070---2021-01-01).
   context-methods to implement disabled ([#1632] by [@xarvic])
 - `LifeCycle::BuildFocusChain` to update the focus-chain ([#1632] by [@xarvic])
 - `DisabledIf` widget wrapper to disable based on the state of Data and Env ([#1702] by [@xarvic])
+
 ### Changed
 
 - Warn on unhandled Commands ([#1533] by [@Maan2003])
@@ -53,6 +56,7 @@ You can find its changes [documented below](#070---2021-01-01).
 ### Removed
 
 ### Fixed
+
 - `Notification`s will not be delivered to the widget that sends them ([#1640] by [@cmyr])
 - `TextBox` can handle standard keyboard shortcuts without needing menus ([#1660] by [@cmyr])
 - GTK Shell: Prevent mangling of newline characters in clipboard ([#1695] by [@ForLoveOfCats])
@@ -60,6 +64,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - Correctly capture and use stroke properties when rendering SVG paths ([#1647] by [@SecondFlight])
 - focus-chain now only includes non hidden (`should_propagate_to_hidden()` on `Event` and `Lifecylce`) widgets ([#1724] by [@xarvic])
 - Fixed layout of scrollbar with very small viewports ([#1715] by [@andrewhickman])
+- Fixed `WindowLevel::Tooltip` on Windows platform ([#1737] by [@djeedai])
 
 ### Visual
 
@@ -457,6 +462,7 @@ Last release without a changelog :(
 [@xarvic]: https://github.com/xarvic
 [@arthmis]: https://github.com/arthmis
 [@ccqpein]: https://github.com/ccqpein
+[@djeedai]: https://github.com/djeedai
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611
@@ -684,6 +690,7 @@ Last release without a changelog :(
 [#1713]: https://github.com/linebender/druid/pull/1713
 [#1715]: https://github.com/linebender/druid/pull/1715
 [#1724]: https://github.com/linebender/druid/pull/1724
+[#1737]: https://github.com/linebender/druid/pull/1737
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0


### PR DESCRIPTION
Implement `WindowLevel::Tooltip` on Windows platform.

**Before change:**
- Tooltip window appear in taskbar
- Window has strange min-size (probably due to OS min constraints)
- Window steals focus from main app window (see grayed out title bar of main app)

![image](https://user-images.githubusercontent.com/6532395/116003485-1357ef80-a5f6-11eb-9a2b-b89c2d8bd38f.png)

**After change:**
- Tooltip window doesn't appear in taskbar
- Window fits any size (tested with nursery's `tooltip.rs`)
- Window doesn't steal focus from main app window

![image](https://user-images.githubusercontent.com/6532395/116003469-063b0080-a5f6-11eb-87ab-24f1e9c7c7c6.png)

**Details**

The change adds `SWP_NOACTIVATE` in many calls to `ShowWindow()` to prevent unwanted Win32 activation stealing the focus. `SWP_NOOWNERZORDER` is also added, inspired by Qt5 (see [here](https://github.com/qt/qtbase/blob/2ce94889a192ea67ba343bf0f6b16ede2648f374/src/plugins/platforms/windows/qwindowswindow.cpp#L870)).

Some `is_focusable` boolean is added to the state to discriminate between a regular "restore" and a non-activating show when `ShowWindow()` is called, because the former implicitly activates the window, stealing focus from the main app window and giving it to the tooltip.

Tentative `WS_`  and `WS_EX_` flags are set for `WindowLevel::Modal` and `WindowLevel::DropDown`. They have not been tested, but feel like a good starting point for whoever's coming next to implement those. In particular note that `DropDown` almost surely wants to be `WS_CHILD` to allow keyboard focus while not graying out the main app window title bar. However, because they have not been tested, `WindowBuilder::set_level()` continues to emit a warning for those levels, and ignore them for now for consistency with the current behavior.