### PR TITLE
Add DebugState

### DIFF
--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -985,6 +985,18 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                         self.state.children.may_contain(&widget)
                     }
                 }
+                InternalLifeCycle::DebugRequestDebugState { widget, state_cell } => {
+                    if *widget == self.id() {
+                        if let Some(data) = &self.old_data {
+                            state_cell.set(self.inner.debug_state(data));
+                        }
+                        false
+                    } else {
+                        // Recurse when the target widget could be our descendant.
+                        // The bloom filter we're checking can return false positives.
+                        self.state.children.may_contain(&widget)
+                    }
+                }
                 InternalLifeCycle::DebugInspectState(f) => {
                     f.call(&self.state);
                     true

--- a/druid/src/debug_state.rs
+++ b/druid/src/debug_state.rs
@@ -1,0 +1,48 @@
+//! A data structure for representing widget trees.
+
+use std::collections::HashMap;
+
+/// A description widget and its children, clonable and comparable, meant
+/// for testing and debugging. This is extremely not optimized.
+#[derive(Default, Clone, PartialEq, Eq)]
+pub struct DebugState {
+    /// The widget's type as a human-readable string.
+    pub display_name: String,
+    /// If a widget has a "central" value (for instance, a textbox's contents),
+    /// it is stored here.
+    pub main_value: String,
+    /// Untyped values that reveal useful information about the widget.
+    pub other_values: HashMap<String, String>,
+    /// Debug info of child widgets.
+    pub children: Vec<DebugState>,
+}
+
+impl std::fmt::Debug for DebugState {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if self.other_values.is_empty() && self.children.is_empty() && self.main_value.is_empty() {
+            f.write_str(&self.display_name)
+        } else if self.other_values.is_empty() && self.children.is_empty() {
+            f.debug_tuple(&self.display_name)
+                .field(&self.main_value)
+                .finish()
+        } else if self.other_values.is_empty() && self.main_value.is_empty() {
+            let mut f_tuple = f.debug_tuple(&self.display_name);
+            for child in &self.children {
+                f_tuple.field(child);
+            }
+            f_tuple.finish()
+        } else {
+            let mut f_struct = f.debug_struct(&self.display_name);
+            if !self.main_value.is_empty() {
+                f_struct.field("_main_value_", &self.main_value);
+            }
+            for (key, value) in self.other_values.iter() {
+                f_struct.field(&key, &value);
+            }
+            if !self.children.is_empty() {
+                f_struct.field("children", &self.children);
+            }
+            f_struct.finish()
+        }
+    }
+}

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -345,6 +345,18 @@ pub enum InternalLifeCycle {
         /// a cell used to store the a widget's state
         state_cell: StateCell,
     },
+    /// For testing: request the `DebugState` of a specific widget.
+    ///
+    /// This is useful if you need to get a best-effort description of the
+    /// state of this widget and its children. You can dispatch this event,
+    /// specifying the widget in question, and that widget will
+    /// set its state in the provided `Cell`, if it exists.
+    DebugRequestDebugState {
+        /// the widget whose state is requested
+        widget: WidgetId,
+        /// a cell used to store the a widget's state
+        state_cell: DebugStateCell,
+    },
     /// For testing: apply the given function on every widget.
     DebugInspectState(StateCheckFn),
 }
@@ -448,21 +460,27 @@ impl InternalLifeCycle {
             | InternalLifeCycle::RouteDisabledChanged => true,
             InternalLifeCycle::ParentWindowOrigin => false,
             InternalLifeCycle::DebugRequestState { .. }
+            | InternalLifeCycle::DebugRequestDebugState { .. }
             | InternalLifeCycle::DebugInspectState(_) => true,
         }
     }
 }
 
-pub(crate) use state_cell::{StateCell, StateCheckFn};
+pub(crate) use state_cell::{DebugStateCell, StateCell, StateCheckFn};
 
 mod state_cell {
     use crate::core::WidgetState;
+    use crate::debug_state::DebugState;
     use crate::WidgetId;
     use std::{cell::RefCell, rc::Rc};
 
-    /// An interior-mutable struct for fetching BasteState.
+    /// An interior-mutable struct for fetching WidgetState.
     #[derive(Clone, Default)]
     pub struct StateCell(Rc<RefCell<Option<WidgetState>>>);
+
+    /// An interior-mutable struct for fetching DebugState.
+    #[derive(Clone, Default)]
+    pub struct DebugStateCell(Rc<RefCell<Option<DebugState>>>);
 
     #[derive(Clone)]
     pub struct StateCheckFn(Rc<dyn Fn(&WidgetState)>);
@@ -493,6 +511,21 @@ mod state_cell {
         }
     }
 
