### PR TITLE
Add `Scroll` widget snap feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - `chrono` feature with `Data` support for [chrono](https://docs.rs/chrono/) types ([#1743] by [@r-ml])
 - Text input handles Delete key ([#1746] by [@bjorn])
 - `lens` macro can access nested fields ([#1764] by [@Maan2003])
-- `Scroll` widget: add the ability to snap the view to the most recent input ([#] by [@becky112358])
+- `Scroll` widget: add the ability to snap the view to the most recent input ([#1798] by [@becky112358])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - `chrono` feature with `Data` support for [chrono](https://docs.rs/chrono/) types ([#1743] by [@r-ml])
 - Text input handles Delete key ([#1746] by [@bjorn])
 - `lens` macro can access nested fields ([#1764] by [@Maan2003])
+- `Scroll` widget: add the ability to snap the view to the most recent input ([#] by [@becky112358])
 
 ### Changed
 
@@ -482,6 +483,7 @@ Last release without a changelog :(
 [@r-ml]: https://github.com/r-ml
 [@djeedai]: https://github.com/djeedai
 [@bjorn]: https://github.com/bjorn
+[@becky112358]: https://github.com/becky112358
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -726,6 +726,7 @@ Last release without a changelog :(
 [#1764]: https://github.com/linebender/druid/pull/1764
 [#1772]: https://github.com/linebender/druid/pull/1772
 [#1787]: https://github.com/linebender/druid/pull/1787
+[#1798]: https://github.com/linebender/druid/pull/1798
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid/examples/scroll_snap.rs
+++ b/druid/examples/scroll_snap.rs
@@ -1,0 +1,91 @@
+use std::sync::Arc;
+
+use druid::widget::{Button, Flex, Label, List, RadioGroup, Scroll};
+use druid::{
+    theme, AppLauncher, Color, Data, Env, FontDescriptor, FontWeight, Lens, Widget, WidgetExt,
+    WindowDesc,
+};
+
+const WINDOW_SIZE: f64 = 200.0;
+const WIDGET_SPACING: f64 = 20.0;
+const COLOR_CLEAR: Color = Color::rgb8(0xff, 0x30, 0x30);
+
+#[derive(Clone, Data, Lens)]
+struct ScrollSnap {
+    a_long_list_of_numbers: Arc<Vec<ScrollSnapMember>>,
+    next_number: u32,
+    snap: bool,
+}
+
+#[derive(Clone, Data)]
+struct ScrollSnapMember {
+    a_single_number: u32,
+}
+
+fn main() {
+    let window = WindowDesc::new(build_window())
+        .title("Window Snap")
+        .window_size((WINDOW_SIZE, WINDOW_SIZE));
+
+    let initial_state = ScrollSnap {
+        a_long_list_of_numbers: Arc::new(Vec::new()),
+        next_number: 0,
+        snap: true,
+    };
+
+    AppLauncher::with_window(window)
+        .configure_env(|env, _| env.set(theme::UI_FONT, FontDescriptor::default()))
+        .launch(initial_state)
+        .expect("Failed to launch application");
+}
+
+fn build_window() -> impl Widget<ScrollSnap> {
+    Flex::column()
+        .with_child(build_button_add())
+        .with_flex_child(build_list(), 1.0)
+        .with_child(build_buttons_snap_subtract())
+}
+
+fn build_button_add() -> impl Widget<ScrollSnap> {
+    Button::new("Click me!").on_click(|_, data: &mut ScrollSnap, _| {
+        Arc::make_mut(&mut data.a_long_list_of_numbers).push(ScrollSnapMember {
+            a_single_number: data.next_number,
+        });
+        data.next_number += 1;
+    })
+}
+
+fn build_list() -> impl Widget<ScrollSnap> {
+    Flex::column().with_flex_child(
+        Scroll::new(List::new(build_individual_item).lens(ScrollSnap::a_long_list_of_numbers))
+            .vertical()
+            .with_snap_vertical(|data: &ScrollSnap, _| data.snap),
+        1.0,
+    )
+}
+
+fn build_individual_item() -> impl Widget<ScrollSnapMember> {
+    Label::new(|data: &ScrollSnapMember, _env: &Env| data.a_single_number.to_string())
+        .fix_width(40.0)
+}
+
+fn build_buttons_snap_subtract() -> impl Widget<ScrollSnap> {
+    let pause = RadioGroup::new(vec![("||", false)]).lens(ScrollSnap::snap);
+
+    let snap = RadioGroup::new(vec![("▼", true)]).lens(ScrollSnap::snap);
+
+    let clear_x = Label::new("X")
+        .with_font(FontDescriptor::default().with_weight(FontWeight::BOLD))
+        .with_text_color(COLOR_CLEAR);
+
+    let clear_button = Button::from_label(clear_x).on_click(move |_, data: &mut ScrollSnap, _| {
+        data.a_long_list_of_numbers = Arc::new(Vec::new())
+    });
+
+    Flex::row()
+        .with_child(pause)
+        .with_spacer(WIDGET_SPACING)
+        .with_child(snap)
+        .with_spacer(WIDGET_SPACING)
+        .with_child(clear_button)
+}

--- a/druid/examples/scroll_snap.rs
+++ b/druid/examples/scroll_snap.rs
@@ -22,7 +22,7 @@ struct ScrollSnapMember {
     a_single_number: u32,
 }
 
-fn main() {
+pub fn main() {
     let window = WindowDesc::new(build_window())
         .title("Window Snap")
         .window_size((WINDOW_SIZE, WINDOW_SIZE));

--- a/druid/examples/web/src/lib.rs
+++ b/druid/examples/web/src/lib.rs
@@ -74,6 +74,7 @@ impl_example!(multiwin);
 impl_example!(open_save);
 impl_example!(panels.unwrap());
 impl_example!(scroll_colors);
+impl_example!(scroll_snap);
 impl_example!(scroll);
 impl_example!(split_demo);
 impl_example!(styled_text.unwrap());


### PR DESCRIPTION
For the `Scroll` widget, add the ability such that whenever the scrolled data changes, the view snaps to view the most recent data.

Add an example demonstrating use of this feature.