### PR TITLE
Make book example code compile

### DIFF
--- a/docs/src/get_started.md
+++ b/docs/src/get_started.md
@@ -26,7 +26,7 @@ fn build_ui() -> impl Widget<()> {
 }
 
 fn main() -> Result<(), PlatformError> {
-    AppLauncher::with_window(WindowDesc::new(build_ui())).launch(())?;
+    AppLauncher::with_window(WindowDesc::new(build_ui)).launch(())?;
     Ok(())
 }
 ```


### PR DESCRIPTION
This example code doesn't work since it calls `build_ui` rather than passing it directly. Removing the parentheses fixes the problem. Note that this is my first interaction with druid, so my fix may not be idiomatic? Would love to hear of a better solution if that's the case.