### PR TITLE
Snap the TextBox cursor to the pixel grid

### DIFF
--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -606,11 +606,15 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
 
             let padding_offset = Vec2::new(textbox_insets.x0, textbox_insets.y0);
 
-            let cursor = if data.is_empty() {
+            let mut cursor = if data.is_empty() {
                 cursor_line + padding_offset
             } else {
                 cursor_line + padding_offset - self.inner.offset()
             };
+
+            // Snap the cursor to the pixel grid so it stays sharp.
+            cursor.p0.x = cursor.p0.x.trunc() + 0.5;
+            cursor.p1.x = cursor.p0.x;
 
             ctx.with_save(|ctx| {
                 ctx.clip(clip_rect);


### PR DESCRIPTION
This snaps the cursor of the TextBox to the grid to ensure it's always rendered as sharp as possible.

## Screenshot:

Top is with grid snapping, bottom without.

![https://i.imgur.com/3YixR6D.png](https://i.imgur.com/3YixR6D.png)
