### PR TITLE
Improve unsafe code in GTK clipboard code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - `Notification`s will not be delivered to the widget that sends them ([#1640] by [@cmyr])
 - `TextBox` can handle standard keyboard shortcuts without needing menus ([#1660] by [@cmyr])
 - GTK Shell: Prevent mangling of newline characters in clipboard ([#1695] by [@ForLoveOfCats])
+- GTK: Replaced call to `std::str::from_utf8_unchecked` with `from_utf8` ([#1820] by [@psychon])
 - Use correct fill rule when rendering SVG paths ([#1606] by [@SecondFlight])
 - Correctly capture and use stroke properties when rendering SVG paths ([#1647] by [@SecondFlight])
 - focus-chain now only includes non hidden (`should_propagate_to_hidden()` on `Event` and `Lifecylce`) widgets ([#1724] by [@xarvic])
@@ -726,6 +727,7 @@ Last release without a changelog :(
 [#1772]: https://github.com/linebender/druid/pull/1772
 [#1787]: https://github.com/linebender/druid/pull/1787
 [#1802]: https://github.com/linebender/druid/pull/1802
+[#1820]: https://github.com/linebender/druid/pull/1820
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid-shell/src/platform/gtk/clipboard.rs
+++ b/druid-shell/src/platform/gtk/clipboard.rs
@@ -130,7 +130,8 @@ impl Clipboard {
         let targets = clipboard.wait_for_targets().unwrap_or_default();
         targets
             .iter()
-            .map(|atom| unsafe { format!("{} ({})", atom.name(), atom.value()) })
+            // SAFETY: Atom::value() is 'self.0 as usize'. No idea why that is unsafe.
+            .map(|atom| format!("{} ({})", atom.name(), unsafe { atom.value() }))
             .collect()
     }
 }

--- a/druid-shell/src/platform/gtk/clipboard.rs
+++ b/druid-shell/src/platform/gtk/clipboard.rs
@@ -64,9 +64,17 @@ impl Clipboard {
             let idx = idx as usize;
             if idx < formats.len() {
                 let item = &formats[idx];
+                let mut not_set = true;
                 if item.identifier == ClipboardFormat::TEXT {
-                    sel.set_text(unsafe { std::str::from_utf8_unchecked(&item.data) });
-                } else {
+                    if let Ok(data) = std::str::from_utf8(&item.data) {
+                        sel.set_text(data);
+                        not_set = false;
+                    } else {
+                        tracing::warn!("Failed to put invalid utf8 text into the clipboard");
+                        // The code below will at least put it as "raw bytes"
+                    }
+                }
+                if not_set {
                     let atom = Atom::intern(item.identifier);
                     let stride = 8;
                     sel.set(&atom, stride, item.data.as_slice());

--- a/druid-shell/src/platform/gtk/clipboard.rs
+++ b/druid-shell/src/platform/gtk/clipboard.rs
@@ -64,17 +64,11 @@ impl Clipboard {
             let idx = idx as usize;
             if idx < formats.len() {
                 let item = &formats[idx];
-                let mut not_set = true;
-                if item.identifier == ClipboardFormat::TEXT {
-                    if let Ok(data) = std::str::from_utf8(&item.data) {
-                        sel.set_text(data);
-                        not_set = false;
-                    } else {
-                        tracing::warn!("Failed to put invalid utf8 text into the clipboard");
-                        // The code below will at least put it as "raw bytes"
-                    }
-                }
-                if not_set {
+                if let (ClipboardFormat::TEXT, Ok(data)) =
+                    (item.identifier, std::str::from_utf8(&item.data))
+                {
+                    sel.set_text(data);
+                } else {
                     let atom = Atom::intern(item.identifier);
                     let stride = 8;
                     sel.set(&atom, stride, item.data.as_slice());


### PR DESCRIPTION
    gtk: Replace unsound std::str::from_utf8_unchecked
    
    When putting text data into the clipboard, the platform code was calling
    std::str::from_utf8_unchecked() on the data. That's not really valid,
    because the caller can provide arbitrary bytes. Thus, this commit
    replaces that with a call to std::str::from_utf8().
    
    In case invalid utf8 was provided, the selection is instead set as raw
    bytes. I am not sure what will happen "down the road" with this, but it
    seems to be the best that can be done.
    
    Fixes: https://github.com/linebender/druid/issues/1814
    Signed-off-by: Uli Schlachter <psychon@znc.in>

I also reported https://github.com/gtk-rs/gtk3-rs/issues/564 to make `gdk::Atom::value()` safe (or at least to figure out why it is unsafe).