### PR TITLE
Correctly clip the TextBox

### DIFF
--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -576,7 +576,7 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
         };
 
         // Paint the background
-        let clip_rect = Size::new(size.width - border_width, size.height)
+        let clip_rect = size
             .to_rect()
             .inset(-border_width / 2.0)
             .to_rounded_rect(env.get(theme::TEXTBOX_BORDER_RADIUS));


### PR DESCRIPTION
By adjusting only the x component of the size before turning it into a rectangle, the right side of the rectangle gets moved to the left, which allowed the text to peak out on the right side. Inset already seems to do what subtracting the border width there was possibly intended to do, so just using the unadjusted size and then later insetting, resolves the problem entirely.

Here for reference the bug that this resolves:

![https://i.imgur.com/Kvr1n4T.png](https://i.imgur.com/Kvr1n4T.png)