+    impl DebugStateCell {
+        /// Set the state. This will panic if it is called twice.
+        pub(crate) fn set(&self, state: DebugState) {
+            assert!(
+                self.0.borrow_mut().replace(state).is_none(),
+                "DebugStateCell already set"
+            )
+        }
+
+        #[allow(dead_code)]
+        pub(crate) fn take(&self) -> Option<DebugState> {
+            self.0.borrow_mut().take()
+        }
+    }
+
     impl StateCheckFn {
         #[cfg(not(target_arch = "wasm32"))]
         pub(crate) fn new(f: impl Fn(&WidgetState) + 'static) -> Self {
@@ -506,6 +539,8 @@ mod state_cell {
         }
     }
 
+    // TODO - Use fmt.debug_tuple?
+
     impl std::fmt::Debug for StateCell {
         fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
             let inner = if self.0.borrow().is_some() {
@@ -514,6 +549,17 @@ mod state_cell {
                 "None"
             };
             write!(f, "StateCell({})", inner)
+        }
+    }
+
+    impl std::fmt::Debug for DebugStateCell {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            let inner = if self.0.borrow().is_some() {
+                "Some"
+            } else {
+                "None"
+            };
+            write!(f, "DebugStateCell({})", inner)
         }
     }
 

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -156,6 +156,7 @@ mod command;
 mod contexts;
 mod core;
 mod data;
+pub mod debug_state;
 mod dialog;
 mod env;
 mod event;
@@ -188,7 +189,7 @@ pub use shell::{
     WindowHandle, WindowLevel, WindowState,
 };
 
-pub use crate::core::WidgetPod;
+pub use crate::core::{WidgetPod, WidgetState};
 pub use app::{AppLauncher, WindowConfig, WindowDesc, WindowSizePolicy};
 pub use app_delegate::{AppDelegate, DelegateCtx};
 pub use box_constraints::BoxConstraints;
@@ -209,7 +210,7 @@ pub use win_handler::DruidHandler;
 pub use window::{Window, WindowId};
 
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) use event::{StateCell, StateCheckFn};
+pub(crate) use event::{DebugStateCell, StateCell, StateCheckFn};
 
 #[deprecated(since = "0.8.0", note = "import from druid::text module instead")]
 pub use piet::{FontFamily, FontStyle, FontWeight, TextAlignment};

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -23,6 +23,8 @@ use crate::ext_event::ExtEventHost;
 use crate::piet::{BitmapTarget, Device, Error, ImageFormat, Piet};
 use crate::*;
 
+use crate::debug_state::DebugState;
+
 pub(crate) const DEFAULT_SIZE: Size = Size::new(400., 400.);
 
 /// A type that tries very hard to provide a comforting and safe environment
@@ -208,6 +210,32 @@ impl<T: Data> Harness<'_, T> {
         cell.take()
     }
 
+    /// Retrieve a copy of the root widget's `DebugState` (and by recursion, all others)
+    pub fn get_root_debug_state(&self) -> DebugState {
+        self.inner.root_debug_state()
+    }
+
+    /// Retrieve a copy of this widget's `DebugState`, or die trying.
+    pub fn get_debug_state(&mut self, widget_id: WidgetId) -> DebugState {
+        match self.try_get_debug_state(widget_id) {
+            Some(thing) => thing,
+            None => panic!("get_debug_state failed for widget {:?}", widget_id),
+        }
+    }
+
+    /// Attempt to retrieve a copy of this widget's `DebugState`.
+    pub fn try_get_debug_state(&mut self, widget_id: WidgetId) -> Option<DebugState> {
+        let cell = DebugStateCell::default();
+        let state_cell = cell.clone();
+        self.lifecycle(LifeCycle::Internal(
+            InternalLifeCycle::DebugRequestDebugState {
+                widget: widget_id,
+                state_cell,
+            },
+        ));
+        cell.take()
+    }
+
     /// Inspect the `WidgetState` of each widget in the tree.
     ///
     /// The provided closure will be called on each widget.
