### PR TITLE
Rename variables named `inner` for clarity.

### DIFF
--- a/druid/src/widget/aspect_ratio_box.rs
+++ b/druid/src/widget/aspect_ratio_box.rs
@@ -24,7 +24,7 @@ use tracing::{instrument, warn};
 /// If not given a child, The box will try to size itself  as large or small as possible
 /// to preserve the aspect ratio.
 pub struct AspectRatioBox<T> {
-    inner: Box<dyn Widget<T>>,
+    child: Box<dyn Widget<T>>,
     ratio: f64,
 }
 
@@ -34,9 +34,9 @@ impl<T> AspectRatioBox<T> {
     /// The aspect ratio is defined as width / height.
     ///
     /// If aspect ratio <= 0.0, the ratio will be set to 1.0
-    pub fn new(inner: impl Widget<T> + 'static, ratio: f64) -> Self {
+    pub fn new(child: impl Widget<T> + 'static, ratio: f64) -> Self {
         Self {
-            inner: Box::new(inner),
+            child: Box::new(child),
             ratio: clamp_ratio(ratio),
         }
     }
@@ -107,7 +107,7 @@ impl<T: Data> Widget<T> for AspectRatioBox<T> {
         skip(self, ctx, event, data, env)
     )]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
-        self.inner.event(ctx, event, data, env);
+        self.child.event(ctx, event, data, env);
     }
 
     #[instrument(
@@ -116,7 +116,7 @@ impl<T: Data> Widget<T> for AspectRatioBox<T> {
         skip(self, ctx, event, data, env)
     )]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
-        self.inner.lifecycle(ctx, event, data, env)
+        self.child.lifecycle(ctx, event, data, env)
     }
 
     #[instrument(
@@ -125,7 +125,7 @@ impl<T: Data> Widget<T> for AspectRatioBox<T> {
         skip(self, ctx, old_data, data, env)
     )]
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
-        self.inner.update(ctx, old_data, data, env);
+        self.child.update(ctx, old_data, data, env);
     }
 
     #[instrument(
@@ -139,26 +139,26 @@ impl<T: Data> Widget<T> for AspectRatioBox<T> {
         if bc.max() == bc.min() {
             warn!("Box constraints are tight. Aspect ratio box will not be able to preserve aspect ratio.");
 
-            return self.inner.layout(ctx, bc, data, env);
+            return self.child.layout(ctx, bc, data, env);
         }
 
         if bc.max().width == f64::INFINITY && bc.max().height == f64::INFINITY {
             warn!("Box constraints are INFINITE. Aspect ratio box won't be able to choose a size because the constraints given by the parent widget are INFINITE.");
 
-            return self.inner.layout(ctx, bc, data, env);
+            return self.child.layout(ctx, bc, data, env);
         }
 
         let bc = self.generate_constraints(bc);
 
-        self.inner.layout(ctx, &bc, data, env)
+        self.child.layout(ctx, &bc, data, env)
     }
 
     #[instrument(name = "AspectRatioBox", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
-        self.inner.paint(ctx, data, env);
+        self.child.paint(ctx, data, env);
     }
 
     fn id(&self) -> Option<WidgetId> {
-        self.inner.id()
+        self.child.id()
     }
 }

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -30,17 +30,17 @@ pub struct Container<T> {
     border: Option<BorderStyle>,
     corner_radius: KeyOrValue<f64>,
 
-    inner: WidgetPod<T, Box<dyn Widget<T>>>,
+    child: WidgetPod<T, Box<dyn Widget<T>>>,
 }
 
 impl<T: Data> Container<T> {
     /// Create Container with a child
-    pub fn new(inner: impl Widget<T> + 'static) -> Self {
+    pub fn new(child: impl Widget<T> + 'static) -> Self {
         Self {
             background: None,
             border: None,
             corner_radius: 0.0.into(),
-            inner: WidgetPod::new(inner).boxed(),
+            child: WidgetPod::new(child).boxed(),
         }
     }
 
@@ -142,12 +142,12 @@ impl<T: Data> Container<T> {
 impl<T: Data> Widget<T> for Container<T> {
     #[instrument(name = "Container", level = "trace", skip(self, ctx, event, data, env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
-        self.inner.event(ctx, event, data, env);
+        self.child.event(ctx, event, data, env);
     }
 
     #[instrument(name = "Container", level = "trace", skip(self, ctx, event, data, env))]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
-        self.inner.lifecycle(ctx, event, data, env)
+        self.child.lifecycle(ctx, event, data, env)
     }
 
     #[instrument(
@@ -161,7 +161,7 @@ impl<T: Data> Widget<T> for Container<T> {
                 brush.update(ctx, old_data, data, env);
             });
         }
