### PR TITLE
Hacky support for protected text fields

### DIFF
--- a/druid/examples/textbox.rs
+++ b/druid/examples/textbox.rs
@@ -21,8 +21,8 @@ use std::sync::Arc;
 
 use druid::widget::{Flex, Label, TextBox};
 use druid::{
-    AppLauncher, Color, Data, Env, Lens, LocalizedString, Menu, Widget, WidgetExt, WindowDesc,
-    WindowId,
+    AppLauncher, Color, Data, Env, FontDescriptor, FontFamily, Lens, LocalizedString, Menu, Widget,
+    WidgetExt, WindowDesc, WindowId,
 };
 
 const WINDOW_TITLE: LocalizedString<AppState> = LocalizedString::new("Text Options");
@@ -39,6 +39,7 @@ const EXPLAINER: &str = "\
 struct AppState {
     multi: Arc<String>,
     single: Arc<String>,
+    password: Arc<String>,
 }
 
 pub fn main() {
@@ -52,6 +53,7 @@ pub fn main() {
     let initial_state = AppState {
         single: "".to_string().into(),
         multi: "".to_string().into(),
+        password: "".to_string().into(),
     };
 
     // start the application
@@ -76,6 +78,13 @@ fn build_root_widget() -> impl Widget<AppState> {
             TextBox::new()
                 .with_placeholder("Single")
                 .lens(AppState::single),
+        )
+        .with_default_spacer()
+        .with_child(
+            TextBox::protected()
+                .with_font(FontDescriptor::new(FontFamily::MONOSPACE))
+                .with_placeholder("Password")
+                .lens(AppState::password),
         )
         .with_default_spacer()
         .with_flex_child(

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -102,6 +102,27 @@ impl<T: EditableText + TextStorage> TextBox<T> {
         this
     }
 
+    /// Return a new textbox suitable for protected (password) input.
+    ///
+    /// This is a hack, and has some constraints / limitations / problems.
+    /// Specifically, all measurement and cursor positioning is done on the
+    /// actual password text. To make this kind of work, we need to use a
+    /// monospace font, so that cursors and selections *generally* line up with
+    /// the replacement glyphs.
+    ///
+    /// Unfortunately, this only works for glyphs that respect the mono width.
+    /// If you enter glyphs that do not (like wide east asian characters, emoji,
+    /// etc) then the cursor positions and selections will get weird.
+    ///
+    /// This obviously isn't ideal, but it feels like a reasonable tradeoff
+    /// for the time being.
+    pub fn protected() -> Self {
+        let mut this = TextBox::new();
+        this.text_mut().borrow_mut().set_protected_input(true);
+        this.set_font(FontDescriptor::new(druid::FontFamily::MONOSPACE));
+        this
+    }
+
     /// If `true` (and this is a [`multiline`] text box) lines will be wrapped
     /// at the maximum layout width.
     ///
@@ -195,10 +216,7 @@ impl<T> TextBox<T> {
         }
 
         let size = size.into();
-        self.text_mut()
-            .borrow_mut()
-            .layout
-            .set_text_size(size.clone());
+        self.text_mut().borrow_mut().set_text_size(size.clone());
         self.placeholder.set_text_size(size);
     }
 
@@ -216,7 +234,7 @@ impl<T> TextBox<T> {
             return;
         }
         let font = font.into();
-        self.text_mut().borrow_mut().layout.set_font(font.clone());
+        self.text_mut().borrow_mut().set_font(font.clone());
         self.placeholder.set_font(font);
     }
 
@@ -532,7 +550,7 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
         let size = self.inner.layout(ctx, &child_bc, data, env);
 
         let text_metrics = if !self.text().can_read() || data.is_empty() {
-            self.placeholder.layout_metrics()
+            dbg!(self.placeholder.layout_metrics())
         } else {
             self.text().borrow().layout.layout_metrics()
         };


### PR DESCRIPTION
This adds TextField::protected, which creates a TextField that obscures
its content, suitable for things like passwords.

This is an expedient (rather than principled) implementation. In
particular, cursor positions will get weird if you enter glyphs that are
not present in the system monospace font.

This has come up enough and involves tricky enough parts of the codebase that I thought it would be easiest to just dig in and see what I could do. This implementation isn't great, but I think it might be *good enough*.

Doing this 'properly' will be a more invasive change; I haven't thought it through too much, but there are a number of problems: for instance, in order to correctly display selections we will need to have a mapping from the selection state of the actual text to the selection state of the replacement text (because we show one replacement glyph per grapheme cluster, the selections in the underlying text are not necessarily valid in the replacement text.)

I'll only merge this if it seems genuinely useful to someone, so try it out and let me know?