@@ -285,6 +313,10 @@ impl<T: Data> Harness<'_, T> {
         self.inner
             .paint_region(&mut self.piet, &self.window_size.to_rect().into());
     }
+
+    pub fn root_debug_state(&self) -> DebugState {
+        self.inner.root_debug_state()
+    }
 }
 
 impl<T: Data> Inner<T> {
@@ -311,6 +343,10 @@ impl<T: Data> Inner<T> {
     fn paint_region(&mut self, piet: &mut Piet, invalid: &Region) {
         self.window
             .do_paint(piet, &invalid, &mut self.cmds, &self.data, &self.env);
+    }
+
+    pub fn root_debug_state(&self) -> DebugState {
+        self.window.root_debug_state(&self.data)
     }
 }
 

--- a/druid/src/widget/align.rs
+++ b/druid/src/widget/align.rs
@@ -14,6 +14,7 @@
 
 //! A widget that aligns its child (for example, centering it).
 
+use crate::debug_state::DebugState;
 use crate::widget::prelude::*;
 use crate::{Data, Rect, Size, UnitPoint, WidgetPod};
 use tracing::{instrument, trace};
@@ -140,6 +141,14 @@ impl<T: Data> Widget<T> for Align<T> {
     #[instrument(name = "Align", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         self.child.paint(ctx, data, env);
+    }
+
+    fn debug_state(&self, data: &T) -> DebugState {
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            children: vec![self.child.widget().debug_state(data)],
+            ..Default::default()
+        }
     }
 }
 

--- a/druid/src/widget/aspect_ratio_box.rs
+++ b/druid/src/widget/aspect_ratio_box.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::debug_state::DebugState;
+
 use druid::widget::prelude::*;
 use druid::Data;
 use tracing::{instrument, warn};
@@ -160,5 +162,13 @@ impl<T: Data> Widget<T> for AspectRatioBox<T> {
 
     fn id(&self) -> Option<WidgetId> {
         self.inner.id()
+    }
+
+    fn debug_state(&self, data: &T) -> DebugState {
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            children: vec![self.inner.debug_state(data)],
+            ..Default::default()
+        }
     }
 }

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -14,6 +14,7 @@
 
 //! A button widget.
 
+use crate::debug_state::DebugState;
 use crate::widget::prelude::*;
 use crate::widget::{Click, ControllerHost, Label, LabelText};
 use crate::{theme, Affine, Data, Insets, LinearGradient, UnitPoint};
@@ -216,5 +217,13 @@ impl<T: Data> Widget<T> for Button<T> {
             ctx.transform(Affine::translate(label_offset));
             self.label.paint(ctx, data, env);
         });
+    }
+
+    fn debug_state(&self, _data: &T) -> DebugState {
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            main_value: self.label.text().to_string(),
+            ..Default::default()
+        }
     }
 }

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -14,6 +14,7 @@
 
 //! A checkbox widget.
 
+use crate::debug_state::DebugState;
 use crate::kurbo::{BezPath, Size};
 use crate::piet::{LineCap, LineJoin, LinearGradient, RenderContext, StrokeStyle, UnitPoint};
 use crate::theme;
@@ -158,5 +159,18 @@ impl Widget<bool> for Checkbox {
 
         // Paint the text label
         self.child_label.draw_at(ctx, (size + x_padding, 0.0));
+    }
+
+    fn debug_state(&self, data: &bool) -> DebugState {
+        let display_value = if *data {
+            format!("[X] {}", self.child_label.text())
+        } else {
+            format!("[_] {}", self.child_label.text())
+        };
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            main_value: display_value,
+            ..Default::default()
+        }
     }
 }

--- a/druid/src/widget/clip_box.rs
+++ b/druid/src/widget/clip_box.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::debug_state::DebugState;
 use crate::kurbo::{Affine, Point, Rect, Size, Vec2};
 use crate::widget::prelude::*;
 use crate::widget::Axis;
@@ -376,6 +377,14 @@ impl<T: Data, W: Widget<T>> Widget<T> for ClipBox<T, W> {
             visible += offset;
             ctx.with_child_ctx(visible, |ctx| self.child.paint_raw(ctx, data, env));
         });
