### PR TITLE
Make TextBox placeholder translatable

### DIFF
--- a/druid/examples/textbox.rs
+++ b/druid/examples/textbox.rs
@@ -34,7 +34,7 @@ const EXPLAINER: &str = "\
     This example demonstrates some of the possible configurations \
     of the TextBox widget.\n\
     The top textbox allows a single line of input, with horizontal scrolling \
-    but no scrollbars. The bottom textbox allows mutliple lines of text, wrapping \
+    but no scrollbars. The bottom textbox allows multiple lines of text, wrapping \
     words to fit the width, and allowing vertical scrolling when it runs out \
     of room to grow vertically.";
 


### PR DESCRIPTION
This makes the `TextBox` placeholder a `LabelText` which can be initialized with a `LocalizedString` and thus translated.

The problem that I have is that the `TextBox` seems to be bound to a very specific editable text via `lens`, and that couples the `LabelText` to the same Data, which means I currently can’t use anything else from my main Data as placeholders of the `LocalizedString` (or `Dynamic` for that matter).