### PR TITLE
Update README.md example to match version 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ use druid::widget::{Button, Flex, Label};
 use druid::{AppLauncher, LocalizedString, PlatformError, Widget, WidgetExt, WindowDesc};
 
 fn main() -> Result<(), PlatformError> {
-    let main_window = WindowDesc::new(ui_builder());
+    let main_window = WindowDesc::new(ui_builder);
     let data = 0_u32;
     AppLauncher::with_window(main_window)
-        .log_to_console()
+        .use_simple_logger()
         .launch(data)
 }
 

--- a/README.md
+++ b/README.md
@@ -32,17 +32,17 @@ We gladly accept contributions via GitHub pull requests. Please see
 
 ## Example
 
-Here's a simple counter example app.
+Here's a simple counter example app:
 
 ```rust
 use druid::widget::{Button, Flex, Label};
 use druid::{AppLauncher, LocalizedString, PlatformError, Widget, WidgetExt, WindowDesc};
 
 fn main() -> Result<(), PlatformError> {
-    let main_window = WindowDesc::new(ui_builder);
+    let main_window = WindowDesc::new(ui_builder());
     let data = 0_u32;
     AppLauncher::with_window(main_window)
-        .use_simple_logger()
+        .log_to_console()
         .launch(data)
 }
 
@@ -58,6 +58,9 @@ fn ui_builder() -> impl Widget<u32> {
     Flex::column().with_child(label).with_child(button)
 }
 ```
+##### This example is compatible with master, [here's an example using 0.7.0](https://crates.io/crates/druid/0.7.0#example)
+<br>
+
 
 Check out the [the examples folder] for a more comprehensive demonstration of
 Druid's existing functionality and widgets.

--- a/README.md
+++ b/README.md
@@ -58,9 +58,7 @@ fn ui_builder() -> impl Widget<u32> {
     Flex::column().with_child(label).with_child(button)
 }
 ```
-##### This example is compatible with master, [here's an example using 0.7.0](https://crates.io/crates/druid/0.7.0#example)
-<br>
-
+This example works with master. Here's an example for 0.7.0: https://docs.rs/druid/latest/druid/#examples.
 
 Check out the [the examples folder] for a more comprehensive demonstration of
 Druid's existing functionality and widgets.
@@ -319,4 +317,3 @@ active and friendly community.
 [Conrod]: https://github.com/PistonDevelopers/conrod
 [Relm]: https://github.com/antoyo/relm
 [Moxie]: https://github.com/anp/moxie
-

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ fn ui_builder() -> impl Widget<u32> {
     Flex::column().with_child(label).with_child(button)
 }
 ```
-This example works with master. Here's an example for 0.7.0: https://docs.rs/druid/latest/druid/#examples.
+This example works with master. Here's an example for 0.7.0: https://docs.rs/druid/latest/druid/#examples
 
 Check out the [the examples folder] for a more comprehensive demonstration of
 Druid's existing functionality and widgets.


### PR DESCRIPTION
As discussed in #1748, although not implied, the README.md example isn't building if using the version mentioned below, 0.7.0. maybe this could avoid troubleshooting for a newcomer.