+    }
+
+    fn debug_state(&self, data: &T) -> DebugState {
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            children: vec![self.child.widget().debug_state(data)],
+            ..Default::default()
+        }
     }
 }
 

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -15,6 +15,7 @@
 //! A widget that provides simple visual styling options to a child.
 
 use super::BackgroundBrush;
+use crate::debug_state::DebugState;
 use crate::widget::prelude::*;
 use crate::{Color, Data, KeyOrValue, Point, WidgetPod};
 use tracing::{instrument, trace, trace_span};
@@ -215,5 +216,13 @@ impl<T: Data> Widget<T> for Container<T> {
         };
 
         self.inner.paint(ctx, data, env);
+    }
+
+    fn debug_state(&self, data: &T) -> DebugState {
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            children: vec![self.inner.widget().debug_state(data)],
+            ..Default::default()
+        }
     }
 }

--- a/druid/src/widget/controller.rs
+++ b/druid/src/widget/controller.rs
@@ -14,6 +14,7 @@
 
 //! A widget-controlling widget.
 
+use crate::debug_state::DebugState;
 use crate::widget::prelude::*;
 use crate::widget::WidgetWrapper;
 
@@ -132,6 +133,14 @@ impl<T, W: Widget<T>, C: Controller<T, W>> Widget<T> for ControllerHost<W, C> {
 
     fn id(&self) -> Option<WidgetId> {
         self.widget.id()
+    }
+
+    fn debug_state(&self, data: &T) -> DebugState {
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            children: vec![self.widget.debug_state(data)],
+            ..Default::default()
+        }
     }
 }
 

--- a/druid/src/widget/disable_if.rs
+++ b/druid/src/widget/disable_if.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::debug_state::DebugState;
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
     Point, Size, UpdateCtx, Widget, WidgetPod,
@@ -67,5 +68,13 @@ impl<T: Data, W: Widget<T>> Widget<T> for DisabledIf<T, W> {
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         self.inner.paint(ctx, data, env);
+    }
+
+    fn debug_state(&self, data: &T) -> DebugState {
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            children: vec![self.inner.widget().debug_state(data)],
+            ..Default::default()
+        }
     }
 }

--- a/druid/src/widget/either.rs
+++ b/druid/src/widget/either.rs
@@ -14,6 +14,7 @@
 
 //! A widget that switches dynamically between two child views.
 
+use crate::debug_state::DebugState;
 use crate::widget::prelude::*;
 use crate::{Data, Point, WidgetPod};
 use tracing::instrument;
@@ -92,6 +93,19 @@ impl<T: Data> Widget<T> for Either<T> {
     #[instrument(name = "Either", level = "trace", skip(self, ctx, data, env), fields(branch = self.current))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         self.current_widget().paint(ctx, data, env)
+    }
+
+    fn debug_state(&self, data: &T) -> DebugState {
+        let current_widget = if self.current {
+            &self.true_branch
+        } else {
+            &self.false_branch
+        };
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            children: vec![current_widget.widget().debug_state(data)],
+            ..Default::default()
+        }
     }
 }
 

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -14,6 +14,7 @@
 
 //! A widget that accepts a closure to update the environment for its child.
 
+use crate::debug_state::DebugState;
 use crate::widget::prelude::*;
 use crate::widget::WidgetWrapper;
 use crate::{Data, Point, WidgetPod};
@@ -103,6 +104,14 @@ impl<T: Data, W: Widget<T>> Widget<T> for EnvScope<T, W> {
         (self.f)(&mut new_env, &data);
 
         self.child.paint(ctx, data, &new_env);
+    }
+
+    fn debug_state(&self, data: &T) -> DebugState {
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            children: vec![self.child.widget().debug_state(data)],
+            ..Default::default()
+        }
     }
 }
 

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -14,6 +14,7 @@
 
 //! A widget that arranges its children in a one-dimensional array.
 
+use crate::debug_state::DebugState;
 use crate::kurbo::{common::FloatExt, Vec2};
 use crate::widget::prelude::*;
 use crate::{Data, KeyOrValue, Point, Rect, WidgetPod};
