### PR TITLE
Builder-style documentation annotation

### DIFF
--- a/druid/src/widget/image.rs
+++ b/druid/src/widget/image.rs
@@ -98,7 +98,7 @@ impl Image {
         }
     }
 
-    /// A builder-style method for specifying the fill strategy.
+    /// Builder-style method for specifying the fill strategy.
     #[inline]
     pub fn fill_mode(mut self, mode: FillStrat) -> Self {
         self.fill = mode;
@@ -113,7 +113,7 @@ impl Image {
         // Invalidation not necessary
     }
 
-    /// A builder-style method for specifying the interpolation strategy.
+    /// Builder-style method for specifying the interpolation strategy.
     #[inline]
     pub fn interpolation_mode(mut self, interpolation: InterpolationMode) -> Self {
         self.interpolation = interpolation;
@@ -128,7 +128,7 @@ impl Image {
         // Invalidation not necessary
     }
 
-    /// Set the area of the image that will be displayed.
+    /// Builder-style method for setting the area of the image that will be displayed.
     ///
     /// If `None`, then the whole image will be displayed.
     #[inline]

--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -42,7 +42,7 @@ impl Svg {
         }
     }
 
-    /// A builder-style method for specifying the fill strategy.
+    /// Builder-style method for specifying the fill strategy.
     pub fn fill_mode(mut self, mode: FillStrat) -> Self {
         self.fill = mode;
         self

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -684,6 +684,9 @@ impl<T: Data> AppState<T> {
             _ if cmd.is(sys_cmd::SHOW_WINDOW) => {
                 tracing::warn!("SHOW_WINDOW command must target a window.")
             }
+            _ if cmd.is(sys_cmd::SHOW_OPEN_PANEL) => {
+                tracing::warn!("SHOW_OPEN_PANEL command must target a window.")
+            }
             _ => {
                 let handled = self.inner.borrow_mut().dispatch_cmd(cmd.clone());
                 if !handled.is_handled() && cmd.must_be_used() {


### PR DESCRIPTION
3 things...

1. I'm a git noob, and don't know why 3e66483 and 5a95fbf are showing up, but I also don't know how to get rid of them.

1. The important change is in line 131 of druid/src/widget/image.rs because that one didn't mention Builder-style at all.
    - It was in making that change that I realised every other use of Builder-style documentation did not contain the article 'a'

1. Feel free to reject this PR and make the changes yourself, if you think they're worth doing but don't want to pollute the commit history with my mess