### PR TITLE
Windows subsystem

### DIFF
--- a/druid/examples/anim.rs
+++ b/druid/examples/anim.rs
@@ -21,6 +21,9 @@
 //! rest of the app. If this is something the rest of your widgets should know
 //! about, you could put it in the `data`.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use std::f64::consts::PI;
 
 use druid::kurbo::{Circle, Line};

--- a/druid/examples/async_event.rs
+++ b/druid/examples/async_event.rs
@@ -18,6 +18,9 @@
 //! takes a long time but don't want to block the main thread
 //! (waiting on an http request, some cpu intensive work etc.)
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use instant::Instant;
 use std::thread;
 use std::time::Duration;

--- a/druid/examples/blocking_function.rs
+++ b/druid/examples/blocking_function.rs
@@ -16,6 +16,9 @@
 //! the other thread some data and then we also pass some data back
 //! to the main thread using commands.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use std::{thread, time};
 
 use druid::widget::prelude::*;

--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -14,6 +14,9 @@
 
 //! Simple calculator.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::{
     theme, AppLauncher, Color, Data, Lens, LocalizedString, RenderContext, Widget, WidgetExt,
     WindowDesc,

--- a/druid/examples/cursor.rs
+++ b/druid/examples/cursor.rs
@@ -19,6 +19,9 @@
 //! open so we have to work around that. When we receive the
 //! `WindowConnected` command we initiate the cursor.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::{
     AppLauncher, Color, Cursor, CursorDesc, Data, Env, ImageBuf, Lens, LocalizedString, WidgetExt,
     WindowDesc,

--- a/druid/examples/custom_widget.rs
+++ b/druid/examples/custom_widget.rs
@@ -15,6 +15,9 @@
 //! An example of a custom drawing widget.
 //! We draw an image, some text, a shape, and a curve.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::kurbo::BezPath;
 use druid::piet::{FontFamily, ImageFormat, InterpolationMode, Text, TextLayoutBuilder};
 use druid::widget::prelude::*;

--- a/druid/examples/disabled.rs
+++ b/druid/examples/disabled.rs
@@ -17,6 +17,9 @@
 //! respond. Pressing Tab should only focus widgets not marked as disabled. If a widget
 //! is focused while getting disabled it should resign the focus.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::widget::{
     Button, Checkbox, CrossAxisAlignment, Flex, Label, Slider, Stepper, Switch, TextBox,
 };

--- a/druid/examples/either.rs
+++ b/druid/examples/either.rs
@@ -16,6 +16,9 @@
 //! This is a very simple example, it uses a bool to determine
 //! which widget gets shown.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::widget::prelude::*;
 use druid::widget::{Checkbox, Either, Flex, Label, Slider};
 use druid::{AppLauncher, Data, Lens, WidgetExt, WindowDesc};