@@ -866,6 +867,23 @@ impl<T: Data> Widget<T> for Flex<T> {
             let line = crate::kurbo::Line::new((0.0, my_baseline), (ctx.size().width, my_baseline));
             let stroke_style = crate::piet::StrokeStyle::new().dash_pattern(&[4.0, 4.0]);
             ctx.stroke_styled(line, &color, 1.0, &stroke_style);
+        }
+    }
+
+    fn debug_state(&self, data: &T) -> DebugState {
+        let children_state = self
+            .children
+            .iter()
+            .map(|child| {
+                let child_widget_pod = child.widget()?;
+                Some(child_widget_pod.widget().debug_state(data))
+            })
+            .flatten()
+            .collect();
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            children: children_state,
+            ..Default::default()
         }
     }
 }

--- a/druid/src/widget/identity_wrapper.rs
+++ b/druid/src/widget/identity_wrapper.rs
@@ -14,6 +14,7 @@
 
 //! A widget that provides an explicit identity to a child.
 
+use crate::debug_state::DebugState;
 use crate::kurbo::Size;
 use crate::widget::prelude::*;
 use crate::widget::WidgetWrapper;
@@ -77,6 +78,14 @@ impl<T: Data, W: Widget<T>> Widget<T> for IdentityWrapper<W> {
 
     fn id(&self) -> Option<WidgetId> {
         Some(self.id)
+    }
+
+    fn debug_state(&self, data: &T) -> DebugState {
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            children: vec![self.inner.debug_state(data)],
+            ..Default::default()
+        }
     }
 }
 

--- a/druid/src/widget/invalidation.rs
+++ b/druid/src/widget/invalidation.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::debug_state::DebugState;
 use crate::widget::prelude::*;
 use crate::Data;
 use tracing::instrument;
@@ -92,5 +93,13 @@ impl<T: Data, W: Widget<T>> Widget<T> for DebugInvalidation<T, W> {
 
     fn id(&self) -> Option<WidgetId> {
         self.inner.id()
+    }
+
+    fn debug_state(&self, data: &T) -> DebugState {
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            children: vec![self.inner.debug_state(data)],
+            ..Default::default()
+        }
     }
 }

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -18,6 +18,7 @@ use std::ops::{Deref, DerefMut};
 
 use druid_shell::Cursor;
 
+use crate::debug_state::DebugState;
 use crate::kurbo::Vec2;
 use crate::text::TextStorage;
 use crate::widget::prelude::*;
@@ -525,6 +526,14 @@ impl<T: Data> Widget<T> for Label<T> {
             tracing::warn!("Label text changed without call to update. See LabelAdapter::set_text for information.");
         }
         self.label.paint(ctx, &self.current_text, env)
+    }
+
+    fn debug_state(&self, _data: &T) -> DebugState {
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            main_value: self.current_text.to_string(),
+            ..Default::default()
+        }
     }
 }
 

--- a/druid/src/widget/lens_wrap.rs
+++ b/druid/src/widget/lens_wrap.rs
@@ -20,6 +20,7 @@
 
 use std::marker::PhantomData;
 
+use crate::debug_state::DebugState;
 use crate::widget::prelude::*;
 use crate::widget::WidgetWrapper;
 use crate::{Data, Lens};
@@ -136,6 +137,15 @@ where
 
     fn id(&self) -> Option<WidgetId> {
         self.inner.id()
+    }
+
+    fn debug_state(&self, data: &T) -> DebugState {
+        let child_state = self.lens.with(data, |data| self.inner.debug_state(data));
+        DebugState {
+            display_name: "LensWrap".to_string(),
+            children: vec![child_state],
+            ..Default::default()
+        }
     }
 }
 

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -26,6 +26,7 @@ use crate::im::{OrdMap, Vector};
 
 use crate::kurbo::{Point, Rect, Size};
 
+use crate::debug_state::DebugState;
 use crate::{
     widget::Axis, BoxConstraints, Data, Env, Event, EventCtx, KeyOrValue, LayoutCtx, LifeCycle,
     LifeCycleCtx, PaintCtx, UpdateCtx, Widget, WidgetPod,
@@ -406,5 +407,21 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
                 child.paint(ctx, child_data, env);
             }
         });
