### PR TITLE
Add HasRawWindowHandle for WindowHandle in druid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - Linux extension: primary_clipboard ([#1843] by [@Maan2003])
 - x11: Implement primary_clipboard ([#1867] by [@psychon])
 - x11: Set WM_CLASS property ([#1868] by [@psychon])
+- Expose `RawWindowHandle` for `WindowHandle` under the `raw-win-handle` feature ([#1828] by [@djeedai])
 
 ### Changed
 
@@ -751,6 +752,7 @@ Last release without a changelog :(
 [#1805]: https://github.com/linebender/druid/pull/1805
 [#1820]: https://github.com/linebender/druid/pull/1820
 [#1825]: https://github.com/linebender/druid/pull/1825
+[#1828]: https://github.com/linebender/druid/pull/1828
 [#1843]: https://github.com/linebender/druid/pull/1843
 [#1850]: https://github.com/linebender/druid/pull/1850
 [#1851]: https://github.com/linebender/druid/pull/1851

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -43,6 +43,10 @@ pub use image;
 pub use kurbo;
 pub use piet_common as piet;
 
+// Reexport the version of `raw_window_handle` we are using.
+#[cfg(feature = "raw-win-handle")]
+pub use raw_window_handle;
+
 #[macro_use]
 mod util;
 

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -28,6 +28,9 @@ x11 = ["druid-shell/x11"]
 crochet = []
 serde = ["im/serde", "druid-shell/serde"]
 
+# Implement HasRawWindowHandle for WindowHandle
+raw-win-handle = ["druid-shell/raw-win-handle"]
+
 # passing on all the image features. AVIF is not supported because it does not
 # support decoding, and that's all we use `Image` for.
 png = ["druid-shell/image_png"]

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -188,6 +188,9 @@ pub use shell::{
     WindowHandle, WindowLevel, WindowState,
 };
 
+#[cfg(feature = "raw-win-handle")]
+pub use crate::shell::raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+
 pub use crate::core::WidgetPod;
 pub use app::{AppLauncher, WindowConfig, WindowDesc, WindowSizePolicy};
 pub use app_delegate::{AppDelegate, DelegateCtx};


### PR DESCRIPTION
Expose the `HasRawWindowHandle` trait impl of druid-shell for
`WindowHandle` into druid itself, so druid users can access it. This
is also under a `raw-win-handle` feature, like the druid-shell one.

Bug: #1505