### PR TITLE
Add child() methods to widgets implementing WidgetWrapper.

### DIFF
--- a/druid/src/widget/controller.rs
+++ b/druid/src/widget/controller.rs
@@ -105,6 +105,16 @@ impl<W, C> ControllerHost<W, C> {
     pub fn new(widget: W, controller: C) -> ControllerHost<W, C> {
         ControllerHost { widget, controller }
     }
+
+    /// Returns a reference to the child widget.
+    pub fn child(&self) -> &W {
+        &self.widget
+    }
+
+    /// Returns a mutable reference to the child widget.
+    pub fn child_mut(&mut self) -> &mut W {
+        &mut self.widget
+    }
 }
 
 impl<T, W: Widget<T>, C: Controller<T, W>> Widget<T> for ControllerHost<W, C> {

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -56,6 +56,16 @@ impl<T, W: Widget<T>> EnvScope<T, W> {
             child: WidgetPod::new(child),
         }
     }
+
+    /// Returns a reference to the child widget.
+    pub fn child(&self) -> &W {
+        self.child.widget()
+    }
+
+    /// Returns a mutable reference to the child widget.
+    pub fn child_mut(&mut self) -> &mut W {
+        self.child.widget_mut()
+    }
 }
 
 impl<T: Data, W: Widget<T>> Widget<T> for EnvScope<T, W> {

--- a/druid/src/widget/identity_wrapper.rs
+++ b/druid/src/widget/identity_wrapper.rs
@@ -32,6 +32,16 @@ impl<W> IdentityWrapper<W> {
     pub fn wrap(child: W, id: WidgetId) -> IdentityWrapper<W> {
         IdentityWrapper { id, child }
     }
+
+    /// Returns a reference to the child widget.
+    pub fn child(&self) -> &W {
+        &self.child
+    }
+
+    /// Returns a mutable reference to the child widget.
+    pub fn child_mut(&mut self) -> &mut W {
+        &mut self.child
+    }
 }
 
 impl<T: Data, W: Widget<T>> Widget<T> for IdentityWrapper<W> {

--- a/druid/src/widget/lens_wrap.rs
+++ b/druid/src/widget/lens_wrap.rs
@@ -80,6 +80,16 @@ impl<T, U, L, W> LensWrap<T, U, L, W> {
     pub fn lens_mut(&mut self) -> &mut L {
         &mut self.lens
     }
+
+    /// Returns a reference to the child widget.
+    pub fn child(&self) -> &W {
+        &self.child
+    }
+
+    /// Returns a mutable reference to the child widget.
+    pub fn child_mut(&mut self) -> &mut W {
+        &mut self.child
+    }
 }
 
 impl<T, U, L, W> Widget<T> for LensWrap<T, U, L, W>

--- a/druid/src/widget/padding.rs
+++ b/druid/src/widget/padding.rs
@@ -65,6 +65,16 @@ impl<T, W: Widget<T>> Padding<T, W> {
             child: WidgetPod::new(child),
         }
     }
+
+    /// Returns a reference to the child widget.
+    pub fn child(&self) -> &W {
+        self.child.widget()
+    }
+
+    /// Returns a mutable reference to the child widget.
+    pub fn child_mut(&mut self) -> &mut W {
+        self.child.widget_mut()
+    }
 }
 
 impl<T, W> WidgetWrapper for Padding<T, W> {


### PR DESCRIPTION
Having child() as an inherent method is more discoverable than simply 
implementing the WidgetWrapper trait.