### PR TITLE
example/image: Lens properly

### DIFF
--- a/druid/examples/image.rs
+++ b/druid/examples/image.rs
@@ -25,7 +25,7 @@ use druid::widget::{prelude::*, FillStrat, Image};
 use druid::widget::{
     Checkbox, CrossAxisAlignment, Flex, Label, RadioGroup, SizedBox, TextBox, WidgetExt,
 };
-use druid::{AppLauncher, Color, Data, ImageBuf, Lens, LensExt, WindowDesc};
+use druid::{AppLauncher, Color, Data, ImageBuf, Lens, WindowDesc};
 
 static FILL_STRAT_OPTIONS: &[(&str, FillStrat)] = &[
     ("Contain", FillStrat::Contain),
@@ -160,7 +160,7 @@ fn make_width() -> impl Widget<AppState> {
             Flex::row().with_child(
                 TextBox::new()
                     .with_formatter(ParseFormatter::new())
-                    .lens(AppState::width.map(|x| *x, |x, y| *x = y))
+                    .lens(AppState::width)
                     .fix_width(60.0),
             ),
         )
@@ -174,7 +174,7 @@ fn make_height() -> impl Widget<AppState> {
             Flex::row().with_child(
                 TextBox::new()
                     .with_formatter(ParseFormatter::new())
-                    .lens(AppState::width.map(|x| *x, |x, y| *x = y))
+                    .lens(AppState::height)
                     .fix_width(60.0),
             ),
         )


### PR DESCRIPTION
I am not sure why no-op map is here and make_height was using AppState::width

Fixes #1909 . But there is bigger problem:

https://github.com/linebender/druid/blob/049747a5fd9dd26cd82a1e01f932b40759b31ef6/druid/src/widget/value_textbox.rs#L373-L381