### PR TITLE
Fix alignment offset for selection in TextBox

### DIFF
--- a/druid/src/text/input_component.rs
+++ b/druid/src/text/input_component.rs
@@ -719,7 +719,7 @@ impl<T: TextStorage + EditableText> EditSession<T> {
     }
 
     fn do_mouse_down(&mut self, point: Point, mods: Modifiers, count: u8) {
-        let point = point + Vec2::new(self.alignment_offset, 0.0);
+        let point = point - Vec2::new(self.alignment_offset, 0.0);
         let pos = self.layout.text_position_for_point(point);
         if mods.shift() {
             self.selection.active = pos;
@@ -735,7 +735,7 @@ impl<T: TextStorage + EditableText> EditSession<T> {
     }
 
     fn do_drag(&mut self, point: Point) {
-        let point = point + Vec2::new(self.alignment_offset, 0.0);
+        let point = point - Vec2::new(self.alignment_offset, 0.0);
         //FIXME: this should behave differently if we were double or triple clicked
         let pos = self.layout.text_position_for_point(point);
         let text = match self.layout.text() {


### PR DESCRIPTION
The alignment offset was accidentally added instead of subtracted from the cursor position.

Fixes #1767 