### PR TITLE
Add serde feature to druid-shell

### DIFF
--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -36,6 +36,7 @@ tga = ["piet-common/tga"]
 farbfeld = ["piet-common/farbfeld"]
 dxt = ["piet-common/dxt"]
 hdr = ["piet-common/hdr"]
+serde = ["kurbo/serde"]
 
 [dependencies]
 # NOTE: When changing the piet or kurbo versions, ensure that

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -26,7 +26,7 @@ image = ["druid-shell/image"]
 svg = ["usvg"]
 x11 = ["druid-shell/x11"]
 crochet = []
-serde = ["im/serde"]
+serde = ["im/serde", "druid-shell/serde"]
 
 # passing on all the image features. AVIF is not supported because it does not
 # support decoding, and that's all we use `Image` for.


### PR DESCRIPTION
I noticed that kurbo wasn't using the serde feature for it's types (Point and such) even though serde was defined as a feature for druid. Adding serde to druid-shell's features fixed the issue for me.