### PR TITLE
[web backend] Limit max level log to debug and update tracing-wasm

### DIFF
--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -69,7 +69,7 @@ im = { version = "15.0.0", optional = true }
 usvg = { version = "0.12.0", optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
-tracing-wasm = { version = "0.1.0" }
+tracing-wasm = { version = "0.2.0" }
 console_error_panic_hook = { version = "0.1.6" }
 
 [dev-dependencies]
@@ -79,6 +79,8 @@ tempfile = "=3.1.0"
 piet-common = { version = "=0.4.1", features = ["png"] }
 pulldown-cmark = { version = "0.8", default-features = false }
 test-env-log = { version = "0.2.5", features = ["trace"], default-features = false }
+# test-env-log needs it
+tracing-subscriber = { version = "0.2.15", features = ["env-filter"] }
 
 [target.'cfg(not(target_arch="wasm32"))'.dev-dependencies]
 open = "1.6"

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -203,9 +203,10 @@ impl<T: Data> AppLauncher<T> {
         #[cfg(target_arch = "wasm32")]
         {
             console_error_panic_hook::set_once();
-            // tracing_wasm doesn't let us filter by level, but chrome/firefox devtools can
-            // already do that anyway
-            tracing_wasm::set_as_global_default();
+            let config = tracing_wasm::WASMLayerConfigBuilder::new()
+                .set_max_level(tracing::Level::DEBUG)
+                .build();
+            tracing_wasm::set_as_global_default_with_config(config)
         }
         self
     }


### PR DESCRIPTION
We were logging everything to console, even the trace events. This was a huge performance issue in Firefox(keyboard latency of ~1sec in disabled example!)