### PR TITLE
X11: Add timeout for getting clipboard contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - X11: Added support for `get_monitors` ([#1804] by [@psychon])
 - x11: Remove some unnecessary casts ([#1851] by [@psychon])
 - `has_focus` method on `WidgetPod` ([#1825] by [@ForLoveOfCats])
-- x11: Add support for getting and setting clipboard contents ([#1805] and [#1851] by [@psychon])
+- x11: Add support for getting and setting clipboard contents ([#1805], [#1851], and [#1866] by [@psychon])
 - Linux extension: primary_clipboard ([#1843] by [@Maan2003])
 
 ### Changed
@@ -746,6 +746,7 @@ Last release without a changelog :(
 [#1851]: https://github.com/linebender/druid/pull/1851
 [#1861]: https://github.com/linebender/druid/pull/1861
 [#1863]: https://github.com/linebender/druid/pull/1863
+[#1866]: https://github.com/linebender/druid/pull/1866
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid-shell/src/backend/x11/clipboard.rs
+++ b/druid-shell/src/backend/x11/clipboard.rs
@@ -18,6 +18,7 @@ use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
 use std::convert::TryFrom;
 use std::rc::Rc;
+use std::time::{Duration, Instant};
 
 use x11rb::connection::{Connection, RequestConnection};
 use x11rb::errors::{ConnectionError, ReplyError, ReplyOrIdError};
@@ -263,6 +264,8 @@ impl ClipboardState {
     {
         debug!("Getting clipboard contents in format {}", format);
 
+        let deadline = Instant::now() + Duration::from_secs(5);
+
         let conn = &*self.connection;
         let format_atom = conn.intern_atom(false, format.as_bytes())?.reply()?.atom;
 
@@ -280,7 +283,7 @@ impl ClipboardState {
         // Now wait for the selection notify event
         conn.flush()?;
         let notify = loop {
-            match conn.wait_for_event()? {
+            match wait_for_event_with_deadline(conn, deadline)? {
                 Event::SelectionNotify(notify) if notify.requestor == window.window => {
                     break notify
                 }
@@ -326,7 +329,7 @@ impl ClipboardState {
         conn.flush()?;
         let mut value = Vec::new();
         loop {
-            match conn.wait_for_event()? {
+            match wait_for_event_with_deadline(conn, deadline)? {
                 Event::PropertyNotify(notify)
                     if (notify.window, notify.state) == (window.window, Property::NEW_VALUE) =>
                 {
@@ -647,4 +650,54 @@ fn reject_transfer(
     };
     conn.send_event(false, event.requestor, EventMask::NO_EVENT, &event)?;
     Ok(())
+}
+
+/// Wait for an X11 event or return a timeout error if the given deadline is in the past.
+fn wait_for_event_with_deadline(
+    conn: &XCBConnection,
+    deadline: Instant,
+) -> Result<Event, ConnectionError> {
+    use nix::poll::{poll, PollFd, PollFlags};
+    use std::os::raw::c_int;
+    use std::os::unix::io::AsRawFd;
+
+    loop {
+        // Is there already an event?
+        if let Some(event) = conn.poll_for_event()? {
+            return Ok(event);
+        }
+
+        // Are we past the deadline?
+        let now = Instant::now();
+        if deadline <= now {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "Timeout while waiting for selection owner to reply",
+            )
+            .into());
+        }
+
+        // Use poll() to wait for the socket to become readable.
+        let mut poll_fds = [PollFd::new(conn.as_raw_fd(), PollFlags::POLLIN)];
+        let poll_timeout = c_int::try_from(deadline.duration_since(now).as_millis())
+            .unwrap_or(c_int::max_value() - 1)
+            // The above rounds down, but we don't want to wake up to early, so add one
+            .saturating_add(1);
+
+        // Wait for the socket to be readable via poll() and try again
+        match poll(&mut poll_fds, poll_timeout) {
+            Ok(_) => {}
+            Err(nix::Error::Sys(nix::errno::Errno::EINTR)) => {}
+            Err(e) => return Err(nix_error_to_io(e).into()),
+        }
+    }
+}
+
+fn nix_error_to_io(e: nix::Error) -> std::io::Error {
+    use std::io::{Error, ErrorKind};
+    match e {
+        nix::Error::Sys(errno) => errno.into(),
+        nix::Error::InvalidPath | nix::Error::InvalidUtf8 => Error::new(ErrorKind::InvalidInput, e),
+        nix::Error::UnsupportedOperation => std::io::Error::new(ErrorKind::Other, e),
+    }
 }


### PR DESCRIPTION
When the selection does not answer, the code would just hang while
waiting for a reply. This could e.g. happen when the "other end"
crashes.

Handle this situation by applying a timeout of five seconds for getting
the clipboard contents. After this timeout, the transfer is aborted with
an error.

This was tested by batching handle_request() in druid-shell's clipboard
code to just return Ok(()). Then, I started the following program:

    fn main() { druid_shell::Application::new().unwrap().clipboard().put_string("whatever"); }

Afterwards, trying to get the clipboard contents with druid_shell would
just hang.

With this commit, the following happens instead:

     WARN druid_shell::backend::x11::clipboard: Error in Clipboard::do_transfer: ConnectionError(IOError(Custom { kind: TimedOut, error: "Timeout while waiting for selection owner to reply" }))

Signed-off-by: Uli Schlachter <psychon@znc.in>