### PR TITLE
druid-shell: Added Delete key handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - `DisabledIf` widget wrapper to disable based on the state of Data and Env ([#1702] by [@xarvic])
 - GTK: added support for `content_insets` ([#1722] by [@jneem])
 - `chrono` feature with `Data` support for [chrono](https://docs.rs/chrono/) types ([#1743] by [@r-ml])
+- Text input handles Delete key ([#1746] by [@bjorn])
 
 ### Changed
 
@@ -468,6 +469,7 @@ Last release without a changelog :(
 [@RichardPoole42]: https://github.com/RichardPoole42
 [@r-ml]: https://github.com/r-ml
 [@djeedai]: https://github.com/djeedai
+[@bjorn]: https://github.com/bjorn
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611
@@ -699,6 +701,7 @@ Last release without a changelog :(
 [#1730]: https://github.com/linebender/druid/pull/1730
 [#1737]: https://github.com/linebender/druid/pull/1737
 [#1743]: https://github.com/linebender/druid/pull/1743
+[#1746]: https://github.com/linebender/druid/pull/1746
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid-shell/src/text.rs
+++ b/druid-shell/src/text.rs
@@ -511,6 +511,9 @@ pub fn simulate_input<H: WinHandler + ?Sized>(
         KbKey::Backspace => {
             input_handler.handle_action(Action::Delete(Movement::Grapheme(Direction::Upstream)));
         }
+        KbKey::Delete => {
+            input_handler.handle_action(Action::Delete(Movement::Grapheme(Direction::Downstream)));
+        }
         KbKey::Enter => {
             // I'm sorry windows, you'll get IME soon.
             input_handler.handle_action(Action::InsertNewLine {


### PR DESCRIPTION
As I was trying the examples on Linux I noticed that whereas Backspace was handled, the Delete key was not. I hope I found the right way to add this functionality (it works at least).