### PR TITLE
x11: Use only a single atom manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - Update look and feel of controls when disabled ([#1717] by [@xarvic])
 - Change the signature of `add_idle_callback` ([#1787] by [@jneem])
 - Move macOS only function to Mac extension trait ([#1863] by [@Maan2003])
+- x11: Only query atoms once instead of per window ([#1865] by [@psychon])
 
 ### Deprecated
 
@@ -746,6 +747,7 @@ Last release without a changelog :(
 [#1851]: https://github.com/linebender/druid/pull/1851
 [#1861]: https://github.com/linebender/druid/pull/1861
 [#1863]: https://github.com/linebender/druid/pull/1863
+[#1865]: https://github.com/linebender/druid/pull/1865
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid-shell/src/backend/x11/application.rs
+++ b/druid-shell/src/backend/x11/application.rs
@@ -39,6 +39,56 @@ use super::clipboard::Clipboard;
 use super::util;
 use super::window::Window;
 
+// This creates a `struct WindowAtoms` containing the specified atoms as members (along with some
+// convenience methods to intern and query those atoms). We use the following atoms:
+//
+// WM_PROTOCOLS
+//
+// List of atoms that identify the communications protocols between
+// the client and window manager in which the client is willing to participate.
+//
+// https://www.x.org/releases/X11R7.6/doc/xorg-docs/specs/ICCCM/icccm.html#wm_protocols_property
+//
+// WM_DELETE_WINDOW
+//
+// Including this atom in the WM_PROTOCOLS property on each window makes sure that
+// if the window manager respects WM_DELETE_WINDOW it will send us the event.
+//
+// The WM_DELETE_WINDOW event is sent when there is a request to close the window.
+// Registering for but ignoring this event means that the window will remain open.
+//
+// https://www.x.org/releases/X11R7.6/doc/xorg-docs/specs/ICCCM/icccm.html#window_deletion
+//
+// _NET_WM_PID
+//
+// A property containing the PID of the process that created the window.
+//
+// https://specifications.freedesktop.org/wm-spec/wm-spec-1.3.html#idm45805407915360
+//
+// _NET_WM_NAME
+//
+// A version of WM_NAME supporting UTF8 text.
+//
+// https://specifications.freedesktop.org/wm-spec/wm-spec-1.3.html#idm45805407982336
+//
+// UTF8_STRING
+//
+// The type of _NET_WM_NAME
+x11rb::atom_manager! {
+    pub(crate) AppAtoms: AppAtomsCookie {
+        WM_PROTOCOLS,
+        WM_DELETE_WINDOW,
+        _NET_WM_PID,
+        _NET_WM_NAME,
+        UTF8_STRING,
+        _NET_WM_WINDOW_TYPE,
+        _NET_WM_WINDOW_TYPE_NORMAL,
+        _NET_WM_WINDOW_TYPE_DROPDOWN_MENU,
+        _NET_WM_WINDOW_TYPE_TOOLTIP,
+        _NET_WM_WINDOW_TYPE_DIALOG,
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct Application {
     /// The connection to the X server.
@@ -62,6 +112,8 @@ pub(crate) struct Application {
     argb_visual_type: Option<Visualtype>,
     /// Pending events that need to be handled later
     pending_events: Rc<RefCell<VecDeque<Event>>>,
+    /// The atoms that we need
+    atoms: AppAtoms,
 
     /// The X11 resource database used to query dpi.
     pub(crate) rdb: Rc<ResourceDb>,
@@ -204,6 +256,10 @@ impl Application {
             col_resize: load_cursor("col-resize"),
         };
 
+        let atoms = AppAtoms::new(&*connection)?
+            .reply()
+            .context("get X11 atoms")?;
+
         let screen = connection
             .setup()
             .roots
@@ -235,6 +291,7 @@ impl Application {
             present_opcode,
             root_visual_type,
             argb_visual_type,
+            atoms,
             pending_events: Default::default(),
             marker: std::marker::PhantomData,
             render_argb32_pictformat_cursor,
@@ -389,6 +446,11 @@ impl Application {
     #[inline]
     pub(crate) fn root_visual_type(&self) -> Visualtype {
         self.root_visual_type
+    }
+
+    #[inline]
+    pub(crate) fn atoms(&self) -> &AppAtoms {
+        &self.atoms
     }
 
     /// Returns `Ok(true)` if we want to exit the main loop.


### PR DESCRIPTION
Instead of having one atom manager instance per window and another for the clipboard, this merges everything into a single instance. The idea is that this is a tiny, tiny bit more performant (but likely unmeasurable so). Also, constructing the clipboard becomes infallible, which is always nice.