+    }
+
+    fn debug_state(&self, data: &T) -> DebugState {
+        let mut children = self.children.iter();
+        let mut children_state = Vec::with_capacity(data.data_len());
+        data.for_each(|child_data, _| {
+            if let Some(child) = children.next() {
+                children_state.push(child.widget().debug_state(child_data));
+            }
+        });
+
+        DebugState {
+            display_name: "List".to_string(),
+            children: children_state,
+            ..Default::default()
+        }
     }
 }

--- a/druid/src/widget/maybe.rs
+++ b/druid/src/widget/maybe.rs
@@ -14,6 +14,8 @@
 
 //! A widget for optional data, with different `Some` and `None` children.
 
+use crate::debug_state::DebugState;
+
 use druid::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Size,
     UpdateCtx, Widget, WidgetExt, WidgetPod,
@@ -140,6 +142,19 @@ impl<T: Data> Widget<Option<T>> for Maybe<T> {
             Some(d) => self.widget.with_some(|w| w.paint(ctx, d, env)),
             None => self.widget.with_none(|w| w.paint(ctx, &(), env)),
         };
+    }
+
+    fn debug_state(&self, data: &Option<T>) -> DebugState {
+        let child_state = match (&self.widget, data.as_ref()) {
+            (MaybeWidget::Some(widget_pod), Some(d)) => vec![widget_pod.widget().debug_state(d)],
+            (MaybeWidget::None(widget_pod), None) => vec![widget_pod.widget().debug_state(&())],
+            _ => vec![],
+        };
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            children: child_state,
+            ..Default::default()
+        }
     }
 }
 

--- a/druid/src/widget/padding.rs
+++ b/druid/src/widget/padding.rs
@@ -14,6 +14,7 @@
 
 //! A widget that just adds padding during layout.
 
+use crate::debug_state::DebugState;
 use crate::widget::{prelude::*, WidgetWrapper};
 use crate::{Data, Insets, KeyOrValue, Point, WidgetPod};
 
@@ -112,5 +113,13 @@ impl<T: Data, W: Widget<T>> Widget<T> for Padding<T, W> {
     #[instrument(name = "Padding", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         self.child.paint(ctx, data, env);
+    }
+
+    fn debug_state(&self, data: &T) -> DebugState {
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            children: vec![self.child.widget().debug_state(data)],
+            ..Default::default()
+        }
     }
 }

--- a/druid/src/widget/parse.rs
+++ b/druid/src/widget/parse.rs
@@ -17,6 +17,7 @@ use std::mem;
 use std::str::FromStr;
 use tracing::instrument;
 
+use crate::debug_state::DebugState;
 use crate::widget::prelude::*;
 use crate::Data;
 
@@ -86,5 +87,13 @@ impl<T: FromStr + Display + Data, W: Widget<String>> Widget<Option<T>> for Parse
 
     fn id(&self) -> Option<WidgetId> {
         self.widget.id()
+    }
+
+    fn debug_state(&self, _data: &Option<T>) -> DebugState {
+        DebugState {
+            display_name: "Parse".to_string(),
+            main_value: self.state.clone(),
+            ..Default::default()
+        }
     }
 }

--- a/druid/src/widget/progress_bar.rs
+++ b/druid/src/widget/progress_bar.rs
@@ -14,6 +14,7 @@
 
 //! A progress bar widget.
 
+use crate::debug_state::DebugState;
 use crate::widget::prelude::*;
 use crate::{theme, LinearGradient, Point, Rect, UnitPoint};
 use tracing::instrument;
@@ -117,5 +118,13 @@ impl Widget<f64> for ProgressBar {
             (env.get(theme::PRIMARY_LIGHT), env.get(theme::PRIMARY_DARK)),
         );
         ctx.fill(rounded_rect, &bar_gradient);
+    }
+
+    fn debug_state(&self, data: &f64) -> DebugState {
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            main_value: data.to_string(),
+            ..Default::default()
+        }
     }
 }

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -14,6 +14,7 @@
 
 //! A radio button widget.
 
+use crate::debug_state::DebugState;
 use crate::kurbo::Circle;
 use crate::widget::prelude::*;
 use crate::widget::{CrossAxisAlignment, Flex, Label, LabelText};
@@ -161,5 +162,18 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
 
         // Paint the text label
         self.child_label.draw_at(ctx, (size + x_padding, 0.0));
