### PR TITLE
Avoid undefined behaviour in GTK animation frames

### DIFF
--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -382,7 +382,7 @@ impl WindowBuilder {
                                 state.request_animation.set(false);
                                 let vbox = state.window.get_children().first().unwrap().clone()
                                     .downcast::<gtk::Box>()
-                                    .unwrap().clone();
+                                    .unwrap();
                                 let first_child = vbox.get_children().last().unwrap().clone();
                                 if first_child.is::<gtk::DrawingArea>() {
                                     first_child.queue_draw();

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -382,8 +382,8 @@ impl WindowBuilder {
                                 state.request_animation.set(false);
                                 let vbox = state.window.get_children().first().unwrap()
                                     .downcast::<gtk::Box>()
-                                    .unwrap();
-                                let first_child = &vbox.get_children().last().unwrap();
+                                    .unwrap().clone();
+                                let first_child = vbox.get_children().last().unwrap().clone();
                                 if first_child.is::<gtk::DrawingArea>() {
                                     first_child.queue_draw();
                                 }
@@ -1212,7 +1212,7 @@ impl WindowHandle {
                 .downcast::<gtk::Box>()
                 .unwrap();
 
-            let first_child = vbox.get_children().first().unwrap();
+            let first_child = vbox.get_children().first().unwrap().clone();
             if let Some(old_menubar) = first_child.downcast_ref::<gtk::MenuBar>() {
                 old_menubar.deactivate();
                 vbox.remove(old_menubar);

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -380,7 +380,7 @@ impl WindowBuilder {
                             state.in_draw.set(false);
                             if state.request_animation.get() {
                                 state.request_animation.set(false);
-                                let vbox = state.window.get_children().first().unwrap()
+                                let vbox = state.window.get_children().first().unwrap().clone()
                                     .downcast::<gtk::Box>()
                                     .unwrap().clone();
                                 let first_child = vbox.get_children().last().unwrap().clone();
@@ -823,7 +823,7 @@ impl WindowState {
                 .clone()
                 .downcast::<gtk::Box>()
                 .unwrap();
-            let first_child = vbox.get_children().last().unwrap();
+            let first_child = vbox.get_children().last().unwrap().clone();
             if first_child.is::<gtk::DrawingArea>() {
                 first_child.queue_draw();
             }

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -29,7 +29,7 @@ use cairo::Surface;
 use gdk::{EventKey, EventMask, ModifierType, ScrollDirection, WindowExt, WindowTypeHint};
 use gio::ApplicationExt;
 use gtk::prelude::*;
-use gtk::{AccelGroup, ApplicationWindow, DrawingArea, SettingsExt};
+use gtk::{AccelGroup, ApplicationWindow, BinExt, DrawingArea, SettingsExt};
 use tracing::{error, warn};
 
 #[cfg(feature = "raw-win-handle")]

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -369,7 +369,7 @@ impl WindowBuilder {
         win_state
             .drawing_area
             .connect_realize(clone!(handle => move |drawing_area| {
-                if let Some(clock) = drawing_area.frame_clock() {
+                if let Some(clock) = drawing_area.get_frame_clock() {
                     clock.connect_before_paint(clone!(handle => move |_clock|{
                         if let Some(state) = handle.state.upgrade() {
                             state.in_draw.set(true);

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -29,7 +29,7 @@ use cairo::Surface;
 use gdk::{EventKey, EventMask, ModifierType, ScrollDirection, WindowExt, WindowTypeHint};
 use gio::ApplicationExt;
 use gtk::prelude::*;
-use gtk::{AccelGroup, ApplicationWindow, ContainerExt, DrawingArea, SettingsExt};
+use gtk::{AccelGroup, ApplicationWindow, DrawingArea, SettingsExt};
 use tracing::{error, warn};
 
 #[cfg(feature = "raw-win-handle")]
@@ -815,18 +815,7 @@ impl WindowState {
         if self.in_draw.get() {
             self.request_animation.set(true);
         } else {
-            let vbox = &self
-                .window
-                .get_children()
-                .first()
-                .unwrap()
-                .clone()
-                .downcast::<gtk::Box>()
-                .unwrap();
-            let first_child = vbox.get_children().last().unwrap().clone();
-            if first_child.is::<gtk::DrawingArea>() {
-                first_child.queue_draw();
-            }
+            self.drawing_area.queue_draw()
         }
     }
 
@@ -1203,7 +1192,6 @@ impl WindowHandle {
     pub fn set_menu(&self, menu: Menu) {
         if let Some(state) = self.state.upgrade() {
             let window = &state.window;
-
             let accel_group = AccelGroup::new();
             window.add_accel_group(&accel_group);
 
@@ -1212,7 +1200,7 @@ impl WindowHandle {
                 .downcast::<gtk::Box>()
                 .unwrap();
 
-            let first_child = vbox.get_children().first().unwrap().clone();
+            let first_child = &vbox.get_children()[0];
             if let Some(old_menubar) = first_child.downcast_ref::<gtk::MenuBar>() {
                 old_menubar.deactivate();
                 vbox.remove(old_menubar);

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -29,7 +29,7 @@ use cairo::Surface;
 use gdk::{EventKey, EventMask, ModifierType, ScrollDirection, WindowExt, WindowTypeHint};
 use gio::ApplicationExt;
 use gtk::prelude::*;
-use gtk::{AccelGroup, ApplicationWindow, BinExt, DrawingArea, SettingsExt};
+use gtk::{AccelGroup, ApplicationWindow, ContainerExt, DrawingArea, SettingsExt};
 use tracing::{error, warn};
 
 #[cfg(feature = "raw-win-handle")]
@@ -380,10 +380,10 @@ impl WindowBuilder {
                             state.in_draw.set(false);
                             if state.request_animation.get() {
                                 state.request_animation.set(false);
-                                let vbox = window.first_child().unwrap()
+                                let vbox = window.get_children().first().unwrap()
                                     .downcast::<gtk::Box>()
                                     .unwrap();
-                                let first_child = &vbox.last_child().unwrap();
+                                let first_child = &vbox.get_children().last().unwrap();
                                 if first_child.is::<gtk::DrawingArea>() {
                                     first_child.queue_draw();
                                 }
@@ -817,11 +817,12 @@ impl WindowState {
         } else {
             let vbox = self
                 .window
-                .first_child()
+                .get_children()
+                .first()
                 .unwrap()
                 .downcast::<gtk::Box>()
                 .unwrap();
-            let first_child = &vbox.last_child().unwrap();
+            let first_child = &vbox.get_children().last().unwrap();
             if first_child.is::<gtk::DrawingArea>() {
                 first_child.queue_draw();
             }
@@ -1210,7 +1211,7 @@ impl WindowHandle {
                 .downcast::<gtk::Box>()
                 .unwrap();
 
-            let first_child = &vbox.get_children()[0];
+            let first_child = &vbox.get_children().first().unwrap();
             if let Some(old_menubar) = first_child.downcast_ref::<gtk::MenuBar>() {
                 old_menubar.deactivate();
                 vbox.remove(first_child);

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -380,13 +380,7 @@ impl WindowBuilder {
                             state.in_draw.set(false);
                             if state.request_animation.get() {
                                 state.request_animation.set(false);
-                                let vbox = state.window.get_children().first().unwrap().clone()
-                                    .downcast::<gtk::Box>()
-                                    .unwrap();
-                                let first_child = vbox.get_children().last().unwrap().clone();
-                                if first_child.is::<gtk::DrawingArea>() {
-                                    first_child.queue_draw();
-                                }
+                                state.drawing_area.queue_draw();
                             }
                         }
                     }));

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -1211,7 +1211,7 @@ impl WindowHandle {
                 .downcast::<gtk::Box>()
                 .unwrap();
 
-            let first_child = &vbox.get_children().first().unwrap();
+            let first_child = vbox.get_children().first().unwrap();
             if let Some(old_menubar) = first_child.downcast_ref::<gtk::MenuBar>() {
                 old_menubar.deactivate();
                 vbox.remove(first_child);

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -380,7 +380,7 @@ impl WindowBuilder {
                             state.in_draw.set(false);
                             if state.request_animation.get() {
                                 state.request_animation.set(false);
-                                let vbox = window.get_children().first().unwrap()
+                                let vbox = state.window.get_children().first().unwrap()
                                     .downcast::<gtk::Box>()
                                     .unwrap();
                                 let first_child = &vbox.get_children().last().unwrap();
@@ -815,14 +815,15 @@ impl WindowState {
         if self.in_draw.get() {
             self.request_animation.set(true);
         } else {
-            let vbox = self
+            let vbox = &self
                 .window
                 .get_children()
                 .first()
                 .unwrap()
+                .clone()
                 .downcast::<gtk::Box>()
                 .unwrap();
-            let first_child = &vbox.get_children().last().unwrap();
+            let first_child = vbox.get_children().last().unwrap();
             if first_child.is::<gtk::DrawingArea>() {
                 first_child.queue_draw();
             }
@@ -1214,7 +1215,7 @@ impl WindowHandle {
             let first_child = vbox.get_children().first().unwrap();
             if let Some(old_menubar) = first_child.downcast_ref::<gtk::MenuBar>() {
                 old_menubar.deactivate();
-                vbox.remove(first_child);
+                vbox.remove(old_menubar);
             }
             let menubar = menu.into_gtk_menubar(self, &accel_group);
             vbox.pack_start(&menubar, false, false, 0);


### PR DESCRIPTION
Requestion an animation frame is and always has been undefined behaviour. 
This is not documented ANYWHERE besides the brains of whoever coded this.
See https://gitlab.gnome.org/GNOME/gtk/-/issues/3703.