### PR TITLE
X11 shell locale detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - Fixed layout of scrollbar with very small viewports ([#1715] by [@andrewhickman])
 - Fixed `WindowLevel::Tooltip` on Windows platform ([#1737] by [@djeedai])
 - X11 backend now supports scaling([#1751] by [@Maan2003])
+- X11 backend now uses the platform locale ([#1756] by [@Maan2003])
 
 ### Visual
 
@@ -701,6 +702,7 @@ Last release without a changelog :(
 [#1737]: https://github.com/linebender/druid/pull/1737
 [#1743]: https://github.com/linebender/druid/pull/1743
 [#1751]: https://github.com/linebender/druid/pull/1751
+[#1756]: https://github.com/linebender/druid/pull/1756
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -504,12 +504,12 @@ impl Application {
         // from gettext manual
         // https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html#Locale-Environment-Variables
         var_non_empty("LANGUAGE")
+            // the LANGUAGE value is priority list seperated by :
+            // See: https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html#The-LANGUAGE-variable
+            .and_then(|locale| locale.split(':').next().map(String::from))
             .or_else(|| var_non_empty("LC_ALL"))
             .or_else(|| var_non_empty("LC_MESSAGES"))
             .or_else(|| var_non_empty("LANG"))
-            // the value is priority list seperated by :
-            // See: https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html#The-LANGUAGE-variable
-            .and_then(|locale| locale.split(':').next().map(String::from))
             .unwrap_or_else(|| "en-US".to_string())
     }
 

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -495,9 +495,22 @@ impl Application {
     }
 
     pub fn get_locale() -> String {
-        // TODO(x11/locales): implement Application::get_locale
-        tracing::warn!("Application::get_locale is currently unimplemented for X11 platforms. (defaulting to en-US)");
-        "en-US".into()
+        let var_non_empty = |var| match std::env::var(var) {
+            Ok(s) if s.is_empty() => None,
+            Ok(s) => Some(s),
+            Err(_) => None,
+        };
+
+        // from gettext manual
+        // https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html#Locale-Environment-Variables
+        var_non_empty("LANGUAGE")
+            .or_else(|| var_non_empty("LC_ALL"))
+            .or_else(|| var_non_empty("LC_MESSAGES"))
+            .or_else(|| var_non_empty("LANG"))
+            // the value is priority list seperated by :
+            // See: https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html#The-LANGUAGE-variable
+            .and_then(|locale| locale.split(':').next().map(String::from))
+            .unwrap_or_else(|| "en-US".to_string())
     }
 
     pub(crate) fn idle_pipe(&self) -> RawFd {


### PR DESCRIPTION
Based on [gettext manual](https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html#Locale-Environment-Variables).

Also on Linux, there is a priority list of locales rather than a single locale. Not sure if `Application::get_locale` should return a priority list.

Fixes: #938 