### PR TITLE
Add request_local_layout

### DIFF
--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -112,6 +112,7 @@ pub struct LayoutCtx<'a, 'b> {
     pub(crate) state: &'a mut ContextState<'b>,
     pub(crate) widget_state: &'a mut WidgetState,
     pub(crate) mouse_pos: Option<Point>,
+    pub(crate) needs_layout: bool,
 }
 
 /// Z-order paint operations with transformations.
@@ -377,6 +378,28 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
     pub fn request_layout(&mut self) {
         trace!("request_layout");
         self.widget_state.needs_layout = true;
+    }
+
+    /// Request a local re-layout
+    ///
+    /// This only triggers a re-laoyout on this Widget
+    /// and its immediate parents all the way up to the root Widget.
+    /// No paint invlidation is done, so the caller needs to take care of it.
+    ///
+    /// As the sibling Widgets' sizes wouldn't be recalculated,
+    /// it could cause a bad layout if this Widget's size is changed.
+    ///
+    /// One good example to use this is in a scroll. You can call this
+    /// when the scroll content's size is changed to update the state of
+    /// the scroll widget, without needs to re-layout and redraw the whole window,
+    /// which can be expensive.
+    ///
+    /// Another use case would be if you've got some kind of "floating" Widget.
+    /// Because of the fact it's "floating", the origin and size of it doens't
+    /// affect any other Widgets.
+    pub fn request_local_layout(&mut self) {
+        trace!("request_local_layout");
+        self.widget_state.needs_local_layout = true;
     }
 
     /// Request an animation frame.

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -127,6 +127,10 @@ pub(crate) struct WidgetState {
 
     pub(crate) needs_layout: bool,
 
+    pub(crate) child_needs_local_layout: bool,
+
+    pub(crate) needs_local_layout: bool,
+
     /// Because of some scrolling or something, `parent_window_origin` needs to be updated.
     pub(crate) needs_window_origin: bool,
 
@@ -559,7 +563,16 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             return Size::ZERO;
         }
 
+        let needs_layout =
+            ctx.needs_layout | self.state.needs_layout | self.state.needs_local_layout;
+
+        if !needs_layout && !self.state.child_needs_local_layout {
+            return self.state.size;
+        }
+
         self.state.needs_layout = false;
+        self.state.needs_local_layout = false;
+        self.state.child_needs_local_layout = false;
         self.state.needs_window_origin = false;
         self.state.is_expecting_set_origin_call = true;
 
@@ -572,6 +585,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             widget_state: &mut self.state,
             state: ctx.state,
             mouse_pos: child_mouse_pos,
+            needs_layout,
         };
 
         let new_size = self.inner.layout(&mut child_ctx, bc, data, env);
@@ -1214,6 +1228,8 @@ impl WidgetState {
             baseline_offset: 0.0,
             is_hot: false,
             needs_layout: false,
+            needs_local_layout: false,
+            child_needs_local_layout: false,
             needs_window_origin: false,
             is_active: false,
             has_active: false,
@@ -1276,6 +1292,8 @@ impl WidgetState {
         child_state.invalid.clear();
 
         self.needs_layout |= child_state.needs_layout;
+        self.child_needs_local_layout |= child_state.needs_local_layout;
+        self.child_needs_local_layout |= child_state.child_needs_local_layout;
         self.needs_window_origin |= child_state.needs_window_origin;
         self.request_anim |= child_state.request_anim;
         self.children_disabled_changed |= child_state.children_disabled_changed;


### PR DESCRIPTION
When called from a widget,
it only triggers a re-laoyout on this Widget
and its immediate parents all the way up to the root Widget.
No paint invlidation is done, so the caller needs to take care of it.

As the sibling Widgets' sizes wouldn't be recalculated,
it could cause a bad layout if this Widget's size is changed.

One good example to use this is in a scroll. You can call this
when the scroll content's size is changed to update the state of
the scroll widget, without needs to re-layout and redraw the whole window,
which can be expensive.

Another use case would be if you've got some kind of "floating" Widget.
Because of the fact it's "floating", the origin and size of it doens't
affect any other Widgets.