### PR TITLE
x11: drop the Application state borrow before running timers

### DIFF
--- a/druid-shell/src/backend/x11/application.rs
+++ b/druid-shell/src/backend/x11/application.rs
@@ -706,7 +706,9 @@ impl Application {
             if let Some(timeout) = next_timeout {
                 if timeout <= now {
                     if let Ok(state) = self.state.try_borrow() {
-                        for w in state.windows.values() {
+                        let values = state.windows.values().cloned().collect::<Vec<_>>();
+                        drop(state);
+                        for w in values {
                             w.run_timers(now);
                         }
                     } else {


### PR DESCRIPTION
Fixes tooltip in sub_window example