### PR TITLE
Add file format popup mac

### DIFF
--- a/druid-shell/examples/shello.rs
+++ b/druid-shell/examples/shello.rs
@@ -58,12 +58,24 @@ impl WinHandler for HelloState {
                 ]);
                 self.handle.open_file(options);
             }
+            0x102 => {
+                let options = FileDialogOptions::new().show_hidden().allowed_types(vec![
+                    FileSpec::new("Rust Files", &["rs", "toml"]),
+                    FileSpec::TEXT,
+                    FileSpec::JPG,
+                ]);
+                self.handle.save_as(options);
+            }
             _ => println!("unexpected id {}", id),
         }
     }
 
     fn open_file(&mut self, _token: FileDialogToken, file_info: Option<FileInfo>) {
         println!("open file result: {:?}", file_info);
+    }
+
+    fn save_as(&mut self, _token: FileDialogToken, file: Option<FileInfo>) {
+        println!("save file result: {:?}", file);
     }
 
     fn key_down(&mut self, event: KeyEvent) -> bool {
@@ -135,6 +147,13 @@ fn main() {
         0x101,
         "O&pen",
         Some(&HotKey::new(SysMods::Cmd, "o")),
+        true,
+        false,
+    );
+    file_menu.add_item(
+        0x102,
+        "S&ave",
+        Some(&HotKey::new(SysMods::Cmd, "s")),
         true,
         false,
     );

--- a/druid-shell/src/backend/gtk/window.rs
+++ b/druid-shell/src/backend/gtk/window.rs
@@ -842,7 +842,10 @@ impl WindowState {
                         options,
                     )
                     .ok()
-                    .map(|s| FileInfo { path: s.into() });
+                    .map(|s| FileInfo {
+                        path: s.into(),
+                        format: None,
+                    });
                     self.with_handler(|h| h.open_file(token, file_info));
                 }
                 DeferredOp::SaveAs(options, token) => {
@@ -852,7 +855,10 @@ impl WindowState {
                         options,
                     )
                     .ok()
-                    .map(|s| FileInfo { path: s.into() });
+                    .map(|s| FileInfo {
+                        path: s.into(),
+                        format: None,
+                    });
                     self.with_handler(|h| h.save_as(token, file_info));
                 }
                 DeferredOp::ContextMenu(menu, handle) => {

--- a/druid-shell/src/backend/mac/dialog.rs
+++ b/druid-shell/src/backend/mac/dialog.rs
@@ -165,7 +165,7 @@ pub(crate) unsafe fn build_panel(ty: FileDialogType, mut options: FileDialogOpti
     panel
 }
 
-// AppKit has a build-in file format accessory view. However, this is only
+// AppKit has a built-in file format accessory view. However, this is only
 // displayed for `NSDocument` based apps. We have to construct our own `NSView`
 // hierachy to implement something similar.
 unsafe fn allowed_types_accessory_view(allowed_types: &[crate::FileSpec]) -> id {

--- a/druid-shell/src/backend/mac/dialog.rs
+++ b/druid-shell/src/backend/mac/dialog.rs
@@ -125,7 +125,7 @@ pub(crate) unsafe fn build_panel(ty: FileDialogType, mut options: FileDialogOpti
     // we add a accessory view to set the file format
     match (&options.allowed_types, ty) {
         (Some(allowed_types), FileDialogType::Save) if !allowed_types.is_empty() => {
-            let accessory_view = allowed_types_accessory_view(&allowed_types);
+            let accessory_view = allowed_types_accessory_view(allowed_types);
             let _: () = msg_send![panel, setAccessoryView: accessory_view];
         }
         _ => (),

--- a/druid-shell/src/backend/mac/window.rs
+++ b/druid-shell/src/backend/mac/window.rs
@@ -1167,8 +1167,7 @@ impl WindowHandle {
         unsafe {
             let panel = dialog::build_panel(ty, opts.clone());
             let block = ConcreteBlock::new(move |response: dialog::NSModalResponse| {
-                let url = dialog::get_path(panel, opts.clone(), response)
-                    .map(|s| FileInfo { path: s.into() });
+                let url = dialog::get_file_info(panel, opts.clone(), response);
                 let view = self_clone.nsview.load();
                 if let Some(view) = (*view).as_ref() {
                     let view_state: *mut c_void = *view.get_ivar("viewState");

--- a/druid-shell/src/backend/mac/window.rs
+++ b/druid-shell/src/backend/mac/window.rs
@@ -1165,9 +1165,10 @@ impl WindowHandle {
         let token = FileDialogToken::next();
         let self_clone = self.clone();
         unsafe {
-            let panel = dialog::build_panel(ty, opts);
+            let panel = dialog::build_panel(ty, opts.clone());
             let block = ConcreteBlock::new(move |response: dialog::NSModalResponse| {
-                let url = dialog::get_path(panel, response).map(|s| FileInfo { path: s.into() });
+                let url = dialog::get_path(panel, opts.clone(), response)
+                    .map(|s| FileInfo { path: s.into() });
                 let view = self_clone.nsview.load();
                 if let Some(view) = (*view).as_ref() {
                     let view_state: *mut c_void = *view.get_ivar("viewState");

--- a/druid-shell/src/backend/mac/window.rs
+++ b/druid-shell/src/backend/mac/window.rs
@@ -55,7 +55,7 @@ use super::menu::Menu;
 use super::text_input::NSRange;
 use super::util::{assert_main_thread, make_nsstring};
 use crate::common_util::IdleCallback;
-use crate::dialog::{FileDialogOptions, FileDialogType, FileInfo};
+use crate::dialog::{FileDialogOptions, FileDialogType};
 use crate::keyboard_types::KeyState;
 use crate::mouse::{Cursor, CursorDesc, MouseButton, MouseButtons, MouseEvent};
 use crate::region::Region;

--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -603,6 +603,7 @@ impl MyWndProc {
                             .ok()
                             .map(|os_str| FileInfo {
                                 path: os_str.into(),
+                                format: None,
                             })
                     };
                     self.with_wnd_state(|s| s.handler.save_as(token, info));
@@ -611,7 +612,10 @@ impl MyWndProc {
                     let info = unsafe {
                         get_file_dialog_path(hwnd, FileDialogType::Open, options)
                             .ok()
-                            .map(|s| FileInfo { path: s.into() })
+                            .map(|s| FileInfo {
+                                path: s.into(),
+                                format: None,
+                            })
                     };
                     self.with_wnd_state(|s| s.handler.open_file(token, info));
                 }

--- a/druid-shell/src/dialog.rs
+++ b/druid-shell/src/dialog.rs
@@ -21,7 +21,16 @@ use std::path::{Path, PathBuf};
 /// This path might point to a file or a directory.
 #[derive(Debug, Clone)]
 pub struct FileInfo {
+    /// The path to the selected file.
+    /// On macOS, this is already rewritten to use the extension that the user selected
+    /// with the `file format` property.
     pub(crate) path: PathBuf,
+    /// The selected file format. If there're multiple different formats available
+    /// this allows understanding the kind of format that the user expects the file
+    /// to be written in. Examples could be Blender 2.4 vs Blender 2.6 vs Blender 2.8.
+    /// The `path` above will already contain the appropriate extension chosen in the
+    /// `format` property, so it is not necessary to mutate `path` any further.
+    pub(crate) format: Option<FileSpec>,
 }
 
 /// Type of file dialog.

--- a/druid-shell/src/dialog.rs
+++ b/druid-shell/src/dialog.rs
@@ -25,15 +25,15 @@ pub struct FileInfo {
     ///
     /// On macOS, this is already rewritten to use the extension that the user selected
     /// with the `file format` property.
-    pub(crate) path: PathBuf,
-    /// The selected file format. 
+    pub path: PathBuf,
+    /// The selected file format.
     ///
     /// If there're multiple different formats available
     /// this allows understanding the kind of format that the user expects the file
     /// to be written in. Examples could be Blender 2.4 vs Blender 2.6 vs Blender 2.8.
     /// The `path` above will already contain the appropriate extension chosen in the
     /// `format` property, so it is not necessary to mutate `path` any further.
-    pub(crate) format: Option<FileSpec>,
+    pub format: Option<FileSpec>,
 }
 
 /// Type of file dialog.

--- a/druid-shell/src/dialog.rs
+++ b/druid-shell/src/dialog.rs
@@ -22,6 +22,7 @@ use std::path::{Path, PathBuf};
 #[derive(Debug, Clone)]
 pub struct FileInfo {
     /// The path to the selected file.
+    ///
     /// On macOS, this is already rewritten to use the extension that the user selected
     /// with the `file format` property.
     pub(crate) path: PathBuf,

--- a/druid-shell/src/dialog.rs
+++ b/druid-shell/src/dialog.rs
@@ -26,7 +26,9 @@ pub struct FileInfo {
     /// On macOS, this is already rewritten to use the extension that the user selected
     /// with the `file format` property.
     pub(crate) path: PathBuf,
-    /// The selected file format. If there're multiple different formats available
+    /// The selected file format. 
+    ///
+    /// If there're multiple different formats available
     /// this allows understanding the kind of format that the user expects the file
     /// to be written in. Examples could be Blender 2.4 vs Blender 2.6 vs Blender 2.8.
     /// The `path` above will already contain the appropriate extension chosen in the


### PR DESCRIPTION
This fixes #998 by adding a file format popup. A couple of caveats (as also explained in my comment [here](https://github.com/linebender/druid/issues/998#issuecomment-872871430):

- MacOS usually shows these for `NSDocument` based apps. In order to have a similar experience, we have to build our own view hierarchy. This might not be pixel perfect similar to, say, how TextEdit does it.
- The implementation does not return the selected save path and the selected file format. Instead, the save path will be mutated based on the selected file format. So if the user enters "example.pdf" as the path and set set file format to "Jpg" the result will be that the path returned from calling the save panel is "example.jpg". 
- The string `File Format:` is currently hard coded into the implementation. This is fine but will break with localization. There's no way to retrieve the operating system resource that is used in apps like TextEdit. 

This is what it looks like:
<img width="440" alt="Screen Shot 2021-07-02 at 11 41 21" src="https://user-images.githubusercontent.com/132234/124274510-a571fc00-db41-11eb-8e3a-11e1148218c9.png">
