### PR TITLE
X11: Always save screen number as usize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - X11 backend now supports custom cursors ([#1801] by [@psychon])
 - X11: Add support for transparent windows ([#1803] by [@psychon])
 - X11: Added support for `get_monitors` ([#1804] by [@psychon])
+- x11: Remove some unnecessary casts ([#1851] by [@psychon])
 - `has_focus` method on `WidgetPod` ([#1825] by [@ForLoveOfCats])
 - x11: Add support for getting clipboard contents ([#1805] by [@psychon])
 
@@ -738,6 +739,7 @@ Last release without a changelog :(
 [#1805]: https://github.com/linebender/druid/pull/1805
 [#1820]: https://github.com/linebender/druid/pull/1820
 [#1825]: https://github.com/linebender/druid/pull/1825
+[#1851]: https://github.com/linebender/druid/pull/1851
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -205,7 +205,7 @@ impl Application {
         let screen = connection
             .setup()
             .roots
-            .get(screen_num as usize)
+            .get(screen_num)
             .ok_or_else(|| anyhow!("Invalid screen num: {}", screen_num))?;
         let root_visual_type = util::get_visual_from_screen(&screen)
             .ok_or_else(|| anyhow!("Couldn't get visual from screen"))?;
@@ -348,8 +348,8 @@ impl Application {
     }
 
     #[inline]
-    pub(crate) fn screen_num(&self) -> i32 {
-        self.screen_num as _
+    pub(crate) fn screen_num(&self) -> usize {
+        self.screen_num
     }
 
     #[inline]

--- a/druid-shell/src/platform/x11/screen.rs
+++ b/druid-shell/src/platform/x11/screen.rs
@@ -37,7 +37,7 @@ where
 pub(crate) fn get_monitors() -> Vec<Monitor> {
     let result = if let Some(app) = crate::Application::try_global() {
         let app = app.platform_app;
-        get_monitors_impl(app.connection().as_ref(), app.screen_num() as usize)
+        get_monitors_impl(app.connection().as_ref(), app.screen_num())
     } else {
         let (conn, screen_num) = match x11rb::connect(None) {
             Ok(res) => res,

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -271,7 +271,7 @@ impl WindowBuilder {
         let size_px = self.size.to_px(scale);
         let screen = setup
             .roots
-            .get(screen_num as usize)
+            .get(screen_num)
             .ok_or_else(|| anyhow!("Invalid screen num: {}", screen_num))?;
         let visual_type = if self.transparent {
             self.app.argb_visual_type()
@@ -1782,7 +1782,7 @@ impl WindowHandle {
                 Some(format) => {
                     let conn = w.app.connection();
                     let setup = &conn.setup();
-                    let screen = &setup.roots[w.app.screen_num() as usize];
+                    let screen = &setup.roots[w.app.screen_num()];
                     match make_cursor(&**conn, setup.image_byte_order, screen.root, format, desc) {
                         // TODO: We 'leak' the cursor - nothing ever calls render_free_cursor
                         Ok(cursor) => Some(cursor),


### PR DESCRIPTION
The screen number is only ever used for indexing into the list of
screens. Thus, usize is the perfect type for this. x11rb even provides
the screen number as usize.

This commit thus can get rid of a couple of casts by just always using
usize.

(History guess: xcb-rs uses i32 for the screen number (because C) and
that's why the code was like this in the first place)

Signed-off-by: Uli Schlachter <psychon@znc.in>