### PR TITLE
[druid-derive] do not enable x11 feature in dev dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,11 +165,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # libx11-dev is needed by druid-derive as dev dependency
-      - name: install libx11-dev
+      # libgtk-dev seems to be needed by e.g. druid-derive
+      - name: install libgtk-dev
         run: |
           sudo apt update
-          sudo apt install libx11-dev libpango1.0-dev libxkbcommon-dev libxkbcommon-x11-dev
+          sudo apt install libgtk-3-dev
         if: contains(matrix.os, 'ubuntu')
 
       - name: install wasm-pack

--- a/druid-derive/Cargo.toml
+++ b/druid-derive/Cargo.toml
@@ -20,6 +20,6 @@ quote = "1.0.7"
 proc-macro2 = "1.0.19"
 
 [dev-dependencies]
-druid = { version = "0.7.0", path = "../druid", default-features = false, features = ["x11"] }
+druid = { version = "0.7.0", path = "../druid" }
 
 float-cmp = { version = "0.8.0", features = ["std"], default-features = false }


### PR DESCRIPTION
enabling x11 makes x11 the default backend when running examples from
workspace root.

Thanks @PoignardAzur for the [suggestion](https://xi.zulipchat.com/#narrow/stream/147926-druid/topic/druid-shell.20backend.20selection/near/248476760)