-        self.inner.update(ctx, data, env);
+        self.child.update(ctx, data, env);
     }
 
     #[instrument(name = "Container", level = "trace", skip(self, ctx, bc, data, env))]
@@ -174,16 +174,16 @@ impl<T: Data> Widget<T> for Container<T> {
             None => 0.0,
         };
         let child_bc = bc.shrink((2.0 * border_width, 2.0 * border_width));
-        let size = self.inner.layout(ctx, &child_bc, data, env);
+        let size = self.child.layout(ctx, &child_bc, data, env);
         let origin = Point::new(border_width, border_width);
-        self.inner.set_origin(ctx, data, env, origin);
+        self.child.set_origin(ctx, data, env, origin);
 
         let my_size = Size::new(
             size.width + 2.0 * border_width,
             size.height + 2.0 * border_width,
         );
 
-        let my_insets = self.inner.compute_parent_paint_insets(my_size);
+        let my_insets = self.child.compute_parent_paint_insets(my_size);
         ctx.set_paint_insets(my_insets);
         trace!("Computed layout: size={}, insets={:?}", my_size, my_insets);
         my_size
@@ -214,6 +214,6 @@ impl<T: Data> Widget<T> for Container<T> {
             ctx.stroke(border_rect, &border.color.resolve(env), border_width);
         };
 
-        self.inner.paint(ctx, data, env);
+        self.child.paint(ctx, data, env);
     }
 }

--- a/druid/src/widget/disable_if.rs
+++ b/druid/src/widget/disable_if.rs
@@ -17,25 +17,25 @@ use crate::{
     Point, Size, UpdateCtx, Widget, WidgetPod,
 };
 
-/// A widget wrapper which disables the inner widget if the provided closure return true.
+/// A widget wrapper which disables the child widget if the provided closure return true.
 ///
 /// See [`is_disabled`] or [`set_disabled`] for more info about disabled state.
 ///
 /// [`is_disabled`]: crate::EventCtx::is_disabled
 /// [`set_disabled`]: crate::EventCtx::set_disabled
 pub struct DisabledIf<T, W> {
-    inner: WidgetPod<T, W>,
+    child: WidgetPod<T, W>,
     disabled_if: Box<dyn Fn(&T, &Env) -> bool>,
 }
 
 impl<T: Data, W: Widget<T>> DisabledIf<T, W> {
-    /// Creates a new `DisabledIf` widget with the inner widget and the closure to decide if the
+    /// Creates a new `DisabledIf` widget with the child widget and the closure to decide if the
     /// widget should be [`disabled`].
     ///
     /// [`disabled`]: crate::EventCtx::is_disabled
     pub fn new(widget: W, disabled_if: impl Fn(&T, &Env) -> bool + 'static) -> Self {
         DisabledIf {
-            inner: WidgetPod::new(widget),
+            child: WidgetPod::new(widget),
             disabled_if: Box::new(disabled_if),
         }
     }
@@ -43,29 +43,29 @@ impl<T: Data, W: Widget<T>> DisabledIf<T, W> {
 
 impl<T: Data, W: Widget<T>> Widget<T> for DisabledIf<T, W> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
-        self.inner.event(ctx, event, data, env);
+        self.child.event(ctx, event, data, env);
     }
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         if let LifeCycle::WidgetAdded = event {
             ctx.set_disabled((self.disabled_if)(data, env));
         }
-        self.inner.lifecycle(ctx, event, data, env);
+        self.child.lifecycle(ctx, event, data, env);
     }
 
     fn update(&mut self, ctx: &mut UpdateCtx, _: &T, data: &T, env: &Env) {
         ctx.set_disabled((self.disabled_if)(data, env));
-        self.inner.update(ctx, data, env);
+        self.child.update(ctx, data, env);
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
-        let size = self.inner.layout(ctx, bc, data, env);
-        self.inner.set_origin(ctx, data, env, Point::ZERO);
-        ctx.set_baseline_offset(self.inner.baseline_offset());
+        let size = self.child.layout(ctx, bc, data, env);
+        self.child.set_origin(ctx, data, env, Point::ZERO);
+        ctx.set_baseline_offset(self.child.baseline_offset());
         size
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
-        self.inner.paint(ctx, data, env);
+        self.child.paint(ctx, data, env);
     }
 }

