### PR TITLE
Make test code available in release builds

### DIFF
--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -73,7 +73,7 @@ pub struct WidgetPod<T, W> {
 /// [`paint`]: trait.Widget.html#tymethod.paint
 /// [`WidgetPod`]: struct.WidgetPod.html
 #[derive(Clone)]
-pub(crate) struct WidgetState {
+pub struct WidgetState {
     pub(crate) id: WidgetId,
     /// The size of the child; this is the value returned by the child's layout
     /// method.
@@ -975,7 +975,6 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                     self.state.needs_window_origin = false;
                     true
                 }
-                #[cfg(test)]
                 InternalLifeCycle::DebugRequestState { widget, state_cell } => {
                     if *widget == self.id() {
                         state_cell.set(self.state.clone());
@@ -986,7 +985,6 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                         self.state.children.may_contain(&widget)
                     }
                 }
-                #[cfg(test)]
                 InternalLifeCycle::DebugInspectState(f) => {
                     f.call(&self.state);
                     true

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -333,18 +333,19 @@ pub enum InternalLifeCycle {
     RouteDisabledChanged,
     /// The parents widget origin in window coordinate space has changed.
     ParentWindowOrigin,
-    /// Testing only: request the `WidgetState` of a specific widget.
+    /// For testing: request the `WidgetState` of a specific widget.
     ///
     /// During testing, you may wish to verify that the state of a widget
     /// somewhere in the tree is as expected. In that case you can dispatch
     /// this event, specifying the widget in question, and that widget will
     /// set its state in the provided `Cell`, if it exists.
-    #[cfg(test)]
     DebugRequestState {
+        /// the widget whose state is requested
         widget: WidgetId,
+        /// a cell used to store the a widget's state
         state_cell: StateCell,
     },
-    #[cfg(test)]
+    /// For testing: apply the given function on every widget.
     DebugInspectState(StateCheckFn),
 }
 
@@ -446,17 +447,14 @@ impl InternalLifeCycle {
             | InternalLifeCycle::RouteFocusChanged { .. }
             | InternalLifeCycle::RouteDisabledChanged => true,
             InternalLifeCycle::ParentWindowOrigin => false,
-            #[cfg(test)]
             InternalLifeCycle::DebugRequestState { .. }
             | InternalLifeCycle::DebugInspectState(_) => true,
         }
     }
 }
 
-#[cfg(test)]
 pub(crate) use state_cell::{StateCell, StateCheckFn};
 
-#[cfg(test)]
 mod state_cell {
     use crate::core::WidgetState;
     use crate::WidgetId;

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -166,8 +166,7 @@ mod mouse;
 pub mod scroll_component;
 mod sub_window;
 #[cfg(not(target_arch = "wasm32"))]
-#[cfg(test)]
-mod tests;
+pub mod tests;
 pub mod text;
 pub mod theme;
 pub mod widget;
@@ -210,7 +209,6 @@ pub use win_handler::DruidHandler;
 pub use window::{Window, WindowId};
 
 #[cfg(not(target_arch = "wasm32"))]
-#[cfg(test)]
 pub(crate) use event::{StateCell, StateCheckFn};
 
 #[deprecated(since = "0.8.0", note = "import from druid::text module instead")]

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -84,6 +84,7 @@ impl<'a> TargetGuard<'a> {
     }
 }
 
+#[allow(missing_docs)]
 impl<T: Data> Harness<'_, T> {
     /// Create a new `Harness` with the given data and a root widget,
     /// and provide that harness to the passed in function.
@@ -189,7 +190,7 @@ impl<T: Data> Harness<'_, T> {
     }
 
     /// Retrieve a copy of this widget's `WidgetState`, or die trying.
