### PR TITLE
x11: Add support for custom cursors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - `chrono` feature with `Data` support for [chrono](https://docs.rs/chrono/) types ([#1743] by [@r-ml])
 - Text input handles Delete key ([#1746] by [@bjorn])
 - `lens` macro can access nested fields ([#1764] by [@Maan2003])
+- X11 backend now supports custom cursors ([#1800] by [@psychon])
 
 ### Changed
 
@@ -724,6 +725,7 @@ Last release without a changelog :(
 [#1764]: https://github.com/linebender/druid/pull/1764
 [#1772]: https://github.com/linebender/druid/pull/1772
 [#1787]: https://github.com/linebender/druid/pull/1787
+[#1800]: https://github.com/linebender/druid/pull/1800
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - `chrono` feature with `Data` support for [chrono](https://docs.rs/chrono/) types ([#1743] by [@r-ml])
 - Text input handles Delete key ([#1746] by [@bjorn])
 - `lens` macro can access nested fields ([#1764] by [@Maan2003])
-- X11 backend now supports custom cursors ([#1800] by [@psychon])
+- X11 backend now supports custom cursors ([#1801] by [@psychon])
 
 ### Changed
 
@@ -725,7 +725,7 @@ Last release without a changelog :(
 [#1764]: https://github.com/linebender/druid/pull/1764
 [#1772]: https://github.com/linebender/druid/pull/1772
 [#1787]: https://github.com/linebender/druid/pull/1787
-[#1800]: https://github.com/linebender/druid/pull/1800
+[#1801]: https://github.com/linebender/druid/pull/1800
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -88,7 +88,7 @@ glib = { version = "0.10.1", optional = true }
 glib-sys = { version = "0.10.0", optional = true }
 gtk-sys = { version = "0.10.0", optional = true }
 nix = { version = "0.18.0", optional = true }
-x11rb = { version = "0.8.0", features = ["allow-unsafe-code", "present", "render", "randr", "xfixes", "resource_manager", "cursor", "image"], optional = true }
+x11rb = { version = "0.8.0", features = ["allow-unsafe-code", "present", "render", "randr", "xfixes", "resource_manager", "cursor"], optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 wasm-bindgen = "0.2.67"

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -88,7 +88,7 @@ glib = { version = "0.10.1", optional = true }
 glib-sys = { version = "0.10.0", optional = true }
 gtk-sys = { version = "0.10.0", optional = true }
 nix = { version = "0.18.0", optional = true }
-x11rb = { version = "0.8.0", features = ["allow-unsafe-code", "present", "randr", "xfixes", "resource_manager", "cursor"], optional = true }
+x11rb = { version = "0.8.0", features = ["allow-unsafe-code", "present", "render", "randr", "xfixes", "resource_manager", "cursor", "image"], optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 wasm-bindgen = "0.2.67"

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -22,8 +22,9 @@ use std::rc::Rc;
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Error};
-use x11rb::connection::Connection;
+use x11rb::connection::{Connection, RequestConnection};
 use x11rb::protocol::present::ConnectionExt as _;
+use x11rb::protocol::render::{self, ConnectionExt as _, Pictformat};
 use x11rb::protocol::xfixes::ConnectionExt as _;
 use x11rb::protocol::xproto::{self, ConnectionExt, CreateWindowAux, EventMask, WindowClass};
 use x11rb::protocol::Event;
@@ -83,6 +84,8 @@ pub(crate) struct Application {
     idle_write: RawFd,
     /// The major opcode of the Present extension, if it is supported.
     present_opcode: Option<u8>,
+    /// Support for the render extension in at least version 0.5?
+    render_argb32_pictformat_cursor: Option<Pictformat>,
 }
 
 /// The mutable `Application` state.
@@ -138,6 +141,36 @@ impl Application {
             }
         };
 
+        let pictformats = connection.render_query_pict_formats()?;
+        let render_create_cursor_supported = match connection.extension_information(render::X11_EXTENSION_NAME)?
+                .and_then(|_| connection.render_query_version(0, 5).ok())
+                .map(|cookie| cookie.reply())
+                .transpose()? {
+            Some(version) if version.major_version >= 1 || version.minor_version >= 5 => true,
+            _ => false,
+        };
+        let render_argb32_pictformat_cursor = if render_create_cursor_supported {
+            pictformats.reply()?
+                .formats
+                .iter()
+                .find(|format| {
+                    format.type_ == render::PictType::DIRECT
+                        && format.depth == 32
+                        && format.direct.red_shift == 16
+                        && format.direct.red_mask == 0xff
+                        && format.direct.green_shift == 8
+                        && format.direct.green_mask == 0xff
+                        && format.direct.blue_shift == 0
+                        && format.direct.blue_mask == 0xff
+                        && format.direct.alpha_shift == 0
+                        && format.direct.alpha_mask == 0xff
+                })
+                .map(|format| format.id)
+        } else {
+            drop(pictformats);
+            None
+        };
+
         let handle = x11rb::cursor::Handle::new(connection.as_ref(), screen_num, &rdb)?.reply()?;
         let load_cursor = |cursor| {
             handle
@@ -167,6 +200,7 @@ impl Application {
             idle_write,
             present_opcode,
             marker: std::marker::PhantomData,
+            render_argb32_pictformat_cursor,
         })
     }
 
@@ -215,6 +249,12 @@ impl Application {
     #[inline]
     pub(crate) fn present_opcode(&self) -> Option<u8> {
         self.present_opcode
+    }
+
+    /// Return the ARGB32 pictformat of the server, but only if RENDER's CreateCursor is supported
+    #[inline]
+    pub(crate) fn render_argb32_pictformat_cursor(&self) -> Option<Pictformat> {
+        self.render_argb32_pictformat_cursor
     }
 
     fn create_event_window(conn: &Rc<XCBConnection>, screen_num: i32) -> Result<u32, Error> {

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -142,15 +142,18 @@ impl Application {
         };
 
         let pictformats = connection.render_query_pict_formats()?;
-        let render_create_cursor_supported = match connection.extension_information(render::X11_EXTENSION_NAME)?
-                .and_then(|_| connection.render_query_version(0, 5).ok())
-                .map(|cookie| cookie.reply())
-                .transpose()? {
+        let render_create_cursor_supported = match connection
+            .extension_information(render::X11_EXTENSION_NAME)?
+            .and_then(|_| connection.render_query_version(0, 5).ok())
+            .map(|cookie| cookie.reply())
+            .transpose()?
+        {
             Some(version) if version.major_version >= 1 || version.minor_version >= 5 => true,
             _ => false,
         };
         let render_argb32_pictformat_cursor = if render_create_cursor_supported {
-            pictformats.reply()?
+            pictformats
+                .reply()?
                 .formats
                 .iter()
                 .find(|format| {

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -162,7 +162,7 @@ impl Application {
                         && format.direct.green_mask == 0xff
                         && format.direct.blue_shift == 0
                         && format.direct.blue_mask == 0xff
-                        && format.direct.alpha_shift == 0
+                        && format.direct.alpha_shift == 24
                         && format.direct.alpha_mask == 0xff
                 })
                 .map(|format| format.id)

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -142,15 +142,12 @@ impl Application {
         };
 
         let pictformats = connection.render_query_pict_formats()?;
-        let render_create_cursor_supported = match connection
+        let render_create_cursor_supported = matches!(connection
             .extension_information(render::X11_EXTENSION_NAME)?
             .and_then(|_| connection.render_query_version(0, 5).ok())
             .map(|cookie| cookie.reply())
-            .transpose()?
-        {
-            Some(version) if version.major_version >= 1 || version.minor_version >= 5 => true,
-            _ => false,
-        };
+            .transpose()?,
+            Some(version) if version.major_version >= 1 || version.minor_version >= 5);
         let render_argb32_pictformat_cursor = if render_create_cursor_supported {
             pictformats
                 .reply()?


### PR DESCRIPTION
This adds custom cursor support to the X11 backend, fixing an open todo from #1755.

Half of the added code is "RENDER initialisation" (is the necessary RENDER version supported? What is the id of the standard ARGB32 format?). The other half of the code "upload this image to the X11 server". I guess the later could be simplified somehow, but I was lazy and did it "manually". This could also be made faster, but I don't think creating cursors is performance critical...

Oh and: Nothing ever deletes custom cursors, so they stay around forever, eating memory in the X11 server. I wonder if one can make the X11 server go out-of-memory with cursors...

This code is completely untested since I can't build druid and thus cannot run the cursor example due to a too old Rust compiler.