--- a/druid/src/widget/identity_wrapper.rs
+++ b/druid/src/widget/identity_wrapper.rs
@@ -23,13 +23,13 @@ use tracing::instrument;
 /// A wrapper that adds an identity to an otherwise anonymous widget.
 pub struct IdentityWrapper<W> {
     id: WidgetId,
-    inner: W,
+    child: W,
 }
 
 impl<W> IdentityWrapper<W> {
     /// Assign an identity to a widget.
-    pub fn wrap(inner: W, id: WidgetId) -> IdentityWrapper<W> {
-        IdentityWrapper { id, inner }
+    pub fn wrap(child: W, id: WidgetId) -> IdentityWrapper<W> {
+        IdentityWrapper { id, child }
     }
 }
 
@@ -40,7 +40,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for IdentityWrapper<W> {
         skip(self, ctx, event, data, env)
     )]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
-        self.inner.event(ctx, event, data, env);
+        self.child.event(ctx, event, data, env);
     }
 
     #[instrument(
@@ -49,7 +49,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for IdentityWrapper<W> {
         skip(self, ctx, event, data, env)
     )]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
-        self.inner.lifecycle(ctx, event, data, env)
+        self.child.lifecycle(ctx, event, data, env)
     }
 
     #[instrument(
@@ -58,7 +58,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for IdentityWrapper<W> {
         skip(self, ctx, old_data, data, env)
     )]
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
-        self.inner.update(ctx, old_data, data, env);
+        self.child.update(ctx, old_data, data, env);
     }
 
     #[instrument(
@@ -67,12 +67,12 @@ impl<T: Data, W: Widget<T>> Widget<T> for IdentityWrapper<W> {
         skip(self, ctx, bc, data, env)
     )]
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
-        self.inner.layout(ctx, bc, data, env)
+        self.child.layout(ctx, bc, data, env)
     }
 
     #[instrument(name = "IdentityWrapper", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
-        self.inner.paint(ctx, data, env);
+        self.child.paint(ctx, data, env);
     }
 
     fn id(&self) -> Option<WidgetId> {
@@ -81,5 +81,5 @@ impl<T: Data, W: Widget<T>> Widget<T> for IdentityWrapper<W> {
 }
 
 impl<W> WidgetWrapper for IdentityWrapper<W> {
-    widget_wrapper_body!(W, inner);
+    widget_wrapper_body!(W, child);
 }

--- a/druid/src/widget/invalidation.rs
+++ b/druid/src/widget/invalidation.rs
@@ -19,16 +19,16 @@ use tracing::instrument;
 /// A widget that draws semi-transparent rectangles of changing colors to help debug invalidation
 /// regions.
 pub struct DebugInvalidation<T, W> {
-    inner: W,
+    child: W,
     debug_color: u64,
     marker: std::marker::PhantomData<T>,
 }
 
 impl<T: Data, W: Widget<T>> DebugInvalidation<T, W> {
     /// Wraps a widget in a `DebugInvalidation`.
-    pub fn new(inner: W) -> Self {
+    pub fn new(child: W) -> Self {
         Self {
-            inner,
+            child,
             debug_color: 0,
             marker: std::marker::PhantomData,
         }
@@ -42,7 +42,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for DebugInvalidation<T, W> {
         skip(self, ctx, event, data, env)
     )]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
-        self.inner.event(ctx, event, data, env);
+        self.child.event(ctx, event, data, env);
     }
 
     #[instrument(
@@ -51,7 +51,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for DebugInvalidation<T, W> {
         skip(self, ctx, event, data, env)
     )]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
-        self.inner.lifecycle(ctx, event, data, env)
+        self.child.lifecycle(ctx, event, data, env)
     }
 
     #[instrument(
@@ -60,7 +60,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for DebugInvalidation<T, W> {
         skip(self, ctx, old_data, data, env)
     )]
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
-        self.inner.update(ctx, old_data, data, env);
+        self.child.update(ctx, old_data, data, env);
     }
 
     #[instrument(
@@ -69,7 +69,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for DebugInvalidation<T, W> {
         skip(self, ctx, bc, data, env)
     )]
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
-        self.inner.layout(ctx, bc, data, env)
+        self.child.layout(ctx, bc, data, env)
     }
 
     #[instrument(
@@ -78,7 +78,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for DebugInvalidation<T, W> {
         skip(self, ctx, data, env)
     )]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
-        self.inner.paint(ctx, data, env);
+        self.child.paint(ctx, data, env);
 
         let color = env.get_debug_color(self.debug_color);
         let stroke_width = 2.0;
