### PR TITLE
Fix localisation stipping in GTK, X11 and macos

### DIFF
--- a/druid-shell/src/backend/gtk/application.rs
+++ b/druid-shell/src/backend/gtk/application.rs
@@ -84,7 +84,11 @@ impl Application {
     }
 
     pub fn get_locale() -> String {
-        glib::get_language_names()[0].as_str().into()
+        let mut locale: String = glib::get_language_names()[0].as_str().into();
+        if let Some(idx) = locale.chars().position(|c| c == '.') {
+            locale.truncate(idx);
+        }
+        locale
     }
 }
 

--- a/druid-shell/src/backend/gtk/application.rs
+++ b/druid-shell/src/backend/gtk/application.rs
@@ -85,7 +85,7 @@ impl Application {
 
     pub fn get_locale() -> String {
         let mut locale: String = glib::get_language_names()[0].as_str().into();
-        if let Some(idx) = locale.chars().position(|c| c == '.') {
+        if let Some(idx) = locale.chars().position(|c| c == '.' || c == '@') {
             locale.truncate(idx);
         }
         locale

--- a/druid-shell/src/backend/gtk/application.rs
+++ b/druid-shell/src/backend/gtk/application.rs
@@ -85,6 +85,7 @@ impl Application {
 
     pub fn get_locale() -> String {
         let mut locale: String = glib::get_language_names()[0].as_str().into();
+        // This is done because the locale parsing library we use expects an unicode locale, but these vars have an ISO locale
         if let Some(idx) = locale.chars().position(|c| c == '.' || c == '@') {
             locale.truncate(idx);
         }

--- a/druid-shell/src/backend/mac/application.rs
+++ b/druid-shell/src/backend/mac/application.rs
@@ -111,7 +111,7 @@ impl Application {
             let locale: id = msg_send![nslocale_class, currentLocale];
             let ident: id = msg_send![locale, localeIdentifier];
             let mut locale = util::from_nsstring(ident);
-            if let Some(idx) = locale.chars().position(|c| c == '@') {
+            if let Some(idx) = locale.chars().position(|c| c == '.' || c == '@') {
                 locale.truncate(idx);
             }
             locale

--- a/druid-shell/src/backend/mac/application.rs
+++ b/druid-shell/src/backend/mac/application.rs
@@ -112,7 +112,7 @@ impl Application {
             let ident: id = msg_send![locale, localeIdentifier];
             let mut locale = util::from_nsstring(ident);
             // This is done because the locale parsing library we use expects an unicode locale, but these vars have an ISO locale
-            if let Some(idx) = locale.chars().position(|c| c == '.' || c == '@') {
+            if let Some(idx) = locale.chars().position(|c| c == '@') {
                 locale.truncate(idx);
             }
             locale

--- a/druid-shell/src/backend/mac/application.rs
+++ b/druid-shell/src/backend/mac/application.rs
@@ -111,6 +111,7 @@ impl Application {
             let locale: id = msg_send![nslocale_class, currentLocale];
             let ident: id = msg_send![locale, localeIdentifier];
             let mut locale = util::from_nsstring(ident);
+            // This is done because the locale parsing library we use expects an unicode locale, but these vars have an ISO locale
             if let Some(idx) = locale.chars().position(|c| c == '.' || c == '@') {
                 locale.truncate(idx);
             }

--- a/druid-shell/src/backend/x11/application.rs
+++ b/druid-shell/src/backend/x11/application.rs
@@ -22,7 +22,6 @@ use std::rc::Rc;
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Error};
-use tracing::debug;
 use x11rb::connection::{Connection, RequestConnection};
 use x11rb::protocol::present::ConnectionExt as _;
 use x11rb::protocol::render::{self, ConnectionExt as _, Pictformat};

--- a/druid-shell/src/backend/x11/application.rs
+++ b/druid-shell/src/backend/x11/application.rs
@@ -786,7 +786,7 @@ impl Application {
             .or_else(|| var_non_empty("LC_MESSAGES"))
             .or_else(|| var_non_empty("LANG"))
             .unwrap_or_else(|| "en-US".to_string());
-        if let Some(idx) = locale.chars().position(|c| c == '.') {
+        if let Some(idx) = locale.chars().position(|c| c == '.' || c == '@') {
             locale.truncate(idx);
         }
         locale

--- a/druid-shell/src/backend/x11/application.rs
+++ b/druid-shell/src/backend/x11/application.rs
@@ -22,6 +22,7 @@ use std::rc::Rc;
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Error};
+use tracing::debug;
 use x11rb::connection::{Connection, RequestConnection};
 use x11rb::protocol::present::ConnectionExt as _;
 use x11rb::protocol::render::{self, ConnectionExt as _, Pictformat};
@@ -786,6 +787,8 @@ impl Application {
             .or_else(|| var_non_empty("LC_MESSAGES"))
             .or_else(|| var_non_empty("LANG"))
             .unwrap_or_else(|| "en-US".to_string());
+
+        // This is done because the locale parsing library we use expects an unicode locale, but these vars have an ISO locale
         if let Some(idx) = locale.chars().position(|c| c == '.' || c == '@') {
             locale.truncate(idx);
         }

--- a/druid-shell/src/backend/x11/application.rs
+++ b/druid-shell/src/backend/x11/application.rs
@@ -778,14 +778,18 @@ impl Application {
 
         // from gettext manual
         // https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html#Locale-Environment-Variables
-        var_non_empty("LANGUAGE")
+        let mut locale = var_non_empty("LANGUAGE")
             // the LANGUAGE value is priority list seperated by :
             // See: https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html#The-LANGUAGE-variable
             .and_then(|locale| locale.split(':').next().map(String::from))
             .or_else(|| var_non_empty("LC_ALL"))
             .or_else(|| var_non_empty("LC_MESSAGES"))
             .or_else(|| var_non_empty("LANG"))
-            .unwrap_or_else(|| "en-US".to_string())
+            .unwrap_or_else(|| "en-US".to_string());
+        if let Some(idx) = locale.chars().position(|c| c == '.') {
+            locale.truncate(idx);
+        }
+        locale
     }
 
     pub(crate) fn idle_pipe(&self) -> RawFd {


### PR DESCRIPTION
on macos we already strip the modifiers, this extends this to all backends and also stripping the charset.

fixes #1864 