### PR TITLE
Bump gtk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,5 @@ default-members = [
     "druid-shell",
     "druid-derive",
 ]
+[patch.crates-io]
+piet-common = { path = '../piet/piet-common' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,3 @@ default-members = [
     "druid-shell",
     "druid-derive",
 ]
-[patch.crates-io]
-piet-common = { path = '../piet/piet-common' }

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -16,7 +16,7 @@ default-target = "x86_64-pc-windows-msvc"
 [features]
 default = ["gtk"]
 gtk = ["gdk-sys", "glib-sys", "gtk-sys", "gtk-rs"]
-x11 = ["x11rb", "nix", "cairo-sys-rs", , "bindgen", "pkg-config"]
+x11 = ["x11rb", "nix", "cairo-sys-rs", "bindgen", "pkg-config"]
 # Implement HasRawWindowHandle for WindowHandle
 raw-win-handle = ["raw-window-handle"]
 

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -77,17 +77,17 @@ bitflags = "1.2.1"
 
 [target.'cfg(target_os="linux")'.dependencies]
 # TODO(x11/dependencies): only use feature "xcb" if using X11
-cairo-rs = { version = "0.9.1", default_features = false, features = ["xcb"] }
-cairo-sys-rs = { version = "0.10.0", default_features = false, optional = true }
-gio = { version = "0.9.1", optional = true }
-gdk = { version = "0.13.2", optional = true }
-gdk-pixbuf = { version = "0.9.0", optional = true }
-gdk-sys = { version = "0.10.0", optional = true }
+cairo-rs = { version = "0.14.0", default_features = false, features = ["xcb"] }
+cairo-sys-rs = { version = "0.14.0", default_features = false, optional = true }
+gio = { version = "0.14.0", optional = true }
+gdk = { version = "0.14.0", optional = true }
+gdk-pixbuf = { version = "0.14.0", optional = true }
+gdk-sys = { version = "0.14.0", optional = true }
 # `gtk` gets renamed to `gtk-rs` so that we can use `gtk` as the feature name.
-gtk-rs = { version = "0.9.2", features = ["v3_22"], package = "gtk", optional = true }
-glib = { version = "0.10.1", optional = true }
-glib-sys = { version = "0.10.0", optional = true }
-gtk-sys = { version = "0.10.0", optional = true }
+gtk-rs = { version = "0.14.0", features = ["v3_22"], package = "gtk", optional = true }
+glib = { version = "0.14.0", optional = true }
+glib-sys = { version = "0.14.0", optional = true }
+gtk-sys = { version = "0.14.0", optional = true }
 nix = { version = "0.18.0", optional = true }
 x11rb = { version = "0.8.0", features = ["allow-unsafe-code", "present", "render", "randr", "xfixes", "xkb", "resource_manager", "cursor"], optional = true }
 

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -16,7 +16,7 @@ default-target = "x86_64-pc-windows-msvc"
 [features]
 default = ["gtk"]
 gtk = ["gdk-sys", "glib-sys", "gtk-sys", "gtk-rs"]
-x11 = ["x11rb", "nix", "cairo-sys-rs"]
+x11 = ["x11rb", "nix", "cairo-sys-rs", , "bindgen", "pkg-config"]
 # Implement HasRawWindowHandle for WindowHandle
 raw-win-handle = ["raw-window-handle"]
 

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -15,8 +15,8 @@ default-target = "x86_64-pc-windows-msvc"
 
 [features]
 default = ["gtk"]
-gtk = ["gio", "gdk", "gdk-sys", "glib", "glib-sys", "gtk-sys", "gtk-rs", "gdk-pixbuf"]
-x11 = ["x11rb", "nix", "cairo-sys-rs", "bindgen", "pkg-config"]
+gtk = ["gdk-sys", "glib-sys", "gtk-sys", "gtk-rs"]
+x11 = ["x11rb", "nix", "cairo-sys-rs"]
 # Implement HasRawWindowHandle for WindowHandle
 raw-win-handle = ["raw-window-handle"]
 
@@ -79,13 +79,9 @@ bitflags = "1.2.1"
 # TODO(x11/dependencies): only use feature "xcb" if using X11
 cairo-rs = { version = "0.14.0", default_features = false, features = ["xcb"] }
 cairo-sys-rs = { version = "0.14.0", default_features = false, optional = true }
-gio = { version = "0.14.0", optional = true }
-gdk = { version = "0.14.0", optional = true }
-gdk-pixbuf = { version = "0.14.0", optional = true }
 gdk-sys = { version = "0.14.0", optional = true }
 # `gtk` gets renamed to `gtk-rs` so that we can use `gtk` as the feature name.
 gtk-rs = { version = "0.14.0", features = ["v3_22"], package = "gtk", optional = true }
-glib = { version = "0.14.0", optional = true }
 glib-sys = { version = "0.14.0", optional = true }
 gtk-sys = { version = "0.14.0", optional = true }
 nix = { version = "0.18.0", optional = true }

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -41,7 +41,7 @@ serde = ["kurbo/serde"]
 [dependencies]
 # NOTE: When changing the piet or kurbo versions, ensure that
 #       the kurbo version included in piet is compatible with the kurbo version specified here.
-piet-common = "=0.4.1"
+piet-common = "=0.5.0-pre1"
 kurbo = "0.8.1"
 
 tracing = "0.1.22"
@@ -96,7 +96,7 @@ version = "0.3.44"
 features = ["Window", "MouseEvent", "CssStyleDeclaration", "WheelEvent", "KeyEvent", "KeyboardEvent", "Navigator"]
 
 [dev-dependencies]
-piet-common = { version = "=0.4.1", features = ["png"] }
+piet-common = { version = "=0.5.0-pre1", features = ["png"] }
 static_assertions = "1.1.0"
 test-env-log = { version = "0.2.5", features = ["trace"], default-features = false }
 tracing-subscriber = "0.2.15"

--- a/druid-shell/src/backend/gtk/application.rs
+++ b/druid-shell/src/backend/gtk/application.rs
@@ -14,8 +14,8 @@
 
 //! GTK implementation of features at the application scope.
 
-use gio::prelude::ApplicationExtManual;
-use gio::{ApplicationFlags, Cancellable};
+use gtk::gio::prelude::ApplicationExtManual;
+use gtk::gio::{ApplicationFlags, Cancellable};
 use gtk::Application as GtkApplication;
 
 use gtk::prelude::{ApplicationExt, GtkApplicationExt};
@@ -77,12 +77,12 @@ impl Application {
 
     pub fn clipboard(&self) -> Clipboard {
         Clipboard {
-            selection: gdk::SELECTION_CLIPBOARD,
+            selection: gtk::gdk::SELECTION_CLIPBOARD,
         }
     }
 
     pub fn get_locale() -> String {
-        let mut locale: String = glib::language_names()[0].as_str().into();
+        let mut locale: String = gtk::glib::language_names()[0].as_str().into();
         // This is done because the locale parsing library we use expects an unicode locale, but these vars have an ISO locale
         if let Some(idx) = locale.chars().position(|c| c == '.' || c == '@') {
             locale.truncate(idx);
@@ -94,7 +94,7 @@ impl Application {
 impl crate::platform::linux::ApplicationExt for crate::Application {
     fn primary_clipboard(&self) -> crate::Clipboard {
         crate::Clipboard(Clipboard {
-            selection: gdk::SELECTION_PRIMARY,
+            selection: gtk::gdk::SELECTION_PRIMARY,
         })
     }
 }

--- a/druid-shell/src/backend/gtk/application.rs
+++ b/druid-shell/src/backend/gtk/application.rs
@@ -15,8 +15,10 @@
 //! GTK implementation of features at the application scope.
 
 use gio::prelude::ApplicationExtManual;
-use gio::{ApplicationExt, ApplicationFlags, Cancellable};
-use gtk::{Application as GtkApplication, GtkApplicationExt};
+use gio::{ApplicationFlags, Cancellable};
+use gtk::Application as GtkApplication;
+
+use gtk::prelude::{ApplicationExt, GtkApplicationExt};
 
 use crate::application::AppHandler;
 
@@ -31,7 +33,7 @@ pub(crate) struct Application {
 impl Application {
     pub fn new() -> Result<Application, Error> {
         // TODO: we should give control over the application ID to the user
-        let gtk_app = match GtkApplication::new(
+        let gtk_app = GtkApplication::new(
             Some("com.github.linebender.druid"),
             // TODO we set this to avoid connecting to an existing running instance
             // of "com.github.linebender.druid" after which we would never receive
@@ -39,10 +41,7 @@ impl Application {
             // Which shows another way once we have in place a mechanism for
             // communication with remote instances.
             ApplicationFlags::NON_UNIQUE,
-        ) {
-            Ok(app) => app,
-            Err(err) => return Err(Error::BoolError(err)),
-        };
+        );
 
         gtk_app.connect_activate(|_app| {
             tracing::info!("gtk: Activated application");
@@ -61,12 +60,11 @@ impl Application {
     }
 
     pub fn run(self, _handler: Option<Box<dyn AppHandler>>) {
-        // TODO: should we pass the command line arguments?
-        self.gtk_app.run(&[]);
+        self.gtk_app.run();
     }
 
     pub fn quit(&self) {
-        match self.gtk_app.get_active_window() {
+        match self.gtk_app.active_window() {
             None => {
                 // no application is running, main is not running
             }
@@ -84,7 +82,7 @@ impl Application {
     }
 
     pub fn get_locale() -> String {
-        let mut locale: String = glib::get_language_names()[0].as_str().into();
+        let mut locale: String = glib::language_names()[0].as_str().into();
         // This is done because the locale parsing library we use expects an unicode locale, but these vars have an ISO locale
         if let Some(idx) = locale.chars().position(|c| c == '.' || c == '@') {
             locale.truncate(idx);

--- a/druid-shell/src/backend/gtk/clipboard.rs
+++ b/druid-shell/src/backend/gtk/clipboard.rs
@@ -36,8 +36,8 @@ pub struct Clipboard {
 impl std::fmt::Debug for Clipboard {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let name = match self.selection {
-            gdk::SELECTION_PRIMARY => "Primary",
-            gdk::SELECTION_CLIPBOARD => "Clipboard",
+            gtk::gdk::SELECTION_PRIMARY => "Primary",
+            gtk::gdk::SELECTION_CLIPBOARD => "Clipboard",
             _ => "(other)",
         };
         f.debug_tuple("Clipboard").field(&name).finish()
@@ -49,7 +49,7 @@ impl Clipboard {
     pub fn put_string(&mut self, string: impl AsRef<str>) {
         let string = string.as_ref().to_string();
 
-        let display = gdk::Display::default().unwrap();
+        let display = gtk::gdk::Display::default().unwrap();
         let clipboard = gtk::Clipboard::for_display(&display, &self.selection);
 
         let targets: Vec<TargetEntry> = CLIPBOARD_TARGETS
@@ -67,7 +67,7 @@ impl Clipboard {
     /// Put multi-format data on the system clipboard.
     pub fn put_formats(&mut self, formats: &[ClipboardFormat]) {
         let entries = make_entries(formats);
-        let display = gdk::Display::default().unwrap();
+        let display = gtk::gdk::Display::default().unwrap();
         let clipboard = gtk::Clipboard::for_display(&display, &self.selection);
 
         // this is gross: we need to reclone all the data in formats in order
@@ -96,7 +96,7 @@ impl Clipboard {
 
     /// Get a string from the system clipboard, if one is available.
     pub fn get_string(&self) -> Option<String> {
-        let display = gdk::Display::default().unwrap();
+        let display = gtk::gdk::Display::default().unwrap();
         let clipboard = gtk::Clipboard::for_display(&display, &self.selection);
 
         for target in &CLIPBOARD_TARGETS {
@@ -112,7 +112,7 @@ impl Clipboard {
     /// Given a list of supported clipboard types, returns the supported type which has
     /// highest priority on the system clipboard, or `None` if no types are supported.
     pub fn preferred_format(&self, formats: &[FormatId]) -> Option<FormatId> {
-        let display = gdk::Display::default().unwrap();
+        let display = gtk::gdk::Display::default().unwrap();
         let clipboard = gtk::Clipboard::for_display(&display, &self.selection);
 
         let targets = clipboard.wait_for_targets()?;
@@ -133,7 +133,7 @@ impl Clipboard {
     /// It is recommended that the `fmt` argument be a format returned by
     /// [`Clipboard::preferred_format`]
     pub fn get_format(&self, format: FormatId) -> Option<Vec<u8>> {
-        let display = gdk::Display::default().unwrap();
+        let display = gtk::gdk::Display::default().unwrap();
         let clipboard = gtk::Clipboard::for_display(&display, &self.selection);
 
         let atom = Atom::intern(format);
@@ -141,7 +141,7 @@ impl Clipboard {
     }
 
     pub fn available_type_names(&self) -> Vec<String> {
-        let display = gdk::Display::default().unwrap();
+        let display = gtk::gdk::Display::default().unwrap();
         let clipboard = gtk::Clipboard::for_display(&display, &self.selection);
 
         let targets = clipboard.wait_for_targets().unwrap_or_default();

--- a/druid-shell/src/backend/gtk/clipboard.rs
+++ b/druid-shell/src/backend/gtk/clipboard.rs
@@ -14,7 +14,7 @@
 
 //! Interactions with the system pasteboard on GTK+.
 
-use gdk::Atom;
+use gtk::gdk::Atom;
 use gtk::{TargetEntry, TargetFlags};
 
 use crate::clipboard::{ClipboardFormat, FormatId};
@@ -49,8 +49,8 @@ impl Clipboard {
     pub fn put_string(&mut self, string: impl AsRef<str>) {
         let string = string.as_ref().to_string();
 
-        let display = gdk::Display::get_default().unwrap();
-        let clipboard = gtk::Clipboard::get_for_display(&display, &self.selection);
+        let display = gdk::Display::default().unwrap();
+        let clipboard = gtk::Clipboard::for_display(&display, &self.selection);
 
         let targets: Vec<TargetEntry> = CLIPBOARD_TARGETS
             .iter()
@@ -60,15 +60,16 @@ impl Clipboard {
 
         clipboard.set_with_data(&targets, move |_, selection, _| {
             const STRIDE_BITS: i32 = 8;
-            selection.set(&selection.get_target(), STRIDE_BITS, string.as_bytes());
+            selection.set(&selection.target(), STRIDE_BITS, string.as_bytes());
         });
     }
 
     /// Put multi-format data on the system clipboard.
     pub fn put_formats(&mut self, formats: &[ClipboardFormat]) {
         let entries = make_entries(formats);
-        let display = gdk::Display::get_default().unwrap();
-        let clipboard = gtk::Clipboard::get_for_display(&display, &self.selection);
+        let display = gdk::Display::default().unwrap();
+        let clipboard = gtk::Clipboard::for_display(&display, &self.selection);
+
         // this is gross: we need to reclone all the data in formats in order
         // to move it into the closure. :/
         let formats = formats.to_owned();
@@ -95,13 +96,13 @@ impl Clipboard {
 
     /// Get a string from the system clipboard, if one is available.
     pub fn get_string(&self) -> Option<String> {
-        let display = gdk::Display::get_default().unwrap();
-        let clipboard = gtk::Clipboard::get_for_display(&display, &self.selection);
+        let display = gdk::Display::default().unwrap();
+        let clipboard = gtk::Clipboard::for_display(&display, &self.selection);
 
         for target in &CLIPBOARD_TARGETS {
             let atom = Atom::intern(target);
             if let Some(selection) = clipboard.wait_for_contents(&atom) {
-                return String::from_utf8(selection.get_data()).ok();
+                return String::from_utf8(selection.data()).ok();
             }
         }
 
@@ -111,8 +112,9 @@ impl Clipboard {
     /// Given a list of supported clipboard types, returns the supported type which has
     /// highest priority on the system clipboard, or `None` if no types are supported.
     pub fn preferred_format(&self, formats: &[FormatId]) -> Option<FormatId> {
-        let display = gdk::Display::get_default().unwrap();
-        let clipboard = gtk::Clipboard::get_for_display(&display, &self.selection);
+        let display = gdk::Display::default().unwrap();
+        let clipboard = gtk::Clipboard::for_display(&display, &self.selection);
+
         let targets = clipboard.wait_for_targets()?;
         let format_atoms = formats
             .iter()
@@ -131,17 +133,17 @@ impl Clipboard {
     /// It is recommended that the `fmt` argument be a format returned by
     /// [`Clipboard::preferred_format`]
     pub fn get_format(&self, format: FormatId) -> Option<Vec<u8>> {
-        let display = gdk::Display::get_default().unwrap();
-        let clipboard = gtk::Clipboard::get_for_display(&display, &self.selection);
+        let display = gdk::Display::default().unwrap();
+        let clipboard = gtk::Clipboard::for_display(&display, &self.selection);
+
         let atom = Atom::intern(format);
-        clipboard
-            .wait_for_contents(&atom)
-            .map(|data| data.get_data())
+        clipboard.wait_for_contents(&atom).map(|data| data.data())
     }
 
     pub fn available_type_names(&self) -> Vec<String> {
-        let display = gdk::Display::get_default().unwrap();
-        let clipboard = gtk::Clipboard::get_for_display(&display, &self.selection);
+        let display = gdk::Display::default().unwrap();
+        let clipboard = gtk::Clipboard::for_display(&display, &self.selection);
+
         let targets = clipboard.wait_for_targets().unwrap_or_default();
         targets
             .iter()

--- a/druid-shell/src/backend/gtk/dialog.rs
+++ b/druid-shell/src/backend/gtk/dialog.rs
@@ -17,7 +17,9 @@
 use std::ffi::OsString;
 
 use anyhow::anyhow;
-use gtk::{FileChooserAction, FileChooserExt, FileFilter, NativeDialogExt, ResponseType, Window};
+use gtk::{FileChooserAction, FileFilter, ResponseType, Window};
+
+use gtk::prelude::{FileChooserExt, NativeDialogExt};
 
 use crate::dialog::{FileDialogOptions, FileDialogType, FileSpec};
 use crate::Error;
@@ -96,7 +98,7 @@ pub(crate) fn get_file_dialog_path(
     let result = dialog.run();
 
     let result = match result {
-        ResponseType::Accept => match dialog.get_filename() {
+        ResponseType::Accept => match dialog.filename() {
             Some(path) => Ok(path.into_os_string()),
             None => Err(anyhow!("No path received for filename")),
         },

--- a/druid-shell/src/backend/gtk/error.rs
+++ b/druid-shell/src/backend/gtk/error.rs
@@ -16,7 +16,7 @@
 
 use std::fmt;
 
-use glib::{BoolError, Error as GLibError};
+use gtk::glib::{BoolError, Error as GLibError};
 
 /// GTK backend errors.
 #[derive(Debug, Clone)]

--- a/druid-shell/src/backend/gtk/keycodes.rs
+++ b/druid-shell/src/backend/gtk/keycodes.rs
@@ -14,12 +14,12 @@
 
 //! GTK code handling.
 
-use gdk::keys::constants::*;
+use gtk::gdk::keys::constants::*;
 
 pub use super::super::shared::hardware_keycode_to_code;
 use crate::keyboard_types::{Key, Location};
 
-pub type RawKey = gdk::keys::Key;
+pub type RawKey = gtk::gdk::keys::Key;
 
 #[allow(clippy::just_underscores_and_digits, non_upper_case_globals)]
 pub fn raw_key_to_key(raw: RawKey) -> Option<Key> {

--- a/druid-shell/src/backend/gtk/menu.rs
+++ b/druid-shell/src/backend/gtk/menu.rs
@@ -14,7 +14,7 @@
 
 //! GTK implementation of menus.
 
-use gdk::ModifierType;
+use gtk::gdk::ModifierType;
 use gtk::{
     AccelGroup, Menu as GtkMenu, MenuBar as GtkMenuBar, MenuItem as GtkMenuItem,
     SeparatorMenuItemBuilder,
@@ -166,7 +166,7 @@ fn register_accelerator(item: &GtkMenuItem, accel_group: &AccelGroup, menu_key: 
     );
 }
 
-fn modifiers_to_gdk_modifier_type(raw_modifiers: RawMods) -> gdk::ModifierType {
+fn modifiers_to_gdk_modifier_type(raw_modifiers: RawMods) -> ModifierType {
     let mut result = ModifierType::empty();
 
     let modifiers: Modifiers = raw_modifiers.into();

--- a/druid-shell/src/backend/gtk/menu.rs
+++ b/druid-shell/src/backend/gtk/menu.rs
@@ -16,9 +16,11 @@
 
 use gdk::ModifierType;
 use gtk::{
-    AccelGroup, GtkMenuExt, GtkMenuItemExt, Menu as GtkMenu, MenuBar as GtkMenuBar,
-    MenuItem as GtkMenuItem, MenuShellExt, SeparatorMenuItemBuilder, WidgetExt,
+    AccelGroup, Menu as GtkMenu, MenuBar as GtkMenuBar, MenuItem as GtkMenuItem,
+    SeparatorMenuItemBuilder,
 };
+
+use gtk::prelude::{GtkMenuExt, GtkMenuItemExt, MenuShellExt, WidgetExt};
 
 use super::keycodes;
 use super::window::WindowHandle;

--- a/druid-shell/src/backend/gtk/screen.rs
+++ b/druid-shell/src/backend/gtk/screen.rs
@@ -15,17 +15,17 @@
 //! GTK Monitors and Screen information.
 
 use crate::screen::Monitor;
-use gdk::Display;
+use gtk::gdk::{Display, DisplayManager, Rectangle};
 use kurbo::{Point, Rect, Size};
 
-fn translate_gdk_rectangle(r: gdk::Rectangle) -> Rect {
+fn translate_gdk_rectangle(r: Rectangle) -> Rect {
     Rect::from_origin_size(
         Point::new(r.x as f64, r.y as f64),
         Size::new(r.width as f64, r.height as f64),
     )
 }
 
-fn translate_gdk_monitor(mon: gdk::Monitor) -> Monitor {
+fn translate_gdk_monitor(mon: gtk::gdk::Monitor) -> Monitor {
     let area = translate_gdk_rectangle(mon.geometry());
     Monitor::new(
         mon.is_primary(),
@@ -37,7 +37,7 @@ fn translate_gdk_monitor(mon: gdk::Monitor) -> Monitor {
 }
 
 pub(crate) fn get_monitors() -> Vec<Monitor> {
-    gdk::DisplayManager::get()
+    DisplayManager::get()
         .list_displays()
         .iter()
         .flat_map(|display: &Display| {

--- a/druid-shell/src/backend/gtk/screen.rs
+++ b/druid-shell/src/backend/gtk/screen.rs
@@ -26,7 +26,7 @@ fn translate_gdk_rectangle(r: gdk::Rectangle) -> Rect {
 }
 
 fn translate_gdk_monitor(mon: gdk::Monitor) -> Monitor {
-    let area = translate_gdk_rectangle(mon.get_geometry());
+    let area = translate_gdk_rectangle(mon.geometry());
     Monitor::new(
         mon.is_primary(),
         area,
@@ -41,8 +41,8 @@ pub(crate) fn get_monitors() -> Vec<Monitor> {
         .list_displays()
         .iter()
         .flat_map(|display: &Display| {
-            (0..display.get_n_monitors())
-                .map(move |i| display.get_monitor(i).map(translate_gdk_monitor))
+            (0..display.n_monitors())
+                .map(move |i| display.monitor(i).map(translate_gdk_monitor))
                 .flatten()
         })
         .collect()

--- a/druid-shell/src/backend/gtk/window.rs
+++ b/druid-shell/src/backend/gtk/window.rs
@@ -14,8 +14,9 @@
 
 //! GTK window creation and management.
 
+use gtk::traits::SettingsExt;
 use std::cell::{Cell, RefCell};
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryInto;
 use std::ffi::c_void;
 use std::os::raw::{c_int, c_uint};
 use std::panic::Location;
@@ -26,10 +27,11 @@ use std::time::Instant;
 
 use anyhow::anyhow;
 use cairo::Surface;
-use gdk::{EventKey, EventMask, ModifierType, ScrollDirection, WindowExt, WindowTypeHint};
-use gio::ApplicationExt;
+use gdk::{EventKey, EventMask, ModifierType, ScrollDirection, WindowTypeHint};
 use gtk::prelude::*;
-use gtk::{AccelGroup, ApplicationWindow, DrawingArea, SettingsExt};
+use gtk::{AccelGroup, ApplicationWindow, DrawingArea};
+
+use instant::Duration;
 use tracing::{error, warn};
 
 #[cfg(feature = "raw-win-handle")]
@@ -259,8 +261,8 @@ impl WindowBuilder {
         window.set_decorated(self.show_titlebar);
         let mut transparent = false;
         if self.transparent {
-            if let Some(screen) = window.get_screen() {
-                let visual = screen.get_rgba_visual();
+            if let Some(screen) = window.screen() {
+                let visual = screen.rgba_visual();
                 transparent = visual.is_some();
                 window.set_visual(visual.as_ref());
             }
@@ -268,8 +270,7 @@ impl WindowBuilder {
         window.set_app_paintable(transparent);
 
         // Get the scale factor based on the GTK reported DPI
-        let scale_factor =
-            window.get_display().get_default_screen().get_resolution() / SCALE_TARGET_DPI;
+        let scale_factor = window.display().default_screen().resolution() / SCALE_TARGET_DPI;
         let scale = Scale::new(scale_factor, scale_factor);
         let area = ScaledArea::from_dp(self.size, scale);
         let size_px = area.size_px();
@@ -369,7 +370,7 @@ impl WindowBuilder {
         win_state
             .drawing_area
             .connect_realize(clone!(handle => move |drawing_area| {
-                if let Some(clock) = drawing_area.get_frame_clock() {
+                if let Some(clock) = drawing_area.frame_clock() {
                     clock.connect_before_paint(clone!(handle => move |_clock|{
                         if let Some(state) = handle.state.upgrade() {
                             state.in_draw.set(true);
@@ -393,8 +394,8 @@ impl WindowBuilder {
                 let mut scale_changed = false;
                 // Check if the GTK reported DPI has changed,
                 // so that we can change our scale factor without restarting the application.
-                if let Some(scale_factor) = state.window.get_window()
-                    .map(|w| w.get_display().get_default_screen().get_resolution() / SCALE_TARGET_DPI) {
+                if let Some(scale_factor) = state.window.window()
+                    .map(|w| w.display().default_screen().resolution() / SCALE_TARGET_DPI) {
                     let reported_scale = Scale::new(scale_factor, scale_factor);
                     if scale != reported_scale {
                         scale = reported_scale;
@@ -406,7 +407,7 @@ impl WindowBuilder {
 
                 // Create a new cairo surface if necessary (either because there is no surface, or
                 // because the size or scale changed).
-                let extents = widget.get_allocation();
+                let extents = widget.allocation();
                 let size_px = Size::new(extents.width as f64, extents.height as f64);
                 let no_surface = state.surface.try_borrow().map(|x| x.is_none()).ok() == Some(true);
                 if no_surface || scale_changed || state.area.get().size_px() != size_px {
@@ -435,7 +436,7 @@ impl WindowBuilder {
                     // because we don't return control to the system or re-borrow the surface from
                     // any code that the client can call.
                     state.with_handler_and_dont_check_the_other_borrows(|handler| {
-                        let surface_context = cairo::Context::new(surface);
+                        let surface_context = cairo::Context::new(surface).unwrap();
 
                         // Clip to the invalid region, in order that our surface doesn't get
                         // messed up if there's any painting outside them.
@@ -455,10 +456,11 @@ impl WindowBuilder {
                         // Copy the entire surface to the drawing area (not just the invalid
                         // region, because there might be parts of the drawing area that were
                         // invalidated by external forces).
-                        let alloc = widget.get_allocation();
-                        context.set_source_surface(surface, 0.0, 0.0);
+                       // TODO: how are we supposed to handle these errors? What can we do besides panic? Probably nothing right?
+                        let alloc = widget.allocation();
+                        context.set_source_surface(surface, 0.0, 0.0).unwrap();
                         context.rectangle(0.0, 0.0, alloc.width as f64, alloc.height as f64);
-                        context.fill();
+                        context.fill().unwrap();
                     });
                 } else {
                     warn!("Drawing was skipped because there was no surface");
@@ -472,8 +474,8 @@ impl WindowBuilder {
             clone!(handle => move |widget, _prev_screen| {
                 if let Some(state) = handle.state.upgrade() {
 
-                    if let Some(screen) = widget.get_screen(){
-                        let visual = screen.get_rgba_visual();
+                    if let Some(screen) = widget.screen(){
+                        let visual = screen.rgba_visual();
                         state.is_transparent.set(visual.is_some());
                         widget.set_visual(visual.as_ref());
                     }
@@ -484,16 +486,16 @@ impl WindowBuilder {
         win_state.drawing_area.connect_button_press_event(clone!(handle => move |_widget, event| {
             if let Some(state) = handle.state.upgrade() {
                 state.with_handler(|handler| {
-                    if let Some(button) = get_mouse_button(event.get_button()) {
+                    if let Some(button) = get_mouse_button(event.button()) {
                         let scale = state.scale.get();
-                        let button_state = event.get_state();
-                        let gtk_count = get_mouse_click_count(event.get_event_type());
-                        let pos: Point =  event.get_position().into();
+                        let button_state = event.state();
+                        let gtk_count = get_mouse_click_count(event.event_type());
+                        let pos: Point =  event.position().into();
                         let count = if gtk_count == 1 {
-                            let settings = state.drawing_area.get_settings().unwrap();
-                            let thresh_dist = settings.get_property_gtk_double_click_distance();
+                            let settings = state.drawing_area.settings().unwrap();
+                            let thresh_dist = settings.gtk_double_click_distance();
                             state.click_counter.set_distance(thresh_dist.into());
-                            if let Ok(ms) = settings.get_property_gtk_double_click_time().try_into() {
+                            if let Ok(ms) = settings.gtk_double_click_time().try_into() {
                                 state.click_counter.set_interval_ms(ms);
                             }
                             state.click_counter.count_for_click(pos)
@@ -523,12 +525,12 @@ impl WindowBuilder {
         win_state.drawing_area.connect_button_release_event(clone!(handle => move |_widget, event| {
             if let Some(state) = handle.state.upgrade() {
                 state.with_handler(|handler| {
-                    if let Some(button) = get_mouse_button(event.get_button()) {
+                    if let Some(button) = get_mouse_button(event.button()) {
                         let scale = state.scale.get();
-                        let button_state = event.get_state();
+                        let button_state = event.state();
                         handler.mouse_up(
                             &MouseEvent {
-                                pos: Point::from(event.get_position()).to_dp(scale),
+                                pos: Point::from(event.position()).to_dp(scale),
                                 buttons: get_mouse_buttons_from_modifiers(button_state).without(button),
                                 mods: get_modifiers(button_state),
                                 count: 0,
@@ -548,9 +550,9 @@ impl WindowBuilder {
             clone!(handle => move |_widget, motion| {
                 if let Some(state) = handle.state.upgrade() {
                     let scale = state.scale.get();
-                    let motion_state = motion.get_state();
+                    let motion_state = motion.state();
                     let mouse_event = MouseEvent {
-                        pos: Point::from(motion.get_position()).to_dp(scale),
+                        pos: Point::from(motion.position()).to_dp(scale),
                         buttons: get_mouse_buttons_from_modifiers(motion_state),
                         mods: get_modifiers(motion_state),
                         count: 0,
@@ -570,9 +572,9 @@ impl WindowBuilder {
             clone!(handle => move |_widget, crossing| {
                 if let Some(state) = handle.state.upgrade() {
                     let scale = state.scale.get();
-                    let crossing_state = crossing.get_state();
+                    let crossing_state = crossing.state();
                     let mouse_event = MouseEvent {
-                        pos: Point::from(crossing.get_position()).to_dp(scale),
+                        pos: Point::from(crossing.position()).to_dp(scale),
                         buttons: get_mouse_buttons_from_modifiers(crossing_state),
                         mods: get_modifiers(crossing_state),
                         count: 0,
@@ -593,12 +595,12 @@ impl WindowBuilder {
             .connect_scroll_event(clone!(handle => move |_widget, scroll| {
                 if let Some(state) = handle.state.upgrade() {
                     let scale = state.scale.get();
-                    let mods = get_modifiers(scroll.get_state());
+                    let mods = get_modifiers(scroll.state());
 
                     // The magic "120"s are from Microsoft's documentation for WM_MOUSEWHEEL.
                     // They claim that one "tick" on a scroll wheel should be 120 units.
                     let shift = mods.shift();
-                    let wheel_delta = match scroll.get_direction() {
+                    let wheel_delta = match scroll.direction() {
                         ScrollDirection::Up if shift => Some(Vec2::new(-120.0, 0.0)),
                         ScrollDirection::Up => Some(Vec2::new(0.0, -120.0)),
                         ScrollDirection::Down if shift => Some(Vec2::new(120.0, 0.0)),
@@ -607,7 +609,7 @@ impl WindowBuilder {
                         ScrollDirection::Right => Some(Vec2::new(120.0, 0.0)),
                         ScrollDirection::Smooth => {
                             //TODO: Look at how gtk's scroll containers implements it
-                            let (mut delta_x, mut delta_y) = scroll.get_delta();
+                            let (mut delta_x, mut delta_y) = scroll.delta();
                             delta_x *= 120.;
                             delta_y *= 120.;
                             if shift {
@@ -627,8 +629,8 @@ impl WindowBuilder {
 
                     if let Some(wheel_delta) = wheel_delta {
                         let mouse_event = MouseEvent {
-                            pos: Point::from(scroll.get_position()).to_dp(scale),
-                            buttons: get_mouse_buttons_from_modifiers(scroll.get_state()),
+                            pos: Point::from(scroll.position()).to_dp(scale),
+                            buttons: get_mouse_buttons_from_modifiers(scroll.state()),
                             mods,
                             count: 0,
                             focus: false,
@@ -648,7 +650,7 @@ impl WindowBuilder {
             .connect_key_press_event(clone!(handle => move |_widget, key| {
                 if let Some(state) = handle.state.upgrade() {
 
-                    let hw_keycode = key.get_hardware_keycode();
+                    let hw_keycode = key.hardware_keycode();
                     let repeat = state.current_keycode.get() == Some(hw_keycode);
 
                     state.current_keycode.set(Some(hw_keycode));
@@ -666,7 +668,7 @@ impl WindowBuilder {
             .connect_key_release_event(clone!(handle => move |_widget, key| {
                 if let Some(state) = handle.state.upgrade() {
 
-                    if state.current_keycode.get() == Some(key.get_hardware_keycode()) {
+                    if state.current_keycode.get() == Some(key.hardware_keycode()) {
                         state.current_keycode.set(None);
                     }
 
@@ -720,7 +722,7 @@ impl WindowBuilder {
         win_state.drawing_area.realize();
         win_state
             .drawing_area
-            .get_window()
+            .window()
             .expect("realize didn't create window")
             .set_event_compression(false);
 
@@ -787,7 +789,7 @@ impl WindowState {
             }
             *surface = None;
 
-            if let Some(w) = self.drawing_area.get_window() {
+            if let Some(w) = self.drawing_area.window() {
                 if self.is_transparent.get() {
                     *surface = w.create_similar_surface(cairo::Content::ColorAlpha, width, height);
                 } else {
@@ -866,9 +868,9 @@ impl WindowState {
                     self.window.add_accel_group(&accel_group);
 
                     let menu = menu.into_gtk_menu(&handle, &accel_group);
-                    menu.set_property_attach_widget(Some(&self.window));
+                    menu.set_attach_widget(Some(&self.window));
                     menu.show_all();
-                    menu.popup_easy(3, gtk::get_current_event_time());
+                    menu.popup_easy(3, gtk::current_event_time());
                 }
             }
         }
@@ -903,7 +905,7 @@ impl WindowHandle {
 
     pub fn get_position(&self) -> Point {
         if let Some(state) = self.state.upgrade() {
-            let (x, y) = state.window.get_position();
+            let (x, y) = state.window.position();
             Point::new(x as f64, y as f64).to_dp(state.scale.get())
         } else {
             Point::new(0.0, 0.0)
@@ -920,8 +922,8 @@ impl WindowHandle {
     pub fn content_insets(&self) -> Insets {
         if let Some(state) = self.state.upgrade() {
             let scale = state.scale.get();
-            let (width_px, height_px) = state.window.get_size();
-            let alloc_px = state.drawing_area.get_allocation();
+            let (width_px, height_px) = state.window.size();
+            let alloc_px = state.drawing_area.allocation();
             let window = Size::new(width_px as f64, height_px as f64).to_dp(scale);
             let alloc = Rect::from_origin_size(
                 (alloc_px.x as f64, alloc_px.y as f64),
@@ -960,7 +962,7 @@ impl WindowHandle {
             WindowLevel::Tooltip | WindowLevel::DropDown | WindowLevel::Modal => true,
         };
         if let Some(state) = self.state.upgrade() {
-            if let Some(window) = state.window.get_window() {
+            if let Some(window) = state.window.window() {
                 window.set_override_redirect(override_redirect);
             }
         }
@@ -977,7 +979,7 @@ impl WindowHandle {
 
     pub fn get_size(&self) -> Size {
         if let Some(state) = self.state.upgrade() {
-            let (x, y) = state.window.get_size();
+            let (x, y) = state.window.size();
             Size::new(x as f64, y as f64).to_dp(state.scale.get())
         } else {
             warn!("Could not get size for GTK window");
@@ -1007,8 +1009,8 @@ impl WindowHandle {
         if let Some(state) = self.state.upgrade() {
             if state.window.is_maximized() {
                 return Maximized;
-            } else if let Some(window) = state.window.get_parent_window() {
-                let state = window.get_state();
+            } else if let Some(window) = state.window.parent_window() {
+                let state = window.state();
                 if (state & gdk::WindowState::ICONIFIED) == gdk::WindowState::ICONIFIED {
                     return Minimized;
                 }
@@ -1089,15 +1091,7 @@ impl WindowHandle {
     pub fn request_timer(&self, deadline: Instant) -> TimerToken {
         let interval = deadline
             .checked_duration_since(Instant::now())
-            .unwrap_or_default()
-            .as_millis();
-        let interval = match u32::try_from(interval) {
-            Ok(iv) => iv,
-            Err(_) => {
-                warn!("timer duration exceeds gtk max of 2^32 millis");
-                u32::max_value()
-            }
-        };
+            .unwrap_or_default();
 
         let token = TimerToken::next();
 
@@ -1113,7 +1107,7 @@ impl WindowHandle {
     }
 
     pub fn set_cursor(&mut self, cursor: &Cursor) {
-        if let Some(gdk_window) = self.state.upgrade().and_then(|s| s.window.get_window()) {
+        if let Some(gdk_window) = self.state.upgrade().and_then(|s| s.window.window()) {
             let cursor = make_gdk_cursor(cursor, &gdk_window);
             gdk_window.set_cursor(cursor.as_ref());
         }
@@ -1121,7 +1115,7 @@ impl WindowHandle {
 
     pub fn make_cursor(&self, desc: &CursorDesc) -> Option<Cursor> {
         if let Some(state) = self.state.upgrade() {
-            if let Some(gdk_window) = state.window.get_window() {
+            if let Some(gdk_window) = state.window.window() {
                 // TODO: gtk::Pixbuf expects unpremultiplied alpha. We should convert.
                 let has_alpha = !matches!(desc.image.format(), ImageFormat::Rgb);
                 let bytes_per_pixel = desc.image.format().bytes_per_pixel();
@@ -1137,7 +1131,7 @@ impl WindowHandle {
                     (desc.image.width() * bytes_per_pixel) as i32,
                 );
                 let c = gdk::Cursor::from_pixbuf(
-                    &gdk_window.get_display(),
+                    &gdk_window.display(),
                     &pixbuf,
                     desc.hot.x.round() as i32,
                     desc.hot.y.round() as i32,
@@ -1195,12 +1189,9 @@ impl WindowHandle {
             let accel_group = AccelGroup::new();
             window.add_accel_group(&accel_group);
 
-            let vbox = window.get_children()[0]
-                .clone()
-                .downcast::<gtk::Box>()
-                .unwrap();
+            let vbox = window.children()[0].clone().downcast::<gtk::Box>().unwrap();
 
-            let first_child = &vbox.get_children()[0];
+            let first_child = &vbox.children()[0];
             if let Some(old_menubar) = first_child.downcast_ref::<gtk::MenuBar>() {
                 old_menubar.deactivate();
                 vbox.remove(old_menubar);
@@ -1287,7 +1278,8 @@ fn run_idle(state: &Arc<WindowState>) -> glib::source::Continue {
         // to empty the idle queue. Returning glib::source::Continue(true) achieves this but
         // causes 100% CPU usage, apparently because glib likes to call us back very quickly.
         let state = Arc::clone(state);
-        glib::timeout_add(16, move || run_idle(&state));
+        let timeout = Duration::from_millis(16);
+        glib::timeout_add(timeout, move || run_idle(&state));
     }
     glib::source::Continue(false)
 }
@@ -1297,7 +1289,7 @@ fn make_gdk_cursor(cursor: &Cursor, gdk_window: &gdk::Window) -> Option<gdk::Cur
         Some(custom.0.clone())
     } else {
         gdk::Cursor::from_name(
-            &gdk_window.get_display(),
+            &gdk_window.display(),
             #[allow(deprecated)]
             match cursor {
                 // cursor name values from https://www.w3.org/TR/css-ui-3/#cursor
@@ -1385,13 +1377,13 @@ fn get_modifiers(modifiers: gdk::ModifierType) -> Modifiers {
 }
 
 fn make_key_event(key: &EventKey, repeat: bool, state: KeyState) -> KeyEvent {
-    let keyval = key.get_keyval();
-    let hardware_keycode = key.get_hardware_keycode();
+    let keyval = key.keyval();
+    let hardware_keycode = key.hardware_keycode();
 
     let keycode = hardware_keycode_to_keyval(hardware_keycode).unwrap_or_else(|| keyval.clone());
 
-    let text = gdk::keys::keyval_to_unicode(*keyval);
-    let mods = get_modifiers(key.get_state());
+    let text = keyval.to_unicode();
+    let mods = get_modifiers(key.state());
     let key = keycodes::raw_key_to_key(keyval).unwrap_or_else(|| {
         if let Some(c) = text {
             if c >= ' ' && c != '\x7f' {

--- a/druid-shell/src/backend/x11/window.rs
+++ b/druid-shell/src/backend/x11/window.rs
@@ -765,7 +765,7 @@ impl Window {
         let invalid = std::mem::replace(&mut *borrow_mut!(self.invalid)?, Region::EMPTY);
         {
             let surface = borrow!(self.cairo_surface)?;
-            let cairo_ctx = cairo::Context::new(&surface);
+            let cairo_ctx = cairo::Context::new(&surface).unwrap();
             let scale = self.scale.get();
             for rect in invalid.rects() {
                 let rect = rect.to_px(scale);

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -79,7 +79,7 @@ console_error_panic_hook = { version = "0.1.6" }
 float-cmp = { version = "0.8.0", features = ["std"], default-features = false }
 # tempfile 3.2.0 broke wasm; I assume it will be yanked (Jan 12, 2021)
 tempfile = "=3.1.0"
-piet-common = { version = "=0.4.1", features = ["png"] }
+piet-common = { version = "=0.5.0-pre1", features = ["png"] }
 pulldown-cmark = { version = "0.8", default-features = false }
 test-env-log = { version = "0.2.5", features = ["trace"], default-features = false }
 # test-env-log needs it


### PR DESCRIPTION
Build time hasn't changed:

before:
`Finished dev [unoptimized + debuginfo] target(s) in 1m 02s`
after:
`Finished dev [unoptimized + debuginfo] target(s) in 1m 06s`

There are a couple less dependencies, but those didn't seem to have any effect on total build times. This also removed direct dependencies from druid-shell. This will reduce maintenance effort a bit.