### PR TITLE
druid: update usvg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ You can find its changes [documented below](#070---2021-01-01).
 
 - Updated to x11rb 0.8.0. ([#1519] by [@psychon])
 - Updated fluent-bundle to 0.15.1 and fluent syntax to 0.11.0 ([#1772] by [@r-ml])
+- Updated usvg to 0.14.1 ([#1802] by [@r-ml])
 
 ### Outside News
 
@@ -724,6 +725,7 @@ Last release without a changelog :(
 [#1764]: https://github.com/linebender/druid/pull/1764
 [#1772]: https://github.com/linebender/druid/pull/1772
 [#1787]: https://github.com/linebender/druid/pull/1787
+[#1802]: https://github.com/linebender/druid/pull/1802
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -66,7 +66,7 @@ instant = { version = "0.1.6", features = ["wasm-bindgen"] }
 # Optional dependencies
 chrono = { version = "0.4.19", optional = true }
 im = { version = "15.0.0", optional = true }
-usvg = { version = "0.12.0", optional = true }
+usvg = { version = "0.14.1", optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 tracing-wasm = { version = "0.2.0" }


### PR DESCRIPTION
Update usvg dependency from 0.12 to 0.14

Apparently no changes are required? \
Builds fine and the example also works fine. 

The main advantange of this change is that druid-shell depends on kurbo 0.8.1 and usvg 0.12 depends on kurbo 0.7.1, \
therefore enabling the svg feature adds another kurbo crate to the dependency tree. \
Updating to usvg 0.14 fixes this.