+    }
+
+    fn debug_state(&self, data: &T) -> DebugState {
+        let value_text = if *data == self.variant {
+            format!("[X] {}", self.child_label.text())
+        } else {
+            self.child_label.text().to_string()
+        };
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            main_value: value_text,
+            ..Default::default()
+        }
     }
 }

--- a/druid/src/widget/scope.rs
+++ b/druid/src/widget/scope.rs
@@ -307,6 +307,9 @@ impl<SP: ScopePolicy, W: Widget<SP::State>> Widget<SP::In> for Scope<SP, W> {
     fn paint(&mut self, ctx: &mut PaintCtx, data: &SP::In, env: &Env) {
         self.with_state(data, |state, inner| inner.paint_raw(ctx, state, env));
     }
+
+    // TODO
+    // fn debug_state(&self, data: &SP::In) -> DebugState;
 }
 
 impl<SP: ScopePolicy, W: Widget<SP::State>> WidgetWrapper for Scope<SP, W> {

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -14,6 +14,7 @@
 
 //! A container that scrolls its contents.
 
+use crate::debug_state::DebugState;
 use crate::widget::prelude::*;
 use crate::widget::{Axis, ClipBox};
 use crate::{scroll_component::*, Data, Rect, Vec2};
@@ -225,6 +226,14 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
         self.clip.paint(ctx, data, env);
         self.scroll_component
             .draw_bars(ctx, &self.clip.viewport(), env);
+    }
+
+    fn debug_state(&self, data: &T) -> DebugState {
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            children: vec![self.clip.debug_state(data)],
+            ..Default::default()
+        }
     }
 }
 

--- a/druid/src/widget/sized_box.rs
+++ b/druid/src/widget/sized_box.rs
@@ -14,6 +14,7 @@
 
 //! A widget with predefined size.
 
+use crate::debug_state::DebugState;
 use std::f64::INFINITY;
 use tracing::{instrument, trace, warn};
 
@@ -189,6 +190,19 @@ impl<T: Data> Widget<T> for SizedBox<T> {
 
     fn id(&self) -> Option<WidgetId> {
         self.inner.as_ref().and_then(|inner| inner.id())
+    }
+
+    fn debug_state(&self, data: &T) -> DebugState {
+        let children = if let Some(child) = &self.inner {
+            vec![child.debug_state(data)]
+        } else {
+            vec![]
+        };
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            children,
+            ..Default::default()
+        }
     }
 }
 

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -14,6 +14,7 @@
 
 //! A slider widget.
 
+use crate::debug_state::DebugState;
 use crate::kurbo::{Circle, Shape};
 use crate::widget::prelude::*;
 use crate::{theme, LinearGradient, Point, Rect, UnitPoint};
@@ -230,5 +231,13 @@ impl Widget<f64> for Slider {
 
         //Actually paint the knob
         ctx.fill(knob_circle, &knob_gradient);
+    }
+
+    fn debug_state(&self, data: &f64) -> DebugState {
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            main_value: data.to_string(),
+            ..Default::default()
+        }
     }
 }

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -14,6 +14,7 @@
 
 //! A widget which splits an area in two, with a settable ratio, and optional draggable resizing.
 
+use crate::debug_state::DebugState;
 use crate::kurbo::Line;
 use crate::widget::flex::Axis;
 use crate::widget::prelude::*;
@@ -500,5 +501,16 @@ impl<T: Data> Widget<T> for Split<T> {
         }
         self.child1.paint(ctx, &data, env);
         self.child2.paint(ctx, &data, env);
+    }
+
+    fn debug_state(&self, data: &T) -> DebugState {
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            children: vec![
+                self.child1.widget().debug_state(data),
+                self.child2.widget().debug_state(data),
+            ],
+            ..Default::default()
+        }
     }
 }

--- a/druid/src/widget/stepper.rs
+++ b/druid/src/widget/stepper.rs
@@ -18,6 +18,7 @@ use std::f64::EPSILON;
 use std::time::Duration;
 use tracing::{instrument, trace};
 
+use crate::debug_state::DebugState;
 use crate::kurbo::BezPath;
 use crate::piet::{LinearGradient, RenderContext, UnitPoint};
 use crate::widget::prelude::*;