--- a/druid/examples/event_viewer.rs
+++ b/druid/examples/event_viewer.rs
@@ -15,6 +15,9 @@
 //! An application that accepts keyboard and mouse input, and displays
 //! information about received events.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::widget::prelude::*;
 use druid::widget::{Controller, CrossAxisAlignment, Flex, Label, List, Scroll, SizedBox, TextBox};
 use druid::{

--- a/druid/examples/flex.rs
+++ b/druid/examples/flex.rs
@@ -17,6 +17,9 @@
 //! knobs to change all the parameters. 99% of the time you will want to
 //! hard-code these parameters, which will simplify your code considerably.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::text::ParseFormatter;
 use druid::widget::prelude::*;
 use druid::widget::{

--- a/druid/examples/game_of_life.rs
+++ b/druid/examples/game_of_life.rs
@@ -15,6 +15,9 @@
 //! This is an example of how you would implement the game of life with druid.
 //! This example doesnt showcase anything specific in druid.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use std::ops::{Index, IndexMut};
 use std::time::{Duration, Instant};
 

--- a/druid/examples/hello.rs
+++ b/druid/examples/hello.rs
@@ -15,6 +15,9 @@
 //! This is a very small example of how to setup a druid application.
 //! It does the almost bare minimum while still being useful.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::widget::prelude::*;
 use druid::widget::{Flex, Label, TextBox};
 use druid::{AppLauncher, Data, Lens, UnitPoint, WidgetExt, WindowDesc};

--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -27,6 +27,9 @@
 //! other circumstances where widgets may need to communicate with specific
 //! other widgets, and identity is a useful mechanism in those cases.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::widget::prelude::*;
 use druid::widget::{Button, Controller, Flex, Label, WidgetId};
 use druid::{AppLauncher, Data, Lens, Selector, WidgetExt, WindowDesc};

--- a/druid/examples/image.rs
+++ b/druid/examples/image.rs
@@ -16,6 +16,9 @@
 //! propperties. You can change the parameters in the GUI to see how
 //! everything behaves.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::piet::InterpolationMode;
 use druid::text::ParseFormatter;
 use druid::widget::{prelude::*, FillStrat, Image};

--- a/druid/examples/invalidation.rs
+++ b/druid/examples/invalidation.rs
@@ -15,6 +15,9 @@
 //! Demonstrates how to debug invalidation regions, and also shows the
 //! invalidation behavior of several build-in widgets.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::im::Vector;
 use druid::kurbo::{self, Shape};
 use druid::widget::prelude::*;

--- a/druid/examples/layout.rs
+++ b/druid/examples/layout.rs
@@ -15,6 +15,9 @@
 //! This example shows how to construct a basic layout,
 //! using columns, rows, and loops, for repeated Widgets.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::widget::{AspectRatioBox, Button, Flex, Label, LineBreaking};
 use druid::{AppLauncher, Color, Widget, WidgetExt, WindowDesc};
 

--- a/druid/examples/lens.rs
+++ b/druid/examples/lens.rs
@@ -14,6 +14,9 @@
 
 //! This example shows basic usage of Lens
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::widget::Slider;
 use druid::widget::{CrossAxisAlignment, Flex, Label, TextBox};
 use druid::{AppLauncher, Data, Env, Lens, LocalizedString, Widget, WidgetExt, WindowDesc};

--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -14,6 +14,9 @@
 
 //! Demos basic list widget and list manipulations.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::im::{vector, Vector};
 use druid::lens::{self, LensExt};
 use druid::widget::{Button, CrossAxisAlignment, Flex, Label, List, Scroll};

--- a/druid/examples/markdown_preview.rs
+++ b/druid/examples/markdown_preview.rs
@@ -14,6 +14,9 @@
 
 //! An example of live markdown preview
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use pulldown_cmark::{Event as ParseEvent, Parser, Tag};
 
 use druid::text::{AttributesAdder, RichText, RichTextBuilder};
@@ -34,7 +37,7 @@ const TEXT: &str = "*Hello* ***world***! This is a `TextBox` where you can \
 		    If you're curious about Druid, a good place to ask questions \
 		    and discuss development work is our [Zulip chat instance], \
 		    in the #druid-help and #druid channels, respectively.\n\n\n\
-		    
+
 		    [Zulip chat instance]: https://xi.zulipchat.com";
 
 const SPACER_SIZE: f64 = 8.0;

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -14,6 +14,9 @@
 
 //! Opening and closing windows and using window and context menus.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::widget::prelude::*;
 use druid::widget::{
     Align, BackgroundBrush, Button, Controller, ControllerHost, Flex, Label, Padding,

--- a/druid/examples/open_save.rs
+++ b/druid/examples/open_save.rs
@@ -14,6 +14,9 @@
 
 //! Usage of file open and saving.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::widget::{Align, Button, Flex, TextBox};
 use druid::{
     commands, AppDelegate, AppLauncher, Command, DelegateCtx, Env, FileDialogOptions, FileSpec,

--- a/druid/examples/panels.rs
+++ b/druid/examples/panels.rs
@@ -14,6 +14,9 @@
 
 //! This example shows how to construct a basic layout.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::kurbo::Circle;
 use druid::widget::{Flex, Label, Painter};
 use druid::{

--- a/druid/examples/scroll.rs
+++ b/druid/examples/scroll.rs
@@ -15,6 +15,9 @@
 //! Shows a scroll widget, and also demonstrates how widgets that paint
 //! outside their bounds can specify their paint region.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::kurbo::Circle;
 use druid::piet::RadialGradient;
 use druid::widget::prelude::*;

--- a/druid/examples/scroll_colors.rs
+++ b/druid/examples/scroll_colors.rs
@@ -14,6 +14,9 @@
 
 //! This example allows to play with scroll bars over different color tones.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::widget::{Container, Flex, Scroll, SizedBox};
 use druid::{AppLauncher, Color, LocalizedString, Widget, WindowDesc};
 

--- a/druid/examples/split_demo.rs
+++ b/druid/examples/split_demo.rs
@@ -14,6 +14,9 @@
 
 //! This example demonstrates the `Split` widget
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::piet::Color;
 use druid::widget::{Align, Container, Label, Padding, Split};
 use druid::{AppLauncher, LocalizedString, Widget, WindowDesc};

--- a/druid/examples/styled_text.rs
+++ b/druid/examples/styled_text.rs
@@ -14,6 +14,9 @@
 
 //! Example of dynamic text styling
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::widget::{
     Checkbox, CrossAxisAlignment, Flex, Label, LensWrap, MainAxisAlignment, Painter, Parse, Scroll,
     Stepper, TextBox,

--- a/druid/examples/sub_window.rs
+++ b/druid/examples/sub_window.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::commands::CLOSE_WINDOW;
 use druid::lens::Unit;
 use druid::widget::{

--- a/druid/examples/svg.rs
+++ b/druid/examples/svg.rs
@@ -14,6 +14,9 @@
 
 //! This example shows how to draw an SVG.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use tracing::error;
 
 use druid::{

--- a/druid/examples/switches.rs
+++ b/druid/examples/switches.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::widget::{
     Checkbox, Flex, Label, LensWrap, MainAxisAlignment, Padding, Parse, Stepper, Switch, TextBox,
     WidgetExt,

--- a/druid/examples/tabs.rs
+++ b/druid/examples/tabs.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::im::Vector;
 use druid::widget::{
     Axis, Button, CrossAxisAlignment, Flex, Label, MainAxisAlignment, RadioGroup, Split, TabInfo,

--- a/druid/examples/text.rs
+++ b/druid/examples/text.rs
@@ -14,6 +14,9 @@
 
 //! An example of various text layout features.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::piet::{PietTextLayoutBuilder, TextStorage as PietTextStorage};
 use druid::text::{Attribute, RichText, TextStorage};
 use druid::widget::prelude::*;

--- a/druid/examples/textbox.rs
+++ b/druid/examples/textbox.rs
@@ -17,6 +17,9 @@
 //! I would like to make this a bit fancier (like the flex demo) but for now
 //! lets keep it simple.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use std::sync::Arc;
 
 use druid::widget::{Flex, Label, TextBox};

--- a/druid/examples/timer.rs
+++ b/druid/examples/timer.rs
@@ -14,6 +14,9 @@
 
 //! An example of a timer.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use std::time::Duration;
 
 use druid::widget::prelude::*;

--- a/druid/examples/transparency.rs
+++ b/druid/examples/transparency.rs
@@ -15,6 +15,9 @@
 //! An example of a transparent window background.
 //! Useful for dropdowns, tooltips and other overlay windows.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::kurbo::Circle;
 use druid::widget::prelude::*;
 use druid::widget::{Flex, Label, Painter, TextBox, WidgetExt};

--- a/druid/examples/value_formatting/src/main.rs
+++ b/druid/examples/value_formatting/src/main.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 mod formatters;
 mod widgets;
 

--- a/druid/examples/view_switcher.rs
+++ b/druid/examples/view_switcher.rs
@@ -14,6 +14,9 @@
 
 //! This example demonstrates the `ViewSwitcher` widget
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::widget::{Button, Flex, Label, Split, TextBox, ViewSwitcher};
 use druid::{AppLauncher, Data, Env, Lens, LocalizedString, Widget, WidgetExt, WindowDesc};
 

--- a/druid/examples/widget_gallery.rs
+++ b/druid/examples/widget_gallery.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
 use druid::{
     im,
     kurbo::{Affine, BezPath, Circle, Point},

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -106,6 +106,12 @@
 //! features = ["im", "svg", "image"]
 //! ```
 //!
+//! # Note for Windows apps
+//!
+//! By default, Windows will open a console with your application's window. If you don't want
+//! the console to be shown, use `#![windows_subsystem = "windows"]` at the beginning of your
+//! crate.
+//!
 //! [`Widget`]: trait.Widget.html
 //! [`Data`]: trait.Data.html
 //! [`Lens`]: trait.Lens.html


### PR DESCRIPTION
Add `windows_subsystem` attribute to examples.
Add a note for windows apps at the beginning of the doc.

Fixes #1568 