@@ -91,6 +91,6 @@ impl<T: Data, W: Widget<T>> Widget<T> for DebugInvalidation<T, W> {
     }
 
     fn id(&self) -> Option<WidgetId> {
-        self.inner.id()
+        self.child.id()
     }
 }

--- a/druid/src/widget/lens_wrap.rs
+++ b/druid/src/widget/lens_wrap.rs
@@ -47,7 +47,7 @@ use tracing::{instrument, trace};
 ///
 /// [`Lens`]: trait.Lens.html
 pub struct LensWrap<T, U, L, W> {
-    inner: W,
+    child: W,
     lens: L,
     // The following is a workaround for otherwise getting E0207.
     // the 'in' data type of the lens
@@ -59,11 +59,11 @@ pub struct LensWrap<T, U, L, W> {
 impl<T, U, L, W> LensWrap<T, U, L, W> {
     /// Wrap a widget with a lens.
     ///
-    /// When the lens has type `Lens<T, U>`, the inner widget has data
+    /// When the lens has type `Lens<T, U>`, the child widget has data
     /// of type `U`, and the wrapped widget has data of type `T`.
-    pub fn new(inner: W, lens: L) -> LensWrap<T, U, L, W> {
+    pub fn new(child: W, lens: L) -> LensWrap<T, U, L, W> {
         LensWrap {
-            inner,
+            child,
             lens,
             phantom_u: Default::default(),
             phantom_t: Default::default(),
@@ -90,16 +90,16 @@ where
 {
     #[instrument(name = "LensWrap", level = "trace", skip(self, ctx, event, data, env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
-        let inner = &mut self.inner;
+        let child = &mut self.child;
         self.lens
-            .with_mut(data, |data| inner.event(ctx, event, data, env))
+            .with_mut(data, |data| child.event(ctx, event, data, env))
     }
 
     #[instrument(name = "LensWrap", level = "trace", skip(self, ctx, event, data, env))]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
-        let inner = &mut self.inner;
+        let child = &mut self.child;
         self.lens
-            .with(data, |data| inner.lifecycle(ctx, event, data, env))
+            .with(data, |data| child.lifecycle(ctx, event, data, env))
     }
 
     #[instrument(
@@ -108,12 +108,12 @@ where
         skip(self, ctx, old_data, data, env)
     )]
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
-        let inner = &mut self.inner;
+        let child = &mut self.child;
         let lens = &self.lens;
         lens.with(old_data, |old_data| {
             lens.with(data, |data| {
                 if ctx.has_requested_update() || !old_data.same(data) || ctx.env_changed() {
-                    inner.update(ctx, old_data, data, env);
+                    child.update(ctx, old_data, data, env);
                 } else {
                     trace!("skipping child update");
                 }
@@ -123,22 +123,22 @@ where
 
     #[instrument(name = "LensWrap", level = "trace", skip(self, ctx, bc, data, env))]
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
-        let inner = &mut self.inner;
+        let child = &mut self.child;
         self.lens
-            .with(data, |data| inner.layout(ctx, bc, data, env))
+            .with(data, |data| child.layout(ctx, bc, data, env))
     }
 
     #[instrument(name = "LensWrap", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
-        let inner = &mut self.inner;
-        self.lens.with(data, |data| inner.paint(ctx, data, env));
+        let child = &mut self.child;
+        self.lens.with(data, |data| child.paint(ctx, data, env));
     }
 
     fn id(&self) -> Option<WidgetId> {
-        self.inner.id()
+        self.child.id()
     }
 }
 
 impl<T, U, L, W> WidgetWrapper for LensWrap<T, U, L, W> {
-    widget_wrapper_body!(W, inner);
+    widget_wrapper_body!(W, child);
 }

--- a/druid/src/widget/sized_box.rs
+++ b/druid/src/widget/sized_box.rs
@@ -30,16 +30,16 @@ use crate::Data;
 /// and width as possible given the parent's constraints. If height or width is not set,
 /// it will be treated as zero.
 pub struct SizedBox<T> {
-    inner: Option<Box<dyn Widget<T>>>,
+    child: Option<Box<dyn Widget<T>>>,
     width: Option<f64>,
     height: Option<f64>,
 }
 
 impl<T> SizedBox<T> {
     /// Construct container with child, and both width and height not set.
-    pub fn new(inner: impl Widget<T> + 'static) -> Self {
+    pub fn new(child: impl Widget<T> + 'static) -> Self {
         Self {
-            inner: Some(Box::new(inner)),
+            child: Some(Box::new(child)),
             width: None,
             height: None,
         }
@@ -53,7 +53,7 @@ impl<T> SizedBox<T> {
     #[doc(alias = "null")]
     pub fn empty() -> Self {
         Self {
-            inner: None,
+            child: None,
             width: None,
             height: None,
         }
@@ -135,15 +135,15 @@ impl<T> SizedBox<T> {
 impl<T: Data> Widget<T> for SizedBox<T> {
     #[instrument(name = "SizedBox", level = "trace", skip(self, ctx, event, data, env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
-        if let Some(ref mut inner) = self.inner {
-            inner.event(ctx, event, data, env);
+        if let Some(ref mut child) = self.child {
+            child.event(ctx, event, data, env);
         }
     }
 
     #[instrument(name = "SizedBox", level = "trace", skip(self, ctx, event, data, env))]
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
-        if let Some(ref mut inner) = self.inner {
-            inner.lifecycle(ctx, event, data, env)
+        if let Some(ref mut child) = self.child {
+            child.lifecycle(ctx, event, data, env)
         }
     }
 
@@ -153,8 +153,8 @@ impl<T: Data> Widget<T> for SizedBox<T> {
         skip(self, ctx, old_data, data, env)
     )]
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
-        if let Some(ref mut inner) = self.inner {
-            inner.update(ctx, old_data, data, env);
+        if let Some(ref mut child) = self.child {
+            child.update(ctx, old_data, data, env);
         }
     }
 
@@ -163,8 +163,8 @@ impl<T: Data> Widget<T> for SizedBox<T> {
         bc.debug_check("SizedBox");
 
         let child_bc = self.child_constraints(bc);
-        let size = match self.inner.as_mut() {
-            Some(inner) => inner.layout(ctx, &child_bc, data, env),
+        let size = match self.child.as_mut() {
+            Some(child) => child.layout(ctx, &child_bc, data, env),
             None => bc.constrain((self.width.unwrap_or(0.0), self.height.unwrap_or(0.0))),
         };
 
@@ -182,13 +182,13 @@ impl<T: Data> Widget<T> for SizedBox<T> {
 
     #[instrument(name = "SizedBox", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
-        if let Some(ref mut inner) = self.inner {
-            inner.paint(ctx, data, env);
+        if let Some(ref mut child) = self.child {
+            child.paint(ctx, data, env);
         }
     }
 
     fn id(&self) -> Option<WidgetId> {
-        self.inner.as_ref().and_then(|inner| inner.id())
+        self.child.as_ref().and_then(|child| child.id())
     }
 }
 

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -71,7 +71,7 @@ pub(crate) struct AppHandler<T> {
 /// State shared by all windows in the UI.
 #[derive(Clone)]
 pub(crate) struct AppState<T> {
-    inner: Rc<RefCell<Inner<T>>>,
+    inner: Rc<RefCell<InnerAppState<T>>>,
 }
 
 /// The information for forwarding druid-shell's file dialog reply to the right place.
@@ -84,7 +84,7 @@ struct DialogInfo {
     cancel_cmd: Selector<()>,
 }
 
-struct Inner<T> {
+struct InnerAppState<T> {
     app: Application,
     delegate: Option<Box<dyn AppDelegate<T>>>,
     command_queue: CommandQueue,
@@ -158,7 +158,7 @@ impl<T> AppState<T> {
         delegate: Option<Box<dyn AppDelegate<T>>>,
         ext_event_host: ExtEventHost,
     ) -> Self {
-        let inner = Rc::new(RefCell::new(Inner {
+        let inner = Rc::new(RefCell::new(InnerAppState {
             app,
             delegate,
             command_queue: VecDeque::new(),
@@ -180,7 +180,7 @@ impl<T> AppState<T> {
     }
 }
 
-impl<T: Data> Inner<T> {
+impl<T: Data> InnerAppState<T> {
     fn handle_menu_cmd(&mut self, cmd_id: MenuItemId, window_id: Option<WindowId>) {
         let queue = &mut self.command_queue;
         let data = &mut self.data;
@@ -208,7 +208,7 @@ impl<T: Data> Inner<T> {
     where
         F: FnOnce(&mut dyn AppDelegate<T>, &mut T, &Env, &mut DelegateCtx) -> R,
     {
-        let Inner {
+        let InnerAppState {
             ref mut delegate,
             ref mut command_queue,
             ref mut data,


### PR DESCRIPTION
In most cases, rename `inner` to `child` for consistency with existing 
code.
Rename `Inner` to `InnerAppState`.

Fixes #269 