### PR TITLE
X11: Add support for transparent windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - `chrono` feature with `Data` support for [chrono](https://docs.rs/chrono/) types ([#1743] by [@r-ml])
 - Text input handles Delete key ([#1746] by [@bjorn])
 - `lens` macro can access nested fields ([#1764] by [@Maan2003])
+- X11: Add support for transparent windows ([#1803] by [@psychon])
 
 ### Changed
 
@@ -724,6 +725,7 @@ Last release without a changelog :(
 [#1764]: https://github.com/linebender/druid/pull/1764
 [#1772]: https://github.com/linebender/druid/pull/1772
 [#1787]: https://github.com/linebender/druid/pull/1787
+[#1803]: https://github.com/linebender/druid/pull/1803
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -25,7 +25,7 @@ use anyhow::{anyhow, Context, Error};
 use x11rb::connection::Connection;
 use x11rb::protocol::present::ConnectionExt as _;
 use x11rb::protocol::xfixes::ConnectionExt as _;
-use x11rb::protocol::xproto::{self, ConnectionExt, CreateWindowAux, EventMask, WindowClass};
+use x11rb::protocol::xproto::{self, ConnectionExt, CreateWindowAux, EventMask, Visualtype, WindowClass};
 use x11rb::protocol::Event;
 use x11rb::resource_manager::Database as ResourceDb;
 use x11rb::xcb_ffi::XCBConnection;
@@ -50,6 +50,11 @@ pub(crate) struct Application {
     /// Let's just avoid the issue altogether. As far as public API is concerned, this causes
     /// `druid_shell::WindowHandle` to be `!Send` and `!Sync`.
     marker: std::marker::PhantomData<*mut XCBConnection>,
+
+    /// The type of visual used by the root window
+    root_visual_type: Visualtype,
+    /// The visual for windows with transparent backgrounds, if supported
+    argb_visual_type: Option<Visualtype>,
 
     /// The X11 resource database used to query dpi.
     pub(crate) rdb: Rc<ResourceDb>,
@@ -156,6 +161,15 @@ impl Application {
             col_resize: load_cursor("col-resize"),
         };
 
+        let screen = connection
+            .setup()
+            .roots
+            .get(screen_num as usize)
+            .ok_or_else(|| anyhow!("Invalid screen num: {}", screen_num))?;
+        let root_visual_type = util::get_visual_from_screen(&screen)
+                .ok_or_else(|| anyhow!("Couldn't get visual from screen"))?;
+        let argb_visual_type = util::get_argb_visual_type(&*connection, &screen)?;
+
         Ok(Application {
             connection,
             rdb,
@@ -166,6 +180,8 @@ impl Application {
             cursors,
             idle_write,
             present_opcode,
+            root_visual_type,
+            argb_visual_type,
             marker: std::marker::PhantomData,
         })
     }
@@ -284,6 +300,31 @@ impl Application {
     #[inline]
     pub(crate) fn screen_num(&self) -> i32 {
         self.screen_num
+    }
+
+    #[inline]
+    pub(crate) fn argb_visual_type(&self) -> Option<Visualtype> {
+        // Check if a composite manager is running
+        let atom_name = format!("_NET_WM_CM_S{}", self.screen_num);
+        let owner = self.connection.intern_atom(false, atom_name.as_bytes())
+            .ok()
+            .and_then(|cookie| cookie.reply().ok())
+            .map(|reply| reply.atom)
+            .and_then(|atom| self.connection.get_selection_owner(atom).ok())
+            .and_then(|cookie| cookie.reply().ok())
+            .map(|reply| reply.owner);
+
+        if Some(x11rb::NONE) == owner {
+            tracing::debug!("_NET_WM_CM_Sn selection is unowned, not providing ARGB visual");
+            None
+        } else {
+            self.argb_visual_type
+        }
+    }
+
+    #[inline]
+    pub(crate) fn root_visual_type(&self) -> Visualtype {
+        self.root_visual_type
     }
 
     /// Returns `Ok(true)` if we want to exit the main loop.

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -25,7 +25,9 @@ use anyhow::{anyhow, Context, Error};
 use x11rb::connection::Connection;
 use x11rb::protocol::present::ConnectionExt as _;
 use x11rb::protocol::xfixes::ConnectionExt as _;
-use x11rb::protocol::xproto::{self, ConnectionExt, CreateWindowAux, EventMask, Visualtype, WindowClass};
+use x11rb::protocol::xproto::{
+    self, ConnectionExt, CreateWindowAux, EventMask, Visualtype, WindowClass,
+};
 use x11rb::protocol::Event;
 use x11rb::resource_manager::Database as ResourceDb;
 use x11rb::xcb_ffi::XCBConnection;
@@ -167,7 +169,7 @@ impl Application {
             .get(screen_num as usize)
             .ok_or_else(|| anyhow!("Invalid screen num: {}", screen_num))?;
         let root_visual_type = util::get_visual_from_screen(&screen)
-                .ok_or_else(|| anyhow!("Couldn't get visual from screen"))?;
+            .ok_or_else(|| anyhow!("Couldn't get visual from screen"))?;
         let argb_visual_type = util::get_argb_visual_type(&*connection, &screen)?;
 
         Ok(Application {
@@ -306,7 +308,9 @@ impl Application {
     pub(crate) fn argb_visual_type(&self) -> Option<Visualtype> {
         // Check if a composite manager is running
         let atom_name = format!("_NET_WM_CM_S{}", self.screen_num);
-        let owner = self.connection.intern_atom(false, atom_name.as_bytes())
+        let owner = self
+            .connection
+            .intern_atom(false, atom_name.as_bytes())
             .ok()
             .and_then(|cookie| cookie.reply().ok())
             .map(|reply| reply.atom)

--- a/druid-shell/src/platform/x11/util.rs
+++ b/druid-shell/src/platform/x11/util.rs
@@ -91,20 +91,20 @@ pub fn get_argb_visual_type(
     conn: &XCBConnection,
     screen: &Screen,
 ) -> Result<Option<Visualtype>, ReplyError> {
-    fn find_visual_for_format(reply: &render::QueryPictFormatsReply, id: render::Pictformat) -> Option<Visualid> {
-        let find_in_depth = |depth: &render::Pictdepth| depth
-            .visuals
-            .iter()
-            .find(|visual| visual.format == id)
-            .map(|visual| visual.visual);
-        let find_in_screen = |screen: &render::Pictscreen| screen
-            .depths
-            .iter()
-            .find_map(find_in_depth);
-        reply
-            .screens
-            .iter()
-            .find_map(find_in_screen)
+    fn find_visual_for_format(
+        reply: &render::QueryPictFormatsReply,
+        id: render::Pictformat,
+    ) -> Option<Visualid> {
+        let find_in_depth = |depth: &render::Pictdepth| {
+            depth
+                .visuals
+                .iter()
+                .find(|visual| visual.format == id)
+                .map(|visual| visual.visual)
+        };
+        let find_in_screen =
+            |screen: &render::Pictscreen| screen.depths.iter().find_map(find_in_depth);
+        reply.screens.iter().find_map(find_in_screen)
     }
 
     // Getting a visual is already funny, but finding the ARGB32 visual is even more fun.

--- a/druid-shell/src/platform/x11/util.rs
+++ b/druid-shell/src/platform/x11/util.rs
@@ -100,13 +100,11 @@ pub fn get_argb_visual_type(
         let find_in_screen = |screen: &render::Pictscreen| screen
             .depths
             .iter()
-            .filter_map(find_in_depth)
-            .next();
+            .find_map(find_in_depth);
         reply
             .screens
             .iter()
-            .filter_map(find_in_screen)
-            .next()
+            .find_map(find_in_screen)
     }
 
     // Getting a visual is already funny, but finding the ARGB32 visual is even more fun.

--- a/druid-shell/src/platform/x11/util.rs
+++ b/druid-shell/src/platform/x11/util.rs
@@ -19,8 +19,11 @@ use std::rc::Rc;
 use std::time::Instant;
 
 use anyhow::{anyhow, Error};
+use x11rb::errors::ReplyError;
+use x11rb::connection::RequestConnection;
 use x11rb::protocol::randr::{ConnectionExt, ModeFlag};
 use x11rb::protocol::xproto::{Screen, Visualtype, Window};
+use x11rb::protocol::render::{self, ConnectionExt as _};
 use x11rb::xcb_ffi::XCBConnection;
 
 use crate::window::TimerToken;
@@ -69,15 +72,64 @@ pub fn refresh_rate(conn: &Rc<XCBConnection>, window_id: Window) -> Option<f64> 
 }
 
 // Apparently you have to get the visualtype this way :|
-pub fn get_visual_from_screen(screen: &Screen) -> Option<Visualtype> {
+fn find_visual_from_screen(screen: &Screen, visual_id: u32) -> Option<Visualtype> {
     for depth in &screen.allowed_depths {
         for visual in &depth.visuals {
-            if visual.visual_id == screen.root_visual {
+            if visual.visual_id == visual_id {
                 return Some(*visual);
             }
         }
     }
     None
+}
+
+pub fn get_visual_from_screen(screen: &Screen) -> Option<Visualtype> {
+    find_visual_from_screen(screen, screen.root_visual)
+}
+
+pub fn get_argb_visual_type(conn: &XCBConnection, screen: &Screen) -> Result<Option<Visualtype>, ReplyError> {
+    // Getting a visual is already funny, but finding the ARGB32 visual is even more fun.
+    // RENDER has picture formats. Each format corresponds to a visual. Thus, we first find the
+    // right picture format, then find the corresponding visual id, then the Visualtype.
+    if conn.extension_information(render::X11_EXTENSION_NAME)?.is_none() {
+        // RENDER not supported
+        Ok(None)
+    } else {
+        let pict_formats = conn.render_query_pict_formats()?.reply()?;
+        // Find the ARGB32 standard format
+        let res = pict_formats.formats
+            .iter()
+            .find(|format| {
+                format.type_ == render::PictType::DIRECT
+                    && format.depth == 32
+                    && format.direct.red_shift == 16
+                    && format.direct.red_mask == 0xff
+                    && format.direct.green_shift == 8
+                    && format.direct.green_mask == 0xff
+                    && format.direct.blue_shift == 0
+                    && format.direct.blue_mask == 0xff
+                    && format.direct.alpha_shift == 24
+                    && format.direct.alpha_mask == 0xff
+            })
+        // Now find the corresponding visual ID
+        .and_then(|format|
+            pict_formats.screens
+                .iter()
+                .filter_map(|screen| screen.depths
+                            .iter()
+                            .filter_map(|depth| depth.visuals
+                                        .iter()
+                                        .find(|visual| visual.format == format.id)
+                                        .map(|visual| visual.visual)
+                                        )
+                            .next()
+                            )
+                .next()
+                )
+            // And finally, we can find the visual
+            .and_then(|visual_id| find_visual_from_screen(screen, visual_id));
+        Ok(res)
+    }
 }
 
 macro_rules! log_x11 {

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -285,13 +285,10 @@ impl WindowBuilder {
 
         // Create the actual window
         let (width_px, height_px) = (size_px.width as u16, size_px.height as u16);
+        let depth = if transparent { 32 } else { screen.root_depth };
         conn.create_window(
             // Window depth
-            if transparent {
-                32
-            } else {
-                x11rb::COPY_DEPTH_FROM_PARENT
-            },
+            depth,
             // The new window's ID
             id,
             // Parent window of this new window
@@ -349,7 +346,7 @@ impl WindowBuilder {
             buf_count,
             width_px,
             height_px,
-            screen.root_depth,
+            depth,
         )?);
 
         // Initialize some properties

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -32,7 +32,7 @@ use x11rb::connection::Connection;
 use x11rb::protocol::present::{CompleteNotifyEvent, ConnectionExt as _, IdleNotifyEvent};
 use x11rb::protocol::xfixes::{ConnectionExt as _, Region as XRegion};
 use x11rb::protocol::xproto::{
-    self, AtomEnum, ChangeWindowAttributesAux, ConfigureNotifyEvent, ConnectionExt, ColormapAlloc,
+    self, AtomEnum, ChangeWindowAttributesAux, ColormapAlloc, ConfigureNotifyEvent, ConnectionExt,
     CreateGCAux, EventMask, Gcontext, Pixmap, PropMode, Rectangle, Visualtype, WindowClass,
 };
 use x11rb::wrapper::ConnectionExt as _;
@@ -255,7 +255,7 @@ impl WindowBuilder {
         };
         let (transparent, visual_type) = match visual_type {
             Some(visual) => (true, visual),
-            None => (false, self.app.root_visual_type())
+            None => (false, self.app.root_visual_type()),
         };
         if transparent != self.transparent {
             warn!("Windows with transparent backgrounds do not work");
@@ -272,8 +272,14 @@ impl WindowBuilder {
         );
         if transparent {
             let colormap = conn.generate_id()?;
-            conn.create_colormap(ColormapAlloc::NONE, colormap, screen.root, visual_type.visual_id)?;
-            cw_values = cw_values.border_pixel(screen.white_pixel)
+            conn.create_colormap(
+                ColormapAlloc::NONE,
+                colormap,
+                screen.root,
+                visual_type.visual_id,
+            )?;
+            cw_values = cw_values
+                .border_pixel(screen.white_pixel)
                 .colormap(colormap);
         };
 
@@ -281,7 +287,11 @@ impl WindowBuilder {
         let (width_px, height_px) = (size_px.width as u16, size_px.height as u16);
         conn.create_window(
             // Window depth
-            if transparent { 32 } else { x11rb::COPY_DEPTH_FROM_PARENT },
+            if transparent {
+                32
+            } else {
+                x11rb::COPY_DEPTH_FROM_PARENT
+            },
             // The new window's ID
             id,
             // Parent window of this new window

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -341,12 +341,7 @@ impl WindowBuilder {
         // other one). Otherwise, we only need one.
         let buf_count = if present_data.is_some() { 2 } else { 1 };
         let buffers = RefCell::new(Buffers::new(
-            conn,
-            id,
-            buf_count,
-            width_px,
-            height_px,
-            depth,
+            conn, id, buf_count, width_px, height_px, depth,
         )?);
 
         // Initialize some properties

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -16,7 +16,7 @@
 
 use std::cell::{Cell, RefCell};
 use std::collections::BinaryHeap;
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 use std::os::unix::io::RawFd;
 use std::panic::Location;
 use std::rc::{Rc, Weak};
@@ -32,8 +32,8 @@ use x11rb::connection::Connection;
 use x11rb::protocol::present::{CompleteNotifyEvent, ConnectionExt as _, IdleNotifyEvent};
 use x11rb::protocol::xfixes::{ConnectionExt as _, Region as XRegion};
 use x11rb::protocol::xproto::{
-    self, AtomEnum, ChangeWindowAttributesAux, ConfigureNotifyEvent, ConnectionExt, CreateGCAux,
-    EventMask, Gcontext, Pixmap, PropMode, Rectangle, Visualtype, WindowClass,
+    self, AtomEnum, ChangeWindowAttributesAux, ConfigureNotifyEvent, ConnectionExt, ColormapAlloc,
+    CreateGCAux, EventMask, Gcontext, Pixmap, PropMode, Rectangle, Visualtype, WindowClass,
 };
 use x11rb::wrapper::ConnectionExt as _;
 use x11rb::xcb_ffi::XCBConnection;
@@ -59,7 +59,7 @@ use crate::{window, ScaledArea};
 use super::application::Application;
 use super::keycodes;
 use super::menu::Menu;
-use super::util::{self, Timer};
+use super::util::Timer;
 
 /// A version of XCB's `xcb_visualtype_t` struct. This was copied from the [example] in x11rb; it
 /// is used to interoperate with cairo.
@@ -100,6 +100,7 @@ pub(crate) struct WindowBuilder {
     app: Application,
     handler: Option<Box<dyn WinHandler>>,
     title: String,
+    transparent: bool,
     size: Size,
 
     // TODO: implement min_size for X11
@@ -113,6 +114,7 @@ impl WindowBuilder {
             app,
             handler: None,
             title: String::new(),
+            transparent: false,
             size: Size::new(500.0, 400.0),
             min_size: Size::new(0.0, 0.0),
         }
@@ -139,8 +141,8 @@ impl WindowBuilder {
         warn!("WindowBuilder::show_titlebar is currently unimplemented for X11 platforms.");
     }
 
-    pub fn set_transparent(&mut self, _transparent: bool) {
-        // Ignored
+    pub fn set_transparent(&mut self, transparent: bool) {
+        self.transparent = transparent;
     }
 
     pub fn set_position(&mut self, _position: Point) {
@@ -246,11 +248,20 @@ impl WindowBuilder {
             .roots
             .get(screen_num as usize)
             .ok_or_else(|| anyhow!("Invalid screen num: {}", screen_num))?;
-        let visual_type = util::get_visual_from_screen(&screen)
-            .ok_or_else(|| anyhow!("Couldn't get visual from screen"))?;
-        let visual_id = visual_type.visual_id;
+        let visual_type = if self.transparent {
+            self.app.argb_visual_type()
+        } else {
+            None
+        };
+        let (transparent, visual_type) = match visual_type {
+            Some(visual) => (true, visual),
+            None => (false, self.app.root_visual_type())
+        };
+        if transparent != self.transparent {
+            warn!("Windows with transparent backgrounds do not work");
+        }
 
-        let cw_values = xproto::CreateWindowAux::new().event_mask(
+        let mut cw_values = xproto::CreateWindowAux::new().event_mask(
             EventMask::EXPOSURE
                 | EventMask::STRUCTURE_NOTIFY
                 | EventMask::KEY_PRESS
@@ -259,12 +270,18 @@ impl WindowBuilder {
                 | EventMask::BUTTON_RELEASE
                 | EventMask::POINTER_MOTION,
         );
+        if transparent {
+            let colormap = conn.generate_id()?;
+            conn.create_colormap(ColormapAlloc::NONE, colormap, screen.root, visual_type.visual_id)?;
+            cw_values = cw_values.border_pixel(screen.white_pixel)
+                .colormap(colormap);
+        };
 
         // Create the actual window
         let (width_px, height_px) = (size_px.width as u16, size_px.height as u16);
         conn.create_window(
             // Window depth
-            x11rb::COPY_FROM_PARENT.try_into().unwrap(),
+            if transparent { 32 } else { x11rb::COPY_DEPTH_FROM_PARENT },
             // The new window's ID
             id,
             // Parent window of this new window
@@ -283,12 +300,16 @@ impl WindowBuilder {
             // Window class type
             WindowClass::INPUT_OUTPUT,
             // Visual ID
-            visual_id,
+            visual_type.visual_id,
             // Window properties mask
             &cw_values,
         )?
         .check()
         .context("create window")?;
+
+        if let Some(colormap) = cw_values.colormap {
+            conn.free_colormap(colormap)?;
+        }
 
         // Allocate a graphics context (currently used only for copying pixels when present is
         // unavailable).


### PR DESCRIPTION
First, some history lesson:

X11 originally did not support transparency.  Visuals describe how pixel
values are interpreted, but they can only describe red/green/blue
components. Then, the RENDER extension came and added transparency. Now
we have picture formats. That's basically the same as a visual, but it
also describes an alpha component. There is a mapping between picture
formats and visual. Also, there is a standard ARGB32 format that is
always supported.

Then came the composite extension. Classically, the X11 server "drew
stuff" directly to the output, but there is no alpha compositing
involved.  With composite, a composite manager can request drawing to be
redirected to an off-screen pixmap. The composite manager will then
produce the "real" visible screen contents. And in doing so, it can take
alpha values into account.

This commit adds support for transparent windows to the X11 backend. For
that, it has to find the standard ARGB32 render picture format and the
corresponding visual. When a transparent window is created, it checks if
a composite manager is running. If not, nothing changes. If everything
worked out (RENDER is supported, we found the ARGB32 picture format, a
composite manager is running), transparent windows are created with this
visual instead of the root window's visual.

When a window has a different bit depth than its parent window, it has
to "fully define" its rendering. Since it has a different bit depth than
its parent, the X11 server cannot just copy background and window border
from the parent. Thus, when we create an ARGB32 window (which has
depth=32), we are creating a window with a different depth than the root
window (most likely depth=24) and have to provide some additional
settings. Even though no border will be used, we still have to define
its color.

Signed-off-by: Uli Schlachter <psychon@znc.in>

------

Since I can only build druid-shell and not druid, this PR only received light testing: I let it open some window and asked `xwininfo` for the window's depth. I only tested that this produces the expected result with a hardcoded `transparent: true` and with/without a composite manager. I did not actually test anything involving transparent window background, but I expect  that to work since cairo should handle all that is necessary. Hopefully...