### PR TITLE
Implement an AlwaysOnTop window level

### DIFF
--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -905,12 +905,14 @@ impl WindowHandle {
                 WindowLevel::Tooltip => WindowTypeHint::Tooltip,
                 WindowLevel::DropDown => WindowTypeHint::DropdownMenu,
                 WindowLevel::Modal => WindowTypeHint::Dialog,
+                WindowLevel::AlwaysOnTop => WindowTypeHint::Normal,
             };
 
             state.window.set_type_hint(hint);
         }
 
         self.set_override_redirect(level);
+        self.set_keep_above(level);
     }
 
     /// The override-redirect flag tells the window manager not to mess with the window; it should
@@ -926,6 +928,19 @@ impl WindowHandle {
         if let Some(state) = self.state.upgrade() {
             if let Some(window) = state.window.get_window() {
                 window.set_override_redirect(override_redirect);
+            }
+        }
+    }
+
+    fn set_keep_above(&self, level: WindowLevel) {
+        let keep_above = match level {
+            WindowLevel::AlwaysOnTop => true,
+            _ => false
+        };
+
+        if let Some(state) = self.state.upgrade() {
+            if let Some(window) = state.window.get_window() {
+                window.set_keep_above(keep_above);
             }
         }
     }

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -92,6 +92,7 @@ mod levels {
             Tooltip => NSFloatingWindowLevel,
             DropDown => NSFloatingWindowLevel,
             Modal => NSModalPanelWindowLevel,
+            AlwaysOnTop => NSFloatingWindowLevel,
         }
     }
 }

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -1307,7 +1307,7 @@ impl WindowBuilder {
 
     pub fn set_level(&mut self, level: WindowLevel) {
         match level {
-            WindowLevel::AppWindow | WindowLevel::Tooltip => self.level = Some(level),
+            WindowLevel::AppWindow | WindowLevel::Tooltip | WindowLevel::AlwaysOnTop => self.level = Some(level),
             _ => {
                 warn!("WindowBuilder::set_level({:?}) is currently unimplemented for Windows platforms.", level);
             }
@@ -1370,6 +1370,9 @@ impl WindowBuilder {
                     }
                     WindowLevel::Modal => {
                         dwStyle = WS_OVERLAPPED;
+                        dwExStyle = WS_EX_TOPMOST;
+                    }
+                    WindowLevel::AlwaysOnTop => {
                         dwExStyle = WS_EX_TOPMOST;
                     }
                 }

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -158,6 +158,8 @@ pub enum WindowLevel {
     DropDown,
     /// A modal dialog
     Modal,
+    /// A top level app window that will stay above other windows
+    AlwaysOnTop
 }
 
 /// Contains the different states a Window can be in.


### PR DESCRIPTION
I've found that while Tooltip and Modal do have AlwaysOnTop functionality, they also have special behavior that isn't wanted in some scenarios.

This new WindowLevel is a normal top-level application window that will stay on top of other windows, should work with windows from other applications and while the current application is not in focus.

Currently on Mac it will only stay on top of windows from the same application, getting it to stay on top of windows from other applications while the current application is not in focus may be tricky.