### PR TITLE
Add HasRawWindowHandle for WindowHandle in druid (rebased against master)

### DIFF
--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -43,6 +43,10 @@ pub use image;
 pub use kurbo;
 pub use piet_common as piet;
 
+// Reexport the version of `raw_window_handle` we are using.
+#[cfg(feature = "raw-win-handle")]
+pub use raw_window_handle;
+
 #[macro_use]
 mod util;
 

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -28,6 +28,9 @@ x11 = ["druid-shell/x11"]
 crochet = []
 serde = ["im/serde", "druid-shell/serde"]
 
+# Implement HasRawWindowHandle for WindowHandle
+raw-win-handle = ["druid-shell/raw-win-handle"]
+
 # passing on all the image features. AVIF is not supported because it does not
 # support decoding, and that's all we use `Image` for.
 png = ["druid-shell/image_png"]

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -188,6 +188,9 @@ pub use shell::{
     WindowHandle, WindowLevel, WindowState,
 };
 
+#[cfg(feature = "raw-win-handle")]
+pub use crate::shell::raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+
 pub use crate::core::WidgetPod;
 pub use app::{AppLauncher, WindowConfig, WindowDesc, WindowSizePolicy};
 pub use app_delegate::{AppDelegate, DelegateCtx};


### PR DESCRIPTION
Expose the `HasRawWindowHandle` trait impl of druid-shell for
`WindowHandle` into druid itself, so druid users can access it. This
is also under a `raw-win-handle` feature, like the druid-shell one.

Bug: #1505

This is all the work of @djeedai in #1828, just rebased against master to help nudge it along the finish line :)