### PR TITLE
Drag and drop

### DIFF
--- a/druid-shell/src/dnd.rs
+++ b/druid-shell/src/dnd.rs
@@ -1,0 +1,96 @@
+use std::path::PathBuf;
+
+use crate::backend::dnd as backend;
+use crate::{Counter, FormatId, Modifiers};
+
+use kurbo::Point;
+use piet_common::ImageBuf;
+
+#[derive(Debug)]
+pub enum DragDropAction {
+    Copy,
+    Move,
+}
+
+#[derive(Debug)]
+pub struct DragData(backend::DragData);
+
+#[derive(Debug, Clone)]
+pub struct DropEvent {
+    pub modifiers: Modifiers,
+    pub position: Point,
+}
+
+#[derive(Clone)]
+pub struct DropContext(pub(crate) backend::DragDropContext);
+
+/// A unique identifier for a drag drop session.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct DragDropId(u64);
+
+impl DragDropId {
+    /// Create a new, unique DragDropId
+    pub(crate) fn next() -> DragDropId {
+        static COUNTER: Counter = Counter::new();
+        DragDropId(COUNTER.next())
+    }
+}
+
+impl DragData {
+    pub fn new() -> Self {
+        DragData(backend::DragData::new())
+    }
+
+    /// Add a data format
+    pub fn add(&mut self, format: FormatId, data: Vec<u8>) {
+        self.0.add(format, data)
+    }
+
+    /// default: true
+    pub fn copyable(&mut self, allowed: bool) {
+        self.0.copyable(allowed)
+    }
+
+    /// default: false
+    pub fn movable(&mut self, allowed: bool) {
+        self.0.movable(allowed)
+    }
+
+    pub fn cursor_image(&mut self, image: ImageBuf) {
+        self.0.cursor_image(image)
+    }
+
+    pub fn files(&mut self, files: Vec<PathBuf>) {
+        self.0.files(files)
+    }
+}
+
+impl DropContext {
+    pub fn deny(&self) {
+        self.0.deny()
+    }
+
+    pub fn action(&self) -> DragDropAction {
+        self.0.action()
+    }
+
+    pub fn set_action(&self, action: DragDropAction) {
+        self.0.set_action(action)
+    }
+
+    pub fn get_format(&self, format: FormatId) -> Option<Vec<u8>> {
+        self.0.get_format(format)
+    }
+
+    pub fn files(&self) -> Option<Vec<PathBuf>> {
+        self.0.files()
+    }
+
+    pub fn preferred_format(&self, formats: &[FormatId]) -> Option<FormatId> {
+        self.0.preferred_format(formats)
+    }
+
+    pub fn id(&self) -> DragDropId {
+        self.0.id()
+    }
+}

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -61,6 +61,7 @@ mod scale;
 mod screen;
 mod window;
 
+mod dnd;
 pub mod platform;
 pub mod text;
 
@@ -68,6 +69,7 @@ pub use application::{AppHandler, Application};
 pub use clipboard::{Clipboard, ClipboardFormat, FormatId};
 pub use common_util::Counter;
 pub use dialog::{FileDialogOptions, FileInfo, FileSpec};
+pub use dnd::{DragData, DragDropAction, DropContext, DropEvent};
 pub use error::Error;
 pub use hotkey::{HotKey, RawMods, SysMods};
 pub use keyboard::{Code, IntoKey, KbKey, KeyEvent, KeyState, Location, Modifiers};

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -21,6 +21,8 @@ use crate::application::Application;
 use crate::backend::window as backend;
 use crate::common_util::Counter;
 use crate::dialog::{FileDialogOptions, FileInfo};
+use crate::dnd::DropEvent;
+use crate::dnd::{DragDropId, DropContext};
 use crate::error::Error;
 use crate::keyboard::KeyEvent;
 use crate::kurbo::{Insets, Point, Rect, Size};
@@ -29,6 +31,7 @@ use crate::mouse::{Cursor, CursorDesc, MouseEvent};
 use crate::region::Region;
 use crate::scale::Scale;
 use crate::text::{Event, InputHandler};
+use crate::{DragData, DragDropAction};
 use piet_common::PietText;
 #[cfg(feature = "raw-win-handle")]
 use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
@@ -419,6 +422,14 @@ impl WindowHandle {
     pub fn get_scale(&self) -> Result<Scale, Error> {
         self.0.get_scale().map_err(Into::into)
     }
+
+    pub fn drop_context(&self) -> Option<DropContext> {
+        self.0.drop_context().map(DropContext)
+    }
+
+    pub fn drag_start(&self, data: DragData, position: Point) -> DragDropId {
+        self.0.drag_start(data, position)
+    }
 }
 
 #[cfg(feature = "raw-win-handle")]
@@ -674,6 +685,24 @@ pub trait WinHandler {
     /// Called when this window stops being the focused window.
     #[allow(unused_variables)]
     fn lost_focus(&mut self) {}
+
+    /// Called when a drop enter the window.
+    fn drop_enter(&mut self) {}
+
+    #[allow(unused_variables)]
+    fn drop_motion(&mut self, event: &DropEvent) {}
+
+    /// Called when a drop leaves the window.
+    fn drop_leave(&mut self) {}
+
+    /// Called when a drop is droped.
+    fn drop_droped(&mut self) {}
+
+    /// Called when a drag session ends
+    ///
+    /// action is None if drag got canceled
+    #[allow(unused_variables)]
+    fn drag_end(&mut self, id: DragDropId, action: Option<DragDropAction>);
 
     /// Called when the shell requests to close the window, for example because the user clicked
     /// the little "X" in the titlebar.


### PR DESCRIPTION
## as Source

- create `DragData`, add supported formats, tweak the options (cursor_image, movable, copyable)
- call `WindowHandle::drag_start` and get `DragDropId`
- When the drag and drop is over, `WinHandler::drag_end` will be called

## as Target

- Whenever a drag and drop item enters the window, `WinHandler::drop_enter` is called. Now, information about the item is provided by `WindowHandle::drop_context`.
- When item moves, `WinHandler::drop_motion` is called with `DropEvent`. `DropEvent` provides the position delta and keyboard modifiers (can be used to action of drag and drop)
- If the item is droped, `WinHandler::drop_droped` is called. drop can be canceled by calling `DropContext::deny`. **After** `WinHandler::drop_droped`, `WindowHandler::drop_context` will start returning `None`.
- If item leaves the window, `WinHandler::drop_leave` will be called. **Before** `WinHandler::drop_leave`, `WindowHandler::drop_context` will start returning `None`.