### PR TITLE
Fix clippy lints for Rust 1.54

### DIFF
--- a/druid-shell/src/backend/mac/menu.rs
+++ b/druid-shell/src/backend/mac/menu.rs
@@ -36,7 +36,7 @@ fn make_menu_item(id: u32, text: &str, key: Option<&HotKey>, enabled: bool, sele
             .initWithTitle_action_keyEquivalent_(
                 make_nsstring(&stripped_text),
                 sel!(handleMenuItem:),
-                make_nsstring(&key_equivalent),
+                make_nsstring(key_equivalent),
             )
             .autorelease();
 

--- a/druid-shell/src/backend/mac/window.rs
+++ b/druid-shell/src/backend/mac/window.rs
@@ -493,7 +493,7 @@ lazy_static! {
         );
 
         let protocol = Protocol::get("NSTextInputClient").unwrap();
-        decl.add_protocol(&protocol);
+        decl.add_protocol(protocol);
 
         ViewClass(decl.register())
     };

--- a/druid-shell/src/backend/windows/clipboard.rs
+++ b/druid-shell/src/backend/windows/clipboard.rs
@@ -49,8 +49,8 @@ impl Clipboard {
             EmptyClipboard();
 
             for format in formats {
-                let handle = make_handle(&format);
-                let format_id = match get_format_id(&format.identifier) {
+                let handle = make_handle(format);
+                let format_id = match get_format_id(format.identifier) {
                     Some(id) => id,
                     None => {
                         tracing::warn!(
@@ -116,10 +116,10 @@ impl Clipboard {
         }
 
         with_clipboard(|| {
-            let format_id = match get_format_id(&format) {
+            let format_id = match get_format_id(format) {
                 Some(id) => id,
                 None => {
-                    tracing::warn!("failed to register clipboard format {}", &format);
+                    tracing::warn!("failed to register clipboard format {}", format);
                     return None;
                 }
             };
@@ -273,7 +273,7 @@ fn get_format_name(format: UINT) -> String {
         if result > 0 {
             let len = result as usize;
             let lpstr = std::slice::from_raw_parts(buffer.as_ptr() as *const u8, len);
-            String::from_utf8_lossy(&lpstr).into_owned()
+            String::from_utf8_lossy(lpstr).into_owned()
         } else {
             let err = GetLastError();
             if err == 87 {

--- a/druid-shell/src/backend/windows/error.rs
+++ b/druid-shell/src/backend/windows/error.rs
@@ -33,7 +33,7 @@ pub enum Error {
     /// Windows error code.
     Hr(HRESULT),
     // Maybe include the full error from the direct2d crate.
-    D2Error,
+    Direct2D,
     /// A function is available on newer version of windows.
     OldWindows,
     /// The `hwnd` pointer was null.
@@ -75,7 +75,7 @@ impl fmt::Display for Error {
                 }
                 Ok(())
             }
-            Error::D2Error => write!(f, "Direct2D error"),
+            Error::Direct2D => write!(f, "Direct2D error"),
             Error::OldWindows => write!(f, "Attempted newer API on older Windows"),
             Error::NullHwnd => write!(f, "Window handle is Null"),
         }

--- a/druid-shell/src/backend/windows/menu.rs
+++ b/druid-shell/src/backend/windows/menu.rs
@@ -104,7 +104,7 @@ impl Menu {
         let mut anno_text = text.to_string();
         if let Some(key) = key {
             anno_text.push('\t');
-            format_hotkey(&key, &mut anno_text);
+            format_hotkey(key, &mut anno_text);
         }
         unsafe {
             let mut flags = MF_STRING;

--- a/druid-shell/src/backend/x11/application.rs
+++ b/druid-shell/src/backend/x11/application.rs
@@ -289,9 +289,9 @@ impl Application {
             .roots
             .get(screen_num)
             .ok_or_else(|| anyhow!("Invalid screen num: {}", screen_num))?;
-        let root_visual_type = util::get_visual_from_screen(&screen)
+        let root_visual_type = util::get_visual_from_screen(screen)
             .ok_or_else(|| anyhow!("Couldn't get visual from screen"))?;
-        let argb_visual_type = util::get_argb_visual_type(&*connection, &screen)?;
+        let argb_visual_type = util::get_argb_visual_type(&*connection, screen)?;
 
         let timestamp = Rc::new(Cell::new(x11rb::CURRENT_TIME));
         let pending_events = Default::default();

--- a/druid-shell/src/backend/x11/clipboard.rs
+++ b/druid-shell/src/backend/x11/clipboard.rs
@@ -419,12 +419,8 @@ impl ClipboardState {
                     if data.len() > maximum_property_length(conn) {
                         // We need to do an INCR transfer.
                         debug!("Starting new INCR transfer");
-                        let transfer = IncrementalTransfer::new(
-                            conn,
-                            event,
-                            Rc::clone(&data),
-                            self.atoms.INCR,
-                        );
+                        let transfer =
+                            IncrementalTransfer::new(conn, event, Rc::clone(data), self.atoms.INCR);
                         match transfer {
                             Ok(transfer) => self.incremental.push(transfer),
                             Err(err) => {

--- a/druid-shell/src/common_util.rs
+++ b/druid-shell/src/common_util.rs
@@ -32,7 +32,7 @@ const MULTI_CLICK_MAX_DISTANCE: f64 = 5.0;
 /// Strip the access keys from the menu string.
 ///
 /// Changes "E&xit" to "Exit". Actual ampersands are escaped as "&&".
-#[cfg(any(target_os = "macos", all(target_os = "linux", feature = "gtk")))]
+#[allow(dead_code)]
 pub fn strip_access_key(raw_menu_text: &str) -> String {
     let mut saw_ampersand = false;
     let mut result = String::new();

--- a/druid/examples/image.rs
+++ b/druid/examples/image.rs
@@ -62,7 +62,7 @@ impl Rebuilder {
     }
 
     fn rebuild_inner(&mut self, data: &AppState) {
-        self.inner = build_widget(&data);
+        self.inner = build_widget(data);
     }
 }
 
@@ -79,7 +79,7 @@ impl Widget<AppState> for Rebuilder {
     }
 
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &AppState, data: &AppState, _env: &Env) {
-        if !old_data.same(&data) {
+        if !old_data.same(data) {
             self.rebuild_inner(data);
             ctx.children_changed();
         }

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -139,7 +139,7 @@ where
             cb(&mut ret, i);
 
             if !item.1.same(&ret) {
-                self[&item.0] = ret;
+                self[item.0] = ret;
             }
         }
     }


### PR DESCRIPTION
Fixes the CI errors that pop up on new pull requests since Rust 1.54 was released.