### PR TITLE
Don't collect invalid rects into vector

### DIFF
--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -424,7 +424,7 @@ impl<T: Data> Window<T> {
             self.layout(queue, data, env);
         }
 
-        for r in invalid.rects().to_owned() {
+        for &r in invalid.rects() {
             piet.clear(
                 Some(r),
                 if self.transparent {


### PR DESCRIPTION
It's a slice that we can just easily iterate over. Collecting into an owned Vec might make sense to solve some borrow issue, but there is none here.