@@ -280,6 +281,14 @@ impl Widget<f64> for Stepper {
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &f64, data: &f64, _env: &Env) {
         if (*data - old_data).abs() > EPSILON {
             ctx.request_paint();
+        }
+    }
+
+    fn debug_state(&self, data: &f64) -> DebugState {
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            main_value: data.to_string(),
+            ..Default::default()
         }
     }
 }

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -17,6 +17,7 @@
 use std::time::Duration;
 use tracing::{instrument, trace};
 
+use crate::debug_state::DebugState;
 use crate::kurbo::{Circle, Shape};
 use crate::piet::{LinearGradient, RenderContext, UnitPoint};
 use crate::widget::prelude::*;
@@ -333,5 +334,13 @@ impl Widget<bool> for Switch {
 
         // paint on/off label
         self.paint_labels(ctx, env, switch_width);
+    }
+
+    fn debug_state(&self, data: &bool) -> DebugState {
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            main_value: data.to_string(),
+            ..Default::default()
+        }
     }
 }

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -17,6 +17,7 @@
 use std::time::Duration;
 use tracing::{instrument, trace};
 
+use crate::debug_state::DebugState;
 use crate::kurbo::Insets;
 use crate::piet::TextLayout as _;
 use crate::text::{
@@ -620,6 +621,15 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
 
         // Paint the border
         ctx.stroke(clip_rect, &border_color, border_width);
+    }
+
+    fn debug_state(&self, data: &T) -> DebugState {
+        let text = data.slice(0..data.len()).unwrap_or_default();
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            main_value: text.to_string(),
+            ..Default::default()
+        }
     }
 }
 

--- a/druid/src/widget/value_textbox.rs
+++ b/druid/src/widget/value_textbox.rs
@@ -17,6 +17,7 @@
 use tracing::instrument;
 
 use super::TextBox;
+use crate::debug_state::DebugState;
 use crate::text::{Formatter, Selection, TextComponent, ValidationError};
 use crate::widget::prelude::*;
 use crate::{Data, Selector};
@@ -413,5 +414,13 @@ impl<T: Data + std::fmt::Debug> Widget<T> for ValueTextBox<T> {
     #[instrument(name = "ValueTextBox", level = "trace", skip(self, ctx, _data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, _data: &T, env: &Env) {
         self.inner.paint(ctx, &self.buffer, env);
+    }
+
+    fn debug_state(&self, _data: &T) -> DebugState {
+        DebugState {
+            display_name: self.short_type_name().to_string(),
+            main_value: self.buffer.clone(),
+            ..Default::default()
+        }
     }
 }

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -27,6 +27,7 @@ use crate::shell::{text::InputHandler, Counter, Cursor, Region, TextFieldToken, 
 use crate::app::{PendingWindow, WindowSizePolicy};
 use crate::contexts::ContextState;
 use crate::core::{CommandQueue, FocusChange, WidgetState};
+use crate::debug_state::DebugState;
 use crate::menu::{MenuItemId, MenuManager};
 use crate::text::TextFieldRegistration;
 use crate::util::ExtendDrain;
@@ -521,6 +522,11 @@ impl<T: Data> Window<T> {
         if self.wants_animation_frame() {
             self.handle.request_anim_frame();
         }
+    }
+
+    /// Get a best-effort representation of the entire widget tree for debug purposes.
+    pub fn root_debug_state(&self, data: &T) -> DebugState {
+        self.root.widget().debug_state(data)
     }
 
     pub(crate) fn update_title(&mut self, data: &T, env: &Env) {


### PR DESCRIPTION
Note: In past discussions, we mentioned the possibility of putting additions like these behind a feature flag. I'm usually against it, because it adds more build configs to test for in CI and before pushing.

But Colin and others have raised valid points; in particular, that feature flags are useful if they can reduce compile times. So in this case, I've tested `cargo build` for and after this PR's commit.

Before:

```
Executed in   65.23 secs   fish           external 
   usr time  303.03 secs  254.00 micros  303.03 secs 
   sys time   18.20 secs  127.00 micros   18.20 secs 
```

After:

```
Executed in   65.42 secs   fish           external 
   usr time  303.62 secs   10.59 millis  303.61 secs 
   sys time   17.83 secs    1.19 millis   17.83 secs 
```

Since there's virtually no difference, I don't think it worth adding a feature flag.