### PR TITLE
x11: Set WM_CLASS on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - `has_focus` method on `WidgetPod` ([#1825] by [@ForLoveOfCats])
 - x11: Add support for getting and setting clipboard contents ([#1805], [#1851], and [#1866] by [@psychon])
 - Linux extension: primary_clipboard ([#1843] by [@Maan2003])
+- x11: Set WM_CLASS property ([#1868] by [@psychon])
 
 ### Changed
 
@@ -752,6 +753,7 @@ Last release without a changelog :(
 [#1863]: https://github.com/linebender/druid/pull/1863
 [#1865]: https://github.com/linebender/druid/pull/1865
 [#1866]: https://github.com/linebender/druid/pull/1866
+[#1868]: https://github.com/linebender/druid/pull/1868
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0


### PR DESCRIPTION
I compared "xprop" output between a random window with the gtk and x11
backends and noticed that WM_CLASS is missing, even though it is
required by ICCCM.

This commit implements setting the WM_CLASS property on x11.

This was tested via "xprop": gtk and x11 backends now produce the same
value for the WM_CLASS property.

Signed-off-by: Uli Schlachter <psychon@znc.in>