### PR TITLE
Remove Selector::must_use, Revert #1533

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ You can find its changes [documented below](#070---2021-01-01).
 
 ### Changed
 
-- Warn on unhandled Commands ([#1533] by [@Maan2003])
+- ~~Warn on unhandled Commands ([#1533] by [@Maan2003])~~ (Reverted in #1813)
 - `WindowDesc::new` takes the root widget directly instead of a closure ([#1559] by [@lassipulkkinen])
 - Switch to trace-based logging ([#1562] by [@PoignardAzur])
 - Spacers in `Flex` are now implemented by calculating the space in `Flex` instead of creating a widget for it ([#1584] by [@JAicewizard])

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -25,18 +25,7 @@ use crate::{WidgetId, WindowId};
 /// The identity of a [`Selector`].
 ///
 /// [`Selector`]: struct.Selector.html
-#[derive(Copy, Clone, PartialEq, Eq)]
-pub(crate) struct SelectorSymbol {
-    str: &'static str,
-    must_use: bool,
-}
-
-impl std::fmt::Debug for SelectorSymbol {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let must_use = if self.must_use { " (must_use)" } else { "" };
-        write!(f, "{}{}", self.str, must_use)
-    }
-}
+pub(crate) type SelectorSymbol = &'static str;
 
 /// An identifier for a particular command.
 ///
@@ -353,25 +342,8 @@ impl Selector<()> {
 
 impl<T> Selector<T> {
     /// Create a new `Selector` with the given string.
-    pub const fn new(str: &'static str) -> Selector<T> {
-        Selector(
-            SelectorSymbol {
-                str,
-                must_use: false,
-            },
-            PhantomData,
-        )
-    }
-
-    /// Create a `Selector` that must be used.
-    pub const fn must_use(str: &'static str) -> Selector<T> {
-        Selector(
-            SelectorSymbol {
-                str,
-                must_use: true,
-            },
-            PhantomData,
-        )
+    pub const fn new(s: &'static str) -> Selector<T> {
+        Selector(s, PhantomData)
     }
 
     /// Returns the `SelectorSymbol` identifying this `Selector`.
@@ -417,11 +389,6 @@ impl Command {
         .default_to(Target::Global)
     }
 
-    /// Checks if this command must be used.
-    pub fn must_be_used(&self) -> bool {
-        self.symbol.must_use
-    }
-
     /// A helper method for creating a `Notification` from a `Command`.
     ///
     /// This is slightly icky; it lets us do `SOME_SELECTOR.with(SOME_PAYLOAD)`
@@ -443,14 +410,6 @@ impl Command {
     /// [`Target`]: enum.Target.html
     pub fn to(mut self, target: impl Into<Target>) -> Self {
         self.target = target.into();
-        self
-    }
-
-    /// Make the `Command` must use.
-    ///
-    /// this will log warning if this `Command` is not handled.
-    pub fn must_use(mut self, must_use: bool) -> Self {
-        self.symbol.must_use = must_use;
         self
     }
 
@@ -492,7 +451,7 @@ impl Command {
         if self.symbol == selector.symbol() {
             Some(self.payload.downcast_ref().unwrap_or_else(|| {
                 panic!(
-                    "The selector {:?} exists twice with different types. See druid::Command::get for more information",
+                    "The selector \"{}\" exists twice with different types. See druid::Command::get for more information",
                     selector.symbol()
                 );
             }))
@@ -518,7 +477,7 @@ impl Command {
     pub fn get_unchecked<T: Any>(&self, selector: Selector<T>) -> &T {
         self.get(selector).unwrap_or_else(|| {
             panic!(
-                "Expected selector {:?} but the command was {:?}.",
+                "Expected selector \"{}\" but the command was \"{}\".",
                 selector.symbol(),
                 self.symbol
             )
@@ -545,7 +504,7 @@ impl Notification {
         if self.symbol == selector.symbol() {
             Some(self.payload.downcast_ref().unwrap_or_else(|| {
                 panic!(
-                    "The selector {:?} exists twice with different types. \
+                    "The selector \"{}\" exists twice with different types. \
                     See druid::Command::get for more information",
                     selector.symbol()
                 );
@@ -587,7 +546,7 @@ impl From<Selector> for Command {
 
 impl<T> std::fmt::Display for Selector<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "Selector({:?}, {})", self.0, any::type_name::<T>())
+        write!(f, "Selector(\"{}\", {})", self.0, any::type_name::<T>())
     }
 }
 
@@ -637,7 +596,7 @@ impl std::fmt::Debug for Notification {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "Notification: Selector {:?} from {:?}",
+            "Notification: Selector {} from {:?}",
             self.symbol, self.source
         )
     }

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -688,10 +688,7 @@ impl<T: Data> AppState<T> {
                 tracing::warn!("SHOW_OPEN_PANEL command must target a window.")
             }
             _ => {
-                let handled = self.inner.borrow_mut().dispatch_cmd(cmd.clone());
-                if !handled.is_handled() && cmd.must_be_used() {
-                    tracing::warn!("{:?} was not handled.", cmd);
-                }
+                self.inner.borrow_mut().dispatch_cmd(cmd);
             }
         }
     }


### PR DESCRIPTION
If more than one widgets have to handle, you can not `set_handled`
because it will stop the propogation of the command. So this still
shows the warning, which is incorrect.