### PR TITLE
Window Drag Handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - `chrono` feature with `Data` support for [chrono](https://docs.rs/chrono/) types ([#1743] by [@r-ml])
 - Text input handles Delete key ([#1746] by [@bjorn])
 - `lens` macro can access nested fields ([#1764] by [@Maan2003])
+- `WindowDragHandle` controller widget to drag windows and move them for Windows and Gtk. ([#1807] by [@blemelin])
 
 ### Changed
 
@@ -483,6 +484,7 @@ Last release without a changelog :(
 [@r-ml]: https://github.com/r-ml
 [@djeedai]: https://github.com/djeedai
 [@bjorn]: https://github.com/bjorn
+[@blemelin]: https://github.com/blemelin
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611
@@ -726,6 +728,7 @@ Last release without a changelog :(
 [#1772]: https://github.com/linebender/druid/pull/1772
 [#1787]: https://github.com/linebender/druid/pull/1787
 [#1802]: https://github.com/linebender/druid/pull/1802
+[#1807]: https://github.com/linebender/druid/pull/1807
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -996,7 +996,8 @@ impl WindowHandle {
     /// Tell the window manager to start a window drag using current mouse position.
     pub fn begin_move_drag(&self) {
         if let Some(state) = self.state.upgrade() {
-            match state.last_mouse_button_press_event.take() { //Consume the mouse button event.
+            match state.last_mouse_button_press_event.take() {
+                //Consume the mouse button event.
                 Some(event) if event.get_event_type() == gdk::EventType::ButtonPress => {
                     state.window.begin_move_drag(
                         event.get_button() as i32,
@@ -1005,7 +1006,7 @@ impl WindowHandle {
                         event.get_time(),
                     )
                 }
-                _ => warn!("Cannot begin window drag if no mouse button is currently down.")
+                _ => warn!("Cannot begin window drag if no mouse button is currently down."),
             }
         }
     }

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -990,20 +990,10 @@ impl WindowHandle {
     }
 
     pub fn handle_titlebar(&self, _val: bool) {
-        warn!("WindowHandle::handle_titlebar is currently unimplemented for gtk.");
-    }
-
-    /// Close the window.
-    pub fn close(&self) {
-        if let Some(state) = self.state.upgrade() {
-            state.closing.set(true);
-            state.window.close();
-        }
+        warn!("WindowHandle::handle_titlebar is currently unimplemented for gtk. Use WindowHandle::begin_move_drag instead.");
     }
 
     /// Tell the window manager to start a window drag using current mouse position.
-    ///
-    /// On Gtk, this must be called immediately after a MouseEvent with a button press is received.
     pub fn begin_move_drag(&self) {
         if let Some(state) = self.state.upgrade() {
             match state.last_mouse_button_press_event.take() { //Consume the mouse button event.
@@ -1015,14 +1005,22 @@ impl WindowHandle {
                         event.get_time(),
                     )
                 }
-                _ => warn!("Cannot drag window if no mouse button is currently down.")
+                _ => warn!("Cannot begin window drag if no mouse button is currently down.")
             }
         }
     }
 
     /// Tell the window manager to end the current window drag, if any.
     pub fn end_move_drag(&self) {
-        //Nothing to do on gtk.
+        //Nothing to do on gtk. Window drag immediately ends when mouse button is released.
+    }
+
+    /// Close the window.
+    pub fn close(&self) {
+        if let Some(state) = self.state.upgrade() {
+            state.closing.set(true);
+            state.window.close();
+        }
     }
 
     /// Bring this window to the front of the window stack and give it focus.

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -26,7 +26,7 @@ use std::time::Instant;
 
 use anyhow::anyhow;
 use cairo::Surface;
-use gdk::{EventKey, EventMask, ModifierType, ScrollDirection, WindowExt, WindowTypeHint, EventButton};
+use gdk::{EventKey, EventMask, ModifierType, ScrollDirection, WindowExt, WindowTypeHint};
 use gio::ApplicationExt;
 use gtk::prelude::*;
 use gtk::{AccelGroup, ApplicationWindow, DrawingArea, SettingsExt};

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -1310,6 +1310,14 @@ impl WindowHandle {
         tracing::warn!("WindowHandle::handle_titlebar is currently unimplemented for Mac.");
     }
 
+    pub fn begin_move_drag(&self) {
+        tracing::warn!("WindowHandle::begin_move_drag is currently unimplemented for Mac.");
+    }
+
+    pub fn end_move_drag(&self) {
+        tracing::warn!("WindowHandle::end_move_drag is currently unimplemented for Mac.");
+    }
+
     pub fn resizable(&self, resizable: bool) {
         unsafe {
             let window: id = msg_send![*self.nsview.load(), window];

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -519,6 +519,14 @@ impl WindowHandle {
         warn!("WindowHandle::handle_titlebar unimplemented for web.");
     }
 
+    pub fn begin_move_drag(&self) {
+        warn!("WindowHandle::begin_move_drag is currently unimplemented for web.");
+    }
+
+    pub fn end_move_drag(&self) {
+        warn!("WindowHandle::end_move_drag is currently unimplemented for web.");
+    }
+
     pub fn close(&self) {
         // TODO
     }

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -1818,16 +1818,6 @@ impl WindowHandle {
         self.defer(DeferredOp::ShowTitlebar(show_titlebar));
     }
 
-    /// Tell the window manager to start a window drag using current mouse position.
-    pub fn begin_move_drag(&self) {
-        self.handle_titlebar(true);
-    }
-
-    /// Tell the window manager to end the current window drag, if any.
-    pub fn end_move_drag(&self) {
-        self.handle_titlebar(false);
-    }
-
     // Sets the position of the window in virtual screen coordinates
     pub fn set_position(&self, position: Point) {
         self.defer(DeferredOp::SetWindowState(window::WindowState::Restored));
@@ -1961,6 +1951,14 @@ impl WindowHandle {
         if let Some(w) = self.state.upgrade() {
             w.handle_titlebar.set(val);
         }
+    }
+
+    pub fn begin_move_drag(&self) {
+        warn!("WindowHandle::begin_move_drag is currently unimplemented for Windows. Use WindowHandle::handle_titlebar instead.");
+    }
+
+    pub fn end_move_drag(&self) {
+        warn!("WindowHandle::end_move_drag is currently unimplemented for Windows. Use WindowHandle::handle_titlebar instead.");
     }
 
     pub fn set_menu(&self, menu: Menu) {

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -1818,6 +1818,16 @@ impl WindowHandle {
         self.defer(DeferredOp::ShowTitlebar(show_titlebar));
     }
 
+    /// Tell the window manager to start a window drag using current mouse position.
+    pub fn begin_move_drag(&self) {
+        self.handle_titlebar(true);
+    }
+
+    /// Tell the window manager to end the current window drag, if any.
+    pub fn end_move_drag(&self) {
+        self.handle_titlebar(false);
+    }
+
     // Sets the position of the window in virtual screen coordinates
     pub fn set_position(&self, position: Point) {
         self.defer(DeferredOp::SetWindowState(window::WindowState::Restored));

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -1521,6 +1521,14 @@ impl WindowHandle {
         warn!("WindowHandle::handle_titlebar is currently unimplemented for X11 platforms.");
     }
 
+    pub fn begin_move_drag(&self) {
+        warn!("WindowHandle::begin_move_drag is currently unimplemented for X11 platforms.");
+    }
+
+    pub fn end_move_drag(&self) {
+        warn!("WindowHandle::end_move_drag is currently unimplemented for X11 platforms.");
+    }
+
     pub fn bring_to_front_and_focus(&self) {
         if let Some(w) = self.window.upgrade() {
             w.bring_to_front_and_focus();

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -30,7 +30,6 @@ use crate::region::Region;
 use crate::scale::Scale;
 use crate::text::{Event, InputHandler};
 use piet_common::PietText;
-use crate::MouseButton;
 #[cfg(feature = "raw-win-handle")]
 use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 
@@ -219,12 +218,22 @@ impl WindowHandle {
 
     /// Tell the window manager to start a window drag using current mouse position.
     ///
+    /// You might not want to call this yourself, since the WindowDragHandle controller widget
+    /// handles everything for you in a cross-platform way (but there are limitations).
+    ///
+    /// Implemented only for Gtk.
     /// On Gtk, this must be called immediately after a MouseEvent with a button press is received.
     pub fn begin_move_drag(&self) {
         self.0.begin_move_drag()
     }
 
     /// Tell the window manager to end the current window drag, if any.
+    ///
+    /// You might not want to call this yourself, since the WindowDragHandle controller widget
+    /// handles everything for you in a cross-platform way (but there are limitations).
+    ///
+    /// Implemented only for Gtk.
+    /// On Gtk, this is ignored, as the drag immediately ends after the mouse button is released.
     pub fn end_move_drag(&self) {
         self.0.end_move_drag()
     }

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -30,6 +30,7 @@ use crate::region::Region;
 use crate::scale::Scale;
 use crate::text::{Event, InputHandler};
 use piet_common::PietText;
+use crate::MouseButton;
 #[cfg(feature = "raw-win-handle")]
 use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 
@@ -214,6 +215,18 @@ impl WindowHandle {
     /// Set whether the window should show titlebar.
     pub fn show_titlebar(&self, show_titlebar: bool) {
         self.0.show_titlebar(show_titlebar)
+    }
+
+    /// Tell the window manager to start a window drag using current mouse position.
+    ///
+    /// On Gtk, this must be called immediately after a MouseEvent with a button press is received.
+    pub fn begin_move_drag(&self) {
+        self.0.begin_move_drag()
+    }
+
+    /// Tell the window manager to end the current window drag, if any.
+    pub fn end_move_drag(&self) {
+        self.0.end_move_drag()
     }
 
     /// Sets the position of the window in [display points](crate::Scale), relative to the origin of the

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -112,3 +112,6 @@ required-features = ["im"]
 [[example]]
 name = "widget_gallery"
 required-features = ["svg", "im", "image", "png"]
+
+[[example]]
+name = "custom_titlebar"

--- a/druid/examples/custom_titlebar.rs
+++ b/druid/examples/custom_titlebar.rs
@@ -19,7 +19,7 @@ use druid::widget::{Flex, Label, WindowDragHandle};
 use druid::{AppLauncher, Color, PlatformError, Widget, WidgetExt, WindowDesc};
 
 fn main() -> Result<(), PlatformError> {
-    //Create a new windows without the default title bar of the platform.
+    //Create a new window without the default title bar of the platform.
     let window = WindowDesc::new(build_root_widget()).show_titlebar(false);
 
     //Launch the application.

--- a/druid/examples/custom_titlebar.rs
+++ b/druid/examples/custom_titlebar.rs
@@ -16,14 +16,14 @@
 //! works on Windows and Gtk.
 
 use druid::widget::{Flex, Label, WindowDragHandle};
-use druid::{AppLauncher, Color, PlatformError, Widget, WidgetExt, WindowDesc};
+use druid::{AppLauncher, Color, Widget, WidgetExt, WindowDesc};
 
-fn main() -> Result<(), PlatformError> {
+pub fn main() {
     //Create a new window without the default title bar of the platform.
     let window = WindowDesc::new(build_root_widget()).show_titlebar(false);
 
     //Launch the application.
-    AppLauncher::with_window(window).log_to_console().launch(())
+    AppLauncher::with_window(window).log_to_console().launch(()).expect("launch failed");
 }
 
 fn build_root_widget() -> impl Widget<()> {

--- a/druid/examples/custom_titlebar.rs
+++ b/druid/examples/custom_titlebar.rs
@@ -1,0 +1,67 @@
+// Copyright 2019 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This demonstrate how to create a custom title bar. Please note that this currently only
+//! works on Windows and Gtk.
+
+use druid::{AppLauncher, PlatformError, Widget, WindowDesc, WidgetExt, Color};
+use druid::widget::{Flex, Label, WindowDragHandle};
+
+fn main() -> Result<(), PlatformError> {
+    //Create a new windows without the default title bar of the platform.
+    let window = WindowDesc::new(build_root_widget()).show_titlebar(false);
+
+    //Launch the application.
+    AppLauncher::with_window(window).log_to_console().launch(())
+}
+
+fn build_root_widget() -> impl Widget<()> {
+    Flex::column()
+        .with_child(build_title_bar())
+}
+
+fn build_title_bar() -> impl Widget<()> {
+    use druid::{WindowConfig, WindowState};
+    use druid::commands::{CONFIGURE_WINDOW, CLOSE_WINDOW};
+
+    //Let's create a custom title bar. We need a label for the title, a minimize button, a maximize
+    //button and an exit button.
+    let title_label = Label::new("My Application").padding((5.0,5.0));
+    let minimize_button = Label::new("🗕").padding((5.0,5.0)).on_click(|ctx, _data, _env| {
+        ctx.submit_command(CONFIGURE_WINDOW.with(
+            WindowConfig::default().set_window_state(WindowState::Minimized)
+        ))
+    });
+    let maximize_button = Label::new("🗖").padding((5.0,5.0)).on_click(|ctx, _data, _env| {
+        ctx.submit_command(CONFIGURE_WINDOW.with(
+            WindowConfig::default().set_window_state(WindowState::Maximized)
+        ))
+    });
+    let exit_button = Label::new("✕").padding((5.0,5.0)).on_click(|ctx, _data, _env| {
+        ctx.submit_command(CLOSE_WINDOW)
+    });
+
+    //Wrap the title label with the WindowDragHandle controller widget. Do not wrap the buttons,
+    //because not only dragging from the buttons is strange, but on most platforms, clicks events
+    //aren't passed though the drag handle.
+    let drag_handle = WindowDragHandle::new(title_label);
+
+    //Here, we use a Flex widget for the layout.
+    Flex::row()
+        .with_flex_child(drag_handle.expand_width(), 1.0)
+        .with_child(minimize_button)
+        .with_child(maximize_button)
+        .with_child(exit_button)
+        .background(Color::from_rgba32_u32(0x2660A4_FF))
+}

--- a/druid/examples/custom_titlebar.rs
+++ b/druid/examples/custom_titlebar.rs
@@ -15,8 +15,8 @@
 //! This demonstrate how to create a custom title bar. Please note that this currently only
 //! works on Windows and Gtk.
 
-use druid::{AppLauncher, PlatformError, Widget, WindowDesc, WidgetExt, Color};
 use druid::widget::{Flex, Label, WindowDragHandle};
+use druid::{AppLauncher, Color, PlatformError, Widget, WidgetExt, WindowDesc};
 
 fn main() -> Result<(), PlatformError> {
     //Create a new windows without the default title bar of the platform.
@@ -27,30 +27,35 @@ fn main() -> Result<(), PlatformError> {
 }
 
 fn build_root_widget() -> impl Widget<()> {
-    Flex::column()
-        .with_child(build_title_bar())
+    Flex::column().with_child(build_title_bar())
 }
 
 fn build_title_bar() -> impl Widget<()> {
+    use druid::commands::{CLOSE_WINDOW, CONFIGURE_WINDOW};
     use druid::{WindowConfig, WindowState};
-    use druid::commands::{CONFIGURE_WINDOW, CLOSE_WINDOW};
 
     //Let's create a custom title bar. We need a label for the title, a minimize button, a maximize
     //button and an exit button.
-    let title_label = Label::new("My Application").padding((5.0,5.0));
-    let minimize_button = Label::new("🗕").padding((5.0,5.0)).on_click(|ctx, _data, _env| {
-        ctx.submit_command(CONFIGURE_WINDOW.with(
-            WindowConfig::default().set_window_state(WindowState::Minimized)
-        ))
-    });
-    let maximize_button = Label::new("🗖").padding((5.0,5.0)).on_click(|ctx, _data, _env| {
-        ctx.submit_command(CONFIGURE_WINDOW.with(
-            WindowConfig::default().set_window_state(WindowState::Maximized)
-        ))
-    });
-    let exit_button = Label::new("✕").padding((5.0,5.0)).on_click(|ctx, _data, _env| {
-        ctx.submit_command(CLOSE_WINDOW)
-    });
+    let title_label = Label::new("My Application").padding((5.0, 5.0));
+    let minimize_button = Label::new("🗕")
+        .padding((5.0, 5.0))
+        .on_click(|ctx, _data, _env| {
+            ctx.submit_command(
+                CONFIGURE_WINDOW
+                    .with(WindowConfig::default().set_window_state(WindowState::Minimized)),
+            )
+        });
+    let maximize_button = Label::new("🗖")
+        .padding((5.0, 5.0))
+        .on_click(|ctx, _data, _env| {
+            ctx.submit_command(
+                CONFIGURE_WINDOW
+                    .with(WindowConfig::default().set_window_state(WindowState::Maximized)),
+            )
+        });
+    let exit_button = Label::new("✕")
+        .padding((5.0, 5.0))
+        .on_click(|ctx, _data, _env| ctx.submit_command(CLOSE_WINDOW));
 
     //Wrap the title label with the WindowDragHandle controller widget. Do not wrap the buttons,
     //because not only dragging from the buttons is strange, but on most platforms, clicks events

--- a/druid/examples/custom_titlebar.rs
+++ b/druid/examples/custom_titlebar.rs
@@ -23,7 +23,10 @@ pub fn main() {
     let window = WindowDesc::new(build_root_widget()).show_titlebar(false);
 
     //Launch the application.
-    AppLauncher::with_window(window).log_to_console().launch(()).expect("launch failed");
+    AppLauncher::with_window(window)
+        .log_to_console()
+        .launch(())
+        .expect("launch failed");
 }
 
 fn build_root_widget() -> impl Widget<()> {

--- a/druid/examples/web/src/lib.rs
+++ b/druid/examples/web/src/lib.rs
@@ -57,6 +57,7 @@ macro_rules! impl_example {
 impl_example!(anim);
 impl_example!(calc);
 impl_example!(cursor);
+impl_example!(custom_titlebar);
 impl_example!(custom_widget);
 impl_example!(disabled);
 impl_example!(either);

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -62,6 +62,7 @@ mod view_switcher;
 #[allow(clippy::module_inception)]
 mod widget;
 mod widget_ext;
+mod window_drag_handle;
 
 pub use self::image::Image;
 pub use added::Added;
@@ -107,6 +108,7 @@ pub use widget::{Widget, WidgetId};
 #[doc(hidden)]
 pub use widget_ext::WidgetExt;
 pub use widget_wrapper::WidgetWrapper;
+pub use window_drag_handle::WindowDragHandle;
 
 /// The types required to implement a `Widget`.
 ///

--- a/druid/src/widget/window_drag_handle.rs
+++ b/druid/src/widget/window_drag_handle.rs
@@ -18,8 +18,8 @@
 
 use tracing::instrument;
 
-use crate::widget::{Controller, ControllerHost};
 use crate::widget::prelude::*;
+use crate::widget::{Controller, ControllerHost};
 
 /// A [`Controller`] widget that makes the target acts as a window grab handle.
 ///
@@ -36,7 +36,7 @@ use crate::widget::prelude::*;
 /// use druid::commands::CLOSE_WINDOW;
 ///
 /// let title_label = WindowDragHandle::new(Label::new("My Application"));
-/// let exit_button = Button::new("X").on_click(|ctx, _data, _env| ctx.submit_command(CLOSE_WINDOW));
+/// let exit_button = Button::new("X").on_click(|ctx, _data : &mut (), _env| ctx.submit_command(CLOSE_WINDOW));
 /// let title_bar = Flex::row().with_child(title_label).with_child(exit_button);
 /// ```
 ///
@@ -61,14 +61,19 @@ impl WindowDragHandle {
 }
 
 impl<T: Data, W: Widget<T>> Controller<T, W> for WindowDragHandle {
-    #[instrument(name = "WindowDragHandle", level = "trace", skip(self, child, ctx, event, data, env))]
+    #[instrument(
+        name = "WindowDragHandle",
+        level = "trace",
+        skip(self, child, ctx, event, data, env)
+    )]
     fn event(&mut self, child: &mut W, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
-        match event {
-            #[cfg(all(feature = "gtk", target_os = "linux"))]
-            Event::MouseDown(_) => ctx.window().begin_move_drag(),
-            #[cfg(target_os = "windows")]
-            Event::MouseMove(_) => ctx.window().handle_titlebar(true),
-            _ => {}
+        #[cfg(all(feature = "gtk", target_os = "linux"))]
+        if let Event::MouseDown(_) = event {
+            ctx.window().begin_move_drag()
+        }
+        #[cfg(target_os = "windows")]
+        if let Event::MouseMove(_) = event {
+            ctx.window().handle_titlebar(true)
         }
         child.event(ctx, event, data, env);
     }

--- a/druid/src/widget/window_drag_handle.rs
+++ b/druid/src/widget/window_drag_handle.rs
@@ -1,0 +1,75 @@
+// Copyright 2018 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A [`Controller`] widget that makes the target acts as a window grab handle.
+//!
+//! [`Controller`]: struct.Controller.html
+
+use tracing::instrument;
+
+use crate::widget::{Controller, ControllerHost};
+use crate::widget::prelude::*;
+
+/// A [`Controller`] widget that makes the target acts as a window grab handle.
+///
+/// On most platforms, click events aren't passed through to the children. As such, it is
+/// recommended to only put text or small icons in a window drag handle.
+///
+/// This controller widget only works for the Windows and Gtk platforms. On any other platform,
+/// it does absolutely nothing.
+///
+/// # Examples
+///
+/// ```
+/// use druid::widget::{WindowDragHandle, Label, Button, Flex};
+/// use druid::commands::CLOSE_WINDOW;
+///
+/// let title_label = WindowDragHandle::new(Label::new("My Application"));
+/// let exit_button = Button::new("X").on_click(|ctx, _data, _env| ctx.submit_command(CLOSE_WINDOW));
+/// let title_bar = Flex::row().with_child(title_label).with_child(exit_button);
+/// ```
+///
+/// # Platform notes
+///
+/// ## Windows
+///
+/// Click events aren't passed through to the children.
+///
+/// ## Gtk
+///
+/// Click events aren't passed through to the children.
+///
+/// [`Controller`]: struct.Controller.html
+pub struct WindowDragHandle;
+
+impl WindowDragHandle {
+    /// Create a new window drag handle, wrapping the provided widget.
+    pub fn new<T: Data, W: Widget<T>>(child: W) -> ControllerHost<W, Self> {
+        ControllerHost::new(child, WindowDragHandle)
+    }
+}
+
+impl<T: Data, W: Widget<T>> Controller<T, W> for WindowDragHandle {
+    #[instrument(name = "WindowDragHandle", level = "trace", skip(self, child, ctx, event, data, env))]
+    fn event(&mut self, child: &mut W, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
+        match event {
+            #[cfg(all(feature = "gtk", target_os = "linux"))]
+            Event::MouseDown(_) => ctx.window().begin_move_drag(),
+            #[cfg(target_os = "windows")]
+            Event::MouseMove(_) => ctx.window().handle_titlebar(true),
+            _ => {}
+        }
+        child.event(ctx, event, data, env);
+    }
+}


### PR DESCRIPTION
Hello!

This PR proposes to add a `WindowDragHandle` widget that, when dragged around, moves the window with it. It wraps one child widget, so the handle can be anything (anything not clickable, that is).

# Proposed changes
- Add a `WindowDragHandle` widget to drag the window around (to move it). Works on *Windows* and *gtk* only.
- Add a `begin_move_drag` and a `end_move_drag` method to the `WindowHandle` struct on all platforms. Implemented only for *gtk* currently.
- Add an example named `custom_titlebar` that demonstrate how to use the `WindowDragHandle` widget.

# Questions to answer
1. This new widget was not first submitted through the [nursery](https://github.com/linebender/druid-widget-nursery). I thought it wasn't possible, since it requires new things in `druid-shell` (i.e `begin_move_drag` and a `end_move_drag`). Should I submit it through that first and cancel this PR ?
2. To make this work on *gtk*, I had to modify the `WindowHandle` struct, adding it a field (`last_mouse_button_press_event`). It stores the last mouse press event received, because I required other values from that "raw" event (like the timestamp or the root position of the cursor). That solution is not elegant, but it does not pollute the `MouseEvent` struct with *gtk only* related values. Is that an acceptable solution ?

# Other comments

This is my first contribution to an open-source project, so I hope I've not made any huge mistake. Please feel free to ask for modifications.