-    pub(crate) fn get_state(&mut self, widget: WidgetId) -> WidgetState {
+    pub fn get_state(&mut self, widget: WidgetId) -> WidgetState {
         match self.try_get_state(widget) {
             Some(thing) => thing,
             None => panic!("get_state failed for widget {:?}", widget),
@@ -197,7 +198,7 @@ impl<T: Data> Harness<'_, T> {
     }
 
     /// Attempt to retrieve a copy of this widget's `WidgetState`.
-    pub(crate) fn try_get_state(&mut self, widget: WidgetId) -> Option<WidgetState> {
+    pub fn try_get_state(&mut self, widget: WidgetId) -> Option<WidgetState> {
         let cell = StateCell::default();
         let state_cell = cell.clone();
         self.lifecycle(LifeCycle::Internal(InternalLifeCycle::DebugRequestState {
@@ -210,7 +211,7 @@ impl<T: Data> Harness<'_, T> {
     /// Inspect the `WidgetState` of each widget in the tree.
     ///
     /// The provided closure will be called on each widget.
-    pub(crate) fn inspect_state(&mut self, f: impl Fn(&WidgetState) + 'static) {
+    pub fn inspect_state(&mut self, f: impl Fn(&WidgetState) + 'static) {
         let checkfn = StateCheckFn::new(f);
         self.lifecycle(LifeCycle::Internal(InternalLifeCycle::DebugInspectState(
             checkfn,

--- a/druid/src/tests/helpers.rs
+++ b/druid/src/tests/helpers.rs
@@ -15,6 +15,11 @@
 //! Helper types for test writing.
 //!
 //! This includes tools for making throwaway widgets more easily.
+//!
+//! Note: Some of these types are undocumented. They're meant to help maintainers of Druid and
+//! people trying to build a framework on top of Druid (like crochet), not to be user-facing.
+
+#![allow(missing_docs)]
 
 use std::cell::RefCell;
 use std::collections::VecDeque;
@@ -53,12 +58,16 @@ pub struct ReplaceChild<T> {
 /// Make one like this:
 ///
 /// ```
+/// # use druid::widget::Label;
+/// # use druid::{WidgetExt, LifeCycle};
+/// use druid::tests::helpers::{Recording, Record, TestWidgetExt};
+/// use druid::tests::harness::Harness;
 /// let recording = Recording::default();
-/// let widget = Label::new().padding(4.0).record(&recording);
+/// let widget = Label::new("Hello").padding(4.0).record(&recording);
 ///
-/// Harness::create((), widget, |harness| {
-///     widget.send_initial_events();
-///     assert_matches!(recording.next(), Record::L(LifeCycle::WidgetAdded));
+/// Harness::create_simple((), widget, |harness| {
+///     harness.send_initial_events();
+///     assert!(matches!(recording.next(), Record::L(LifeCycle::WidgetAdded)));
 /// })
 /// ```
 pub struct Recorder<W> {
@@ -302,6 +311,8 @@ impl<T: Data, W: Widget<T>> Widget<T> for Recorder<W> {
         self.recording.push(Record::Paint)
     }
 }
+
+// TODO - use const generics instead
 
 // easily make a bunch of WidgetIds
 pub fn widget_id2() -> (WidgetId, WidgetId) {

--- a/druid/src/tests/helpers.rs
+++ b/druid/src/tests/helpers.rs
@@ -312,44 +312,12 @@ impl<T: Data, W: Widget<T>> Widget<T> for Recorder<W> {
     }
 }
 
-// TODO - use const generics instead
+pub fn widget_ids<const N: usize>() -> [WidgetId; N] {
+    let mut ids = [WidgetId::reserved(0); N];
 
-// easily make a bunch of WidgetIds
-pub fn widget_id2() -> (WidgetId, WidgetId) {
-    (WidgetId::next(), WidgetId::next())
-}
+    for id in &mut ids {
+        *id = WidgetId::next()
+    }
 
-pub fn widget_id3() -> (WidgetId, WidgetId, WidgetId) {
-    (WidgetId::next(), WidgetId::next(), WidgetId::next())
-}
-
-pub fn widget_id4() -> (WidgetId, WidgetId, WidgetId, WidgetId) {
-    (
-        WidgetId::next(),
-        WidgetId::next(),
-        WidgetId::next(),
-        WidgetId::next(),
-    )
-}
-
-#[allow(dead_code)]
-pub fn widget_id5() -> (WidgetId, WidgetId, WidgetId, WidgetId, WidgetId) {
-    (
-        WidgetId::next(),
-        WidgetId::next(),
-        WidgetId::next(),
-        WidgetId::next(),
-        WidgetId::next(),
-    )
-}
-
-pub fn widget_id6() -> (WidgetId, WidgetId, WidgetId, WidgetId, WidgetId, WidgetId) {
-    (
-        WidgetId::next(),
-        WidgetId::next(),
-        WidgetId::next(),
-        WidgetId::next(),
-        WidgetId::next(),
-        WidgetId::next(),
-    )
+    ids
 }

--- a/druid/src/tests/layout_tests.rs
+++ b/druid/src/tests/layout_tests.rs
@@ -46,7 +46,7 @@ fn simple_layout() {
 
 #[test]
 fn row_column() {
-    let (id1, id2, id3, id4, id5, id6) = widget_id6();
+    let [id1, id2, id3, id4, id5, id6] = widget_ids();
     let widget = Flex::row()
         .must_fill_main_axis(true)
         .with_flex_child(
@@ -81,7 +81,7 @@ fn row_column() {
 
 #[test]
 fn simple_paint_rect() {
-    let (id1, id2) = widget_id2();
+    let [id1, id2] = widget_ids();
 
     let widget = ModularWidget::<(), ()>::new(())
         .layout_fn(|_, ctx, bc, _, _| {

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -14,9 +14,14 @@
 
 //! Additional unit tests that cross file or module boundaries.
 
-pub(crate) mod harness;
-mod helpers;
+#![allow(unused_imports)]
+
+pub mod harness;
+pub mod helpers;
+
+#[cfg(test)]
 mod invalidation_tests;
+#[cfg(test)]
 mod layout_tests;
 
 use std::cell::Cell;
@@ -31,7 +36,8 @@ use harness::*;
 use helpers::*;
 use kurbo::Vec2;
 
-fn move_mouse(p: impl Into<Point>) -> MouseEvent {
+/// Helper function to construct a "move to this position" mouse event.
+pub fn move_mouse(p: impl Into<Point>) -> MouseEvent {
     let pos = p.into();
     MouseEvent {
         pos,
@@ -45,7 +51,8 @@ fn move_mouse(p: impl Into<Point>) -> MouseEvent {
     }
 }
 
-fn scroll_mouse(p: impl Into<Point>, delta: impl Into<Vec2>) -> MouseEvent {
+/// Helper function to construct a "scroll by n ticks" mouse event.
+pub fn scroll_mouse(p: impl Into<Point>, delta: impl Into<Vec2>) -> MouseEvent {
     let pos = p.into();
     MouseEvent {
         pos,
@@ -66,6 +73,7 @@ fn scroll_mouse(p: impl Into<Point>, delta: impl Into<Vec2>) -> MouseEvent {
 /// directory will be cleaned up at the end of the PathBufs lifetime. This
 /// uses the `tempfile` crate.
 #[allow(dead_code)]
+#[cfg(test)]
 pub fn temp_dir_for_test() -> std::path::PathBuf {
     let current_exe_path = env::current_exe().unwrap();
     let mut exe_dir = current_exe_path.parent().unwrap();

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -92,7 +92,7 @@ pub fn temp_dir_for_test() -> std::path::PathBuf {
 /// test that the first widget to request focus during an event gets it.
 #[test]
 fn propagate_hot() {
-    let (button, pad, root, empty) = widget_id4();
+    let [button, pad, root, empty] = widget_ids();
 
     let root_rec = Recording::default();
     let padding_rec = Recording::default();
@@ -210,7 +210,7 @@ fn take_focus() {
             })
     }
 
-    let (id_1, id_2, _id_3) = widget_id3();
+    let [id_1, id_2, _id_3] = widget_ids();
 
     // we use these so that we can check the widget's internal state
     let left_focus: Rc<Cell<Option<bool>>> = Default::default();
@@ -294,7 +294,7 @@ fn focus_changed() {
     let b_rec = Recording::default();
     let c_rec = Recording::default();
 
-    let (id_a, id_b, id_c) = widget_id3();
+    let [id_a, id_b, id_c] = widget_ids();
 
     // a contains b which contains c
     let c = make_focus_container(vec![]).record(&c_rec).with_id(id_c);
@@ -807,7 +807,7 @@ fn adding_child_lifecycle() {
 
 #[test]
 fn participate_in_autofocus() {
-    let (id_1, id_2, id_3, id_4, id_5, id_6) = widget_id6();
+    let [id_1, id_2, id_3, id_4, id_5, id_6] = widget_ids();
 
     // this widget starts with a single child, and will replace them with a split
     // when we send it a command.
@@ -848,7 +848,7 @@ fn participate_in_autofocus() {
 
 #[test]
 fn child_tracking() {
-    let (id_1, id_2, id_3, id_4) = widget_id4();
+    let [id_1, id_2, id_3, id_4] = widget_ids();
 
     let widget = Split::columns(
         SizedBox::empty().with_id(id_1),
@@ -876,8 +876,7 @@ fn child_tracking() {
 #[test]
 /// Test that all children are registered correctly after a child is replaced.
 fn register_after_adding_child() {
-    let (id_1, id_2, id_3, id_4, id_5, id_6) = widget_id6();
-    let id_7 = WidgetId::next();
+    let [id_1, id_2, id_3, id_4, id_5, id_6, id_7] = widget_ids();
 
     let replacer = ReplaceChild::new(Slider::new().with_id(id_1), move || {
         Split::columns(Slider::new().with_id(id_2), Slider::new().with_id(id_3)).with_id(id_7)

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -384,13 +384,11 @@ impl<T: Data> Window<T> {
         self.invalid.clear();
     }
 
-    #[cfg(test)]
     #[allow(dead_code)]
     pub(crate) fn invalid(&self) -> &Region {
         &self.invalid
     }
 
-    #[cfg(test)]
     #[allow(dead_code)]
     pub(crate) fn invalid_mut(&mut self) -> &mut Region {
         &mut self.invalid
@@ -479,7 +477,6 @@ impl<T: Data> Window<T> {
 
     /// only expose `layout` for testing; normally it is called as part of `do_paint`
     #[cfg(not(target_arch = "wasm32"))]
-    #[cfg(test)]
     pub(crate) fn just_layout(&mut self, queue: &mut CommandQueue, data: &T, env: &Env) {
         self.layout(queue, data, env)
     }


### PR DESCRIPTION
Having instrumentation code (eg DebugRequestState) be `#[test]`
makes it impossible to use from parent crates.
This is a problem if you want to do unit tests in something like
panoramix or crochet.