### PR TITLE
Support for open/save dialogs on x11.

### DIFF
--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -16,7 +16,7 @@ default-target = "x86_64-pc-windows-msvc"
 [features]
 default = ["gtk"]
 gtk = ["gio", "gdk", "gdk-sys", "glib", "glib-sys", "gtk-sys", "gtk-rs", "gdk-pixbuf"]
-x11 = ["x11rb", "nix", "cairo-sys-rs"]
+x11 = ["x11rb", "nix", "cairo-sys-rs", "serde", "zbus", "zvariant", "zvariant_derive"]
 # Implement HasRawWindowHandle for WindowHandle
 raw-win-handle = ["raw-window-handle"]
 
@@ -88,7 +88,11 @@ glib = { version = "0.10.1", optional = true }
 glib-sys = { version = "0.10.0", optional = true }
 gtk-sys = { version = "0.10.0", optional = true }
 nix = { version = "0.18.0", optional = true }
+serde = { version = "1.0", optional = true }
 x11rb = { version = "0.8.0", features = ["allow-unsafe-code", "present", "randr", "xfixes", "resource_manager", "cursor"], optional = true }
+zbus = { version = "2.0.0-beta.3", optional = true }
+zvariant = { version = "2.0.0-beta.3", optional = true }
+zvariant_derive = { version = "2.0.0-beta.3", optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 wasm-bindgen = "0.2.67"

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -33,6 +33,7 @@ use x11rb::xcb_ffi::XCBConnection;
 use crate::application::AppHandler;
 
 use super::clipboard::Clipboard;
+use super::dbus::DbusHandle;
 use super::util;
 use super::window::Window;
 
@@ -51,6 +52,7 @@ pub(crate) struct Application {
     /// `druid_shell::WindowHandle` to be `!Send` and `!Sync`.
     marker: std::marker::PhantomData<*mut XCBConnection>,
 
+    pub(crate) dbus: DbusHandle,
     /// The X11 resource database used to query dpi.
     pub(crate) rdb: Rc<ResourceDb>,
     pub(crate) cursors: Cursors,
@@ -158,6 +160,7 @@ impl Application {
 
         Ok(Application {
             connection,
+            dbus: DbusHandle::default(),
             rdb,
             screen_num: screen_num as i32,
             window_id,

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -33,7 +33,6 @@ use x11rb::xcb_ffi::XCBConnection;
 use crate::application::AppHandler;
 
 use super::clipboard::Clipboard;
-use super::dbus::DbusHandle;
 use super::util;
 use super::window::Window;
 
@@ -52,7 +51,6 @@ pub(crate) struct Application {
     /// `druid_shell::WindowHandle` to be `!Send` and `!Sync`.
     marker: std::marker::PhantomData<*mut XCBConnection>,
 
-    pub(crate) dbus: DbusHandle,
     /// The X11 resource database used to query dpi.
     pub(crate) rdb: Rc<ResourceDb>,
     pub(crate) cursors: Cursors,
@@ -160,7 +158,6 @@ impl Application {
 
         Ok(Application {
             connection,
-            dbus: DbusHandle::default(),
             rdb,
             screen_num: screen_num as i32,
             window_id,

--- a/druid-shell/src/platform/x11/dbus.rs
+++ b/druid-shell/src/platform/x11/dbus.rs
@@ -1,0 +1,264 @@
+//! This module contains functions for opening file dialogs using DBus.
+
+use std::collections::HashMap;
+use std::os::unix::ffi::OsStringExt;
+
+use tracing::warn;
+use zbus::{dbus_proxy, fdo, Connection};
+use zvariant::{OwnedObjectPath, OwnedValue};
+
+use super::window::{IdleHandle, IdleKind};
+use crate::{FileDialogOptions, FileDialogToken, FileInfo};
+
+// I made this struct to store, e.g., connection state and pending responses. But I'm getting
+// deadlocks when trying to use the connection, so for now just make a new connection each time.
+#[derive(Clone, Default)]
+pub struct DbusHandle {}
+
+fn response_thread(
+    conn: Connection,
+    idle: IdleHandle,
+    path: OwnedObjectPath,
+    tok: FileDialogToken,
+    open: bool,
+) -> fdo::Result<()> {
+    let path = path.into_inner();
+    loop {
+        let msg = conn.receive_message()?;
+        let msg_header = msg.header()?;
+        if msg_header.message_type()? == zbus::MessageType::Signal
+            && msg_header.member()? == Some("Response")
+        {
+            if let Some(reply_path) = msg.header()?.path()? {
+                if &path == reply_path {
+                    let response = msg.body::<ResponseResult<FileDialogResponse>>()?;
+                    let file_info = if let ResponseType::Success = response.0 {
+                        // FIXME: what are we supposed to do if there are multiple files?
+                        response.1.uris.first().and_then(|s| {
+                            // FIXME: we get a URI, but we want a path. There must be a less hacky
+                            // way to do this...
+                            if s.starts_with("file://") {
+                                Some(FileInfo {
+                                    path: s[7..].into(),
+                                })
+                            } else {
+                                None
+                            }
+                        })
+                    } else {
+                        None
+                    };
+                    /*
+                    idle.add_idle_callback(move |handler| {
+                        if let Some(handler) = handler.downcast_ref::<Box<dyn WinHandler>>() {
+                            handler.open_file(tok, file_info);
+                        }
+                    });
+                    */
+                    if open {
+                        idle.add_idle(IdleKind::OpenFile(tok, file_info));
+                    } else {
+                        idle.add_idle(IdleKind::SaveFile(tok, file_info));
+                    }
+                    return Ok(());
+                } else {
+                    warn!("got path {:?}, expected {:?}", reply_path, path);
+                }
+            }
+        }
+    }
+}
+
+impl DbusHandle {
+    pub fn open_file(
+        &self,
+        window: u32,
+        idle: IdleHandle,
+        options: FileDialogOptions,
+    ) -> fdo::Result<FileDialogToken> {
+        let connection = Connection::new_session()?;
+        let proxy = FileChooserProxy::new(&connection)?;
+
+        let title = options.title.clone().unwrap_or("Open file".to_owned());
+        let opts = OpenOptions::from(options);
+        let reply = proxy.open_file(&format!("x11:{}", window), &title, opts)?;
+        let tok = FileDialogToken::next();
+
+        std::thread::spawn(move || response_thread(connection, idle, reply, tok, true));
+
+        Ok(tok)
+    }
+
+    pub fn save_file(
+        &self,
+        window: u32,
+        idle: IdleHandle,
+        options: FileDialogOptions,
+    ) -> fdo::Result<FileDialogToken> {
+        let connection = Connection::new_session()?;
+        let proxy = FileChooserProxy::new(&connection)?;
+
+        let title = options.title.clone().unwrap_or("Save as".to_owned());
+        let opts = SaveOptions::from(options);
+        let reply = proxy.save_file(&format!("x11:{}", window), &title, opts)?;
+        let tok = FileDialogToken::next();
+
+        std::thread::spawn(move || response_thread(connection, idle, reply, tok, false));
+
+        Ok(tok)
+    }
+}
+
+/// The options supported by the freedesktop.org filechooser protocol. These are documented at
+/// https://flatpak.github.io/xdg-desktop-portal/portal-docs.html#gdbus-org.freedesktop.portal.FileChooser
+#[derive(zvariant_derive::SerializeDict, zvariant_derive::TypeDict)]
+// FIXME: the dbus_proxy macro makes me make this pub
+pub struct OpenOptions {
+    /// Label for the accept button. FDO says that mnemonic underlines are supported; does the
+    /// druid end use mnemonic underlines also? (TODO)
+    accept_label: Option<String>,
+    /// Whether the dialog should be modal. Ours are always modal.
+    modal: bool,
+    /// Do we allow selecting multiple files?
+    multiple: bool,
+    /// Whether to select folders instead of files.
+    directory: bool,
+    /// The list of allowed file filters.
+    filters: Vec<Filter>,
+    /// The default filter.
+    current_filter: Option<Filter>,
+}
+
+/// The options supported by the freedesktop.org filechooser protocol. These are documented at
+/// https://flatpak.github.io/xdg-desktop-portal/portal-docs.html#gdbus-org.freedesktop.portal.FileChooser
+#[derive(zvariant_derive::SerializeDict, zvariant_derive::TypeDict)]
+// FIXME: the dbus_proxy macro makes me make this pub
+pub struct SaveOptions {
+    /// Label for the accept button. FDO says that mnemonic underlines are supported; does the
+    /// druid end use mnemonic underlines also? (TODO)
+    accept_label: Option<String>,
+    /// Whether the dialog should be modal. Ours are always modal.
+    modal: bool,
+    /// The list of allowed file filters.
+    filters: Vec<Filter>,
+    /// The default filter.
+    current_filter: Option<Filter>,
+    /// The suggested filename.
+    current_name: Option<String>,
+    /// The starting directory.
+    current_folder: Option<Vec<u8>>,
+}
+
+/// A file filter.
+///
+/// The first argument is a description of the filter (e.g. "Images"). The second argument is a
+/// list of allowed file types. The `u32` determines the meaning of the string: FDO supports both
+/// mimetypes and glob patterns (but we only use glob patterns).
+#[derive(serde::Serialize, zvariant_derive::Type)]
+struct Filter(&'static str, Vec<(u32, String)>);
+
+impl From<crate::FileDialogOptions> for OpenOptions {
+    fn from(opts: crate::FileDialogOptions) -> OpenOptions {
+        OpenOptions {
+            accept_label: opts.button_text,
+            modal: true,
+            multiple: opts.multi_selection,
+            directory: opts.select_directories,
+            filters: opts
+                .allowed_types
+                .unwrap_or(Vec::new())
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            current_filter: opts.default_type.map(Into::into),
+        }
+    }
+}
+
+impl From<crate::FileDialogOptions> for SaveOptions {
+    fn from(opts: crate::FileDialogOptions) -> SaveOptions {
+        SaveOptions {
+            accept_label: opts.button_text,
+            modal: true,
+            filters: opts
+                .allowed_types
+                .unwrap_or(Vec::new())
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            current_filter: opts.default_type.map(Into::into),
+            current_name: opts.default_name,
+            current_folder: opts
+                .starting_directory
+                .map(|p| p.into_os_string().into_vec()),
+        }
+    }
+}
+
+impl From<crate::FileSpec> for Filter {
+    fn from(fs: crate::FileSpec) -> Filter {
+        Filter(
+            fs.name,
+            fs.extensions
+                .iter()
+                .map(|ext| (0, format!("*.{}", ext)))
+                .collect(),
+        )
+    }
+}
+
+/// The response from a DBus method call contains an error code, followed by the actual data we
+/// asked for.
+#[derive(serde::Deserialize, Debug)]
+struct ResponseResult<T>(ResponseType, T);
+
+/// The response to a file dialog request.
+#[derive(zvariant_derive::DeserializeDict, Debug)]
+struct FileDialogResponse {
+    /// The list of selected files.
+    uris: Vec<String>,
+    /// The DBus protocol allows for the file dialog to contain various combo-boxes. We don't use
+    /// them.
+    choices: Option<Vec<(String, String)>>,
+}
+
+impl zvariant::Type for FileDialogResponse {
+    fn signature() -> zvariant::Signature<'static> {
+        <HashMap<&str, OwnedValue>>::signature()
+    }
+}
+
+impl<T: zvariant::Type> zvariant::Type for ResponseResult<T> {
+    fn signature() -> zvariant::Signature<'static> {
+        <(u32, T)>::signature()
+    }
+}
+
+#[dbus_proxy(
+    interface = "org.freedesktop.portal.FileChooser",
+    default_service = "org.freedesktop.portal.Desktop",
+    default_path = "/org/freedesktop/portal/desktop"
+)]
+trait FileChooser {
+    fn open_file(
+        &self,
+        parent_window: &str,
+        title: &str,
+        options: OpenOptions,
+    ) -> fdo::Result<OwnedObjectPath>;
+
+    fn save_file(
+        &self,
+        parent_window: &str,
+        title: &str,
+        options: SaveOptions,
+    ) -> fdo::Result<OwnedObjectPath>;
+}
+
+#[derive(Clone, Copy, Debug, serde::Deserialize, zvariant_derive::Type)]
+#[repr(u32)]
+enum ResponseType {
+    Success = 0,
+    Cancelled = 1,
+    Other = 2,
+}

--- a/druid-shell/src/platform/x11/mod.rs
+++ b/druid-shell/src/platform/x11/mod.rs
@@ -35,7 +35,7 @@ mod util;
 
 pub mod application;
 pub mod clipboard;
-mod dbus;
+mod dialog;
 pub mod error;
 pub mod keycodes;
 pub mod menu;

--- a/druid-shell/src/platform/x11/mod.rs
+++ b/druid-shell/src/platform/x11/mod.rs
@@ -35,6 +35,7 @@ mod util;
 
 pub mod application;
 pub mod clipboard;
+mod dbus;
 pub mod error;
 pub mod keycodes;
 pub mod menu;

--- a/druid/examples/open_save.rs
+++ b/druid/examples/open_save.rs
@@ -59,7 +59,7 @@ fn ui_builder() -> impl Widget<String> {
         ctx.submit_command(druid::commands::SHOW_SAVE_PANEL.with(save_dialog_options.clone()))
     });
     let open = Button::new("Open").on_click(move |ctx, _, _| {
-        ctx.submit_command(druid::commands::SHOW_SAVE_PANEL.with(open_dialog_options.clone()))
+        ctx.submit_command(druid::commands::SHOW_OPEN_PANEL.with(open_dialog_options.clone()))
     });
 
     let mut col = Flex::column();


### PR DESCRIPTION
This is a first stab at doing open/save in the x11 backend (addressing #936). Very much in a WIP state, but I'm opening this because I have a few unresolved questions.

This is using the freedesktop.org DBus specification to launch a native file dialog, as suggested in #936. Of course it would be nice to have a druid-native dialog also, but this has the advantages of (a) being less work and (b) having support in the flatpak sandbox.

## Dependencies

This introduces a number of new dependencies:
- `zbus`/`zvariant`/`serde`: these are pretty much required for using DBus, I think.
- `zvariant_derive`: could be avoided; it's currently saving about 50 lines of serde boilerplate.

I'm not currently depending on the [`ashpd`](https://github.com/bilelmoussaoui/ashpd), although I'd kind of like to. It would save probably around 100 lines right now, but has some advantages and disadvantages:
- it's new, and doesn't seem to be used much yet
- on the other hand, the maintainer is super responsive (and has been to me in the past)
- it has a bunch of stuff we don't need
- but we might want some of them in the future (e.g. notifications, trash, printing)