### PR TITLE
Give a WinHandler to the idle callback.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - Lens implemented for tuples of Lenses of length 2-8, Tuple2 removed ([#1654] by [@Maan2003])
 - Window size and positioning code is now in display points ([#1713] by [@jneem])
 - Update look and feel of controls when disabled ([#1717] by [@xarvic])
+- Change the signature of `add_idle_callback` ([#1787] by [@jneem])
 
 ### Deprecated
 
@@ -722,6 +723,7 @@ Last release without a changelog :(
 [#1761]: https://github.com/linebender/druid/pull/1761
 [#1764]: https://github.com/linebender/druid/pull/1764
 [#1772]: https://github.com/linebender/druid/pull/1772
+[#1787]: https://github.com/linebender/druid/pull/1787
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid-shell/src/common_util.rs
+++ b/druid-shell/src/common_util.rs
@@ -14,7 +14,6 @@
 
 //! Common functions used by the backends
 
-use std::any::Any;
 use std::cell::Cell;
 use std::num::NonZeroU64;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -23,6 +22,7 @@ use std::time::Duration;
 use instant::Instant;
 
 use crate::kurbo::Point;
+use crate::WinHandler;
 
 // This is the default timing on windows.
 const MULTI_CLICK_INTERVAL: Duration = Duration::from_millis(500);
@@ -52,11 +52,11 @@ pub fn strip_access_key(raw_menu_text: &str) -> String {
 
 /// A trait for implementing the boxed callback hack.
 pub(crate) trait IdleCallback: Send {
-    fn call(self: Box<Self>, a: &dyn Any);
+    fn call(self: Box<Self>, a: &mut dyn WinHandler);
 }
 
-impl<F: FnOnce(&dyn Any) + Send> IdleCallback for F {
-    fn call(self: Box<F>, a: &dyn Any) {
+impl<F: FnOnce(&mut dyn WinHandler) + Send> IdleCallback for F {
+    fn call(self: Box<F>, a: &mut dyn WinHandler) {
         (*self)(a)
     }
 }

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -14,7 +14,6 @@
 
 //! GTK window creation and management.
 
-use std::any::Any;
 use std::cell::{Cell, RefCell};
 use std::convert::{TryFrom, TryInto};
 use std::ffi::c_void;
@@ -1206,7 +1205,7 @@ impl IdleHandle {
     /// priority than other UI events, but that's not necessarily the case.
     pub fn add_idle_callback<F>(&self, callback: F)
     where
-        F: FnOnce(&dyn Any) + Send + 'static,
+        F: FnOnce(&mut dyn WinHandler) + Send + 'static,
     {
         let mut queue = self.idle_queue.lock().unwrap();
         if let Some(state) = self.state.upgrade() {
@@ -1239,7 +1238,7 @@ fn run_idle(state: &Arc<WindowState>) -> glib::source::Continue {
 
         for item in queue {
             match item {
-                IdleKind::Callback(it) => it.call(handler.as_any()),
+                IdleKind::Callback(it) => it.call(handler),
                 IdleKind::Token(it) => handler.idle(it),
             }
         }

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -16,7 +16,6 @@
 
 #![allow(non_snake_case)]
 
-use std::any::Any;
 use std::ffi::c_void;
 use std::mem;
 use std::sync::{Arc, Mutex, Weak};
@@ -904,7 +903,7 @@ extern "C" fn run_idle(this: &mut Object, _: Sel) {
     );
     for item in queue {
         match item {
-            IdleKind::Callback(it) => it.call(view_state.handler.as_any()),
+            IdleKind::Callback(it) => it.call(&mut *view_state.handler),
             IdleKind::Token(it) => {
                 view_state.handler.as_mut().idle(it);
             }
@@ -1404,7 +1403,7 @@ impl IdleHandle {
     /// priority than other UI events, but that's not necessarily the case.
     pub fn add_idle_callback<F>(&self, callback: F)
     where
-        F: FnOnce(&dyn Any) + Send + 'static,
+        F: FnOnce(&mut dyn WinHandler) + Send + 'static,
     {
         self.add_idle(IdleKind::Callback(Box::new(callback)));
     }

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -16,7 +16,6 @@
 
 #![allow(non_snake_case, clippy::cast_lossless)]
 
-use std::any::Any;
 use std::cell::{Cell, RefCell};
 use std::mem;
 use std::panic::Location;
@@ -1226,7 +1225,7 @@ impl WndProc for MyWndProc {
                     let queue = self.handle.borrow().take_idle_queue();
                     for callback in queue {
                         match callback {
-                            IdleKind::Callback(it) => it.call(s.handler.as_any()),
+                            IdleKind::Callback(it) => it.call(&mut *s.handler),
                             IdleKind::Token(token) => s.handler.idle(token),
                         }
                     }
@@ -2173,7 +2172,7 @@ impl IdleHandle {
     /// which means it won't be scheduled if the window is closed.
     pub fn add_idle_callback<F>(&self, callback: F)
     where
-        F: FnOnce(&dyn Any) + Send + 'static,
+        F: FnOnce(&mut dyn WinHandler) + Send + 'static,
     {
         let mut queue = self.queue.lock().unwrap();
         if queue.is_empty() {

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -14,7 +14,6 @@
 
 //! X11 window creation and window management.
 
-use std::any::Any;
 use std::cell::{Cell, RefCell};
 use std::collections::BinaryHeap;
 use std::convert::{TryFrom, TryInto};
@@ -1147,7 +1146,7 @@ impl Window {
             for callback in queue {
                 match callback {
                     IdleKind::Callback(f) => {
-                        f.call(handler.as_any());
+                        f.call(handler);
                     }
                     IdleKind::Token(tok) => {
                         handler.idle(tok);
@@ -1424,7 +1423,7 @@ impl IdleHandle {
 
     pub fn add_idle_callback<F>(&self, callback: F)
     where
-        F: FnOnce(&dyn Any) + Send + 'static,
+        F: FnOnce(&mut dyn WinHandler) + Send + 'static,
     {
         self.queue
             .lock()

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -97,7 +97,7 @@ impl IdleHandle {
     /// priority than other UI events, but that's not necessarily the case.
     pub fn add_idle<F>(&self, callback: F)
     where
-        F: FnOnce(&dyn Any) + Send + 'static,
+        F: FnOnce(&mut dyn WinHandler) + Send + 'static,
     {
         self.0.add_idle_callback(callback)
     }


### PR DESCRIPTION
I asked about this on zulip and no one replied, so I'm guessing that the reasons for the existing signature of `add_idle_callback` were lost in the mists of time. It used to be that an idle callback got a `&dyn Any`, but that `Any` is always just the `WinHandler` (so, `DruidHandler` in all `druid` apps). Since `&DruidHandler` isn't much use (all the interesting things are `&mut`), I'm guessing that no one was really using it.