### PR TITLE
Provide access to lens in LensWrap

### DIFF
--- a/druid/src/widget/lens_wrap.rs
+++ b/druid/src/widget/lens_wrap.rs
@@ -69,6 +69,16 @@ impl<T, U, L, W> LensWrap<T, U, L, W> {
             phantom_t: Default::default(),
         }
     }
+
+    /// Get a reference to the lens.
+    pub fn lens(&self) -> &L {
+        &self.lens
+    }
+
+    /// Get a mutable reference to the lens.
+    pub fn lens_mut(&mut self) -> &mut L {
+        &mut self.lens
+    }
 }
 
 impl<T, U, L, W> Widget<T> for LensWrap<T, U, L, W>


### PR DESCRIPTION
I'm writing a widget for the nursery where I needed to modify a field in a lens owned by a `LensWrap`, and the easiest way was to make this patch.