### PR TITLE
Supports accessing nested fields with lens macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -716,7 +716,7 @@ Last release without a changelog :(
 [#1755]: https://github.com/linebender/druid/pull/1755
 [#1756]: https://github.com/linebender/druid/pull/1756
 [#1761]: https://github.com/linebender/druid/pull/1761
-[#1763]: https://github.com/linebender/druid/pull/1763
+[#1764]: https://github.com/linebender/druid/pull/1764
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - GTK: added support for `content_insets` ([#1722] by [@jneem])
 - `chrono` feature with `Data` support for [chrono](https://docs.rs/chrono/) types ([#1743] by [@r-ml])
 - Text input handles Delete key ([#1746] by [@bjorn])
+- `lens` macro can access nested fields ([#1764] by [@Maan2003])
 
 ### Changed
 
@@ -715,6 +716,7 @@ Last release without a changelog :(
 [#1755]: https://github.com/linebender/druid/pull/1755
 [#1756]: https://github.com/linebender/druid/pull/1756
 [#1761]: https://github.com/linebender/druid/pull/1761
+[#1763]: https://github.com/linebender/druid/pull/1763
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid/src/lens/lens.rs
+++ b/druid/src/lens/lens.rs
@@ -283,18 +283,20 @@ where
 /// This is a convenience macro for constructing `Field` lenses for fields or indexable elements.
 ///
 /// ```
-/// struct Foo { x: u32 }
+/// struct Foo { x: Bar }
+/// struct Bar { y: [i32; 10] }
 /// let lens = druid::lens!(Foo, x);
 /// let lens = druid::lens!((u32, bool), 1);
 /// let lens = druid::lens!([u8], [4]);
+/// let lens = druid::lens!(Foo, x.y[5]);
 /// ```
 #[macro_export]
 macro_rules! lens {
     ($ty:ty, [$index:expr]) => {
         $crate::lens::Field::new::<$ty, _>(move |x| &x[$index], move |x| &mut x[$index])
     };
-    ($ty:ty, $field:tt) => {
-        $crate::lens::Field::new::<$ty, _>(move |x| &x.$field, move |x| &mut x.$field)
+    ($ty:ty, $($field:tt)*) => {
+        $crate::lens::Field::new::<$ty, _>(move |x| &x.$($field)*, move |x| &mut x.$($field)*)
     };
 }
 


### PR DESCRIPTION
Now this is valid

``` rust
struct Foo { x: Bar }
struct Bar { y: [i32; 10] }
lens!(Foo, x.y[5]);
```