### PR TITLE
x11: Implement LinuxApplicationExt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - `has_focus` method on `WidgetPod` ([#1825] by [@ForLoveOfCats])
 - x11: Add support for getting and setting clipboard contents ([#1805], [#1851], and [#1866] by [@psychon])
 - Linux extension: primary_clipboard ([#1843] by [@Maan2003])
+- x11: Implement primary_clipboard ([#1867] by [@psychon])
 
 ### Changed
 
@@ -752,6 +753,7 @@ Last release without a changelog :(
 [#1863]: https://github.com/linebender/druid/pull/1863
 [#1865]: https://github.com/linebender/druid/pull/1865
 [#1866]: https://github.com/linebender/druid/pull/1866
+[#1867]: https://github.com/linebender/druid/pull/1867
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid-shell/src/platform/linux.rs
+++ b/druid-shell/src/platform/linux.rs
@@ -32,7 +32,5 @@ mod test {
 
     use super::*;
     use static_assertions as sa;
-    // TODO(shell/x11): implement LinuxApplicationExt
-    #[cfg(not(feature = "x11"))]
     sa::assert_impl_all!(Application: LinuxApplicationExt);
 }


### PR DESCRIPTION
This allows interacting with the primary selection in the X11 backend.

Signed-off-by: Uli Schlachter <psychon@znc.in>
