### PR TITLE
x11: invalidate_rect expand the rect properly

### DIFF
--- a/druid-shell/src/backend/x11/window.rs
+++ b/druid-shell/src/backend/x11/window.rs
@@ -909,8 +909,8 @@ impl Window {
     }
 
     fn add_invalid_rect(&self, rect: Rect) -> Result<(), Error> {
-        // expanding not needed here, because we are expanding at every use of invalid
-        borrow_mut!(self.invalid)?.add_rect(rect);
+        let scale = self.scale.get();
+        borrow_mut!(self.invalid)?.add_rect(rect.to_px(scale).expand().to_dp(scale));
         Ok(())
     }
 

--- a/druid-shell/src/backend/x11/window.rs
+++ b/druid-shell/src/backend/x11/window.rs
@@ -768,7 +768,7 @@ impl Window {
             let cairo_ctx = cairo::Context::new(&surface).unwrap();
             let scale = self.scale.get();
             for rect in invalid.rects() {
-                let rect = rect.to_px(scale);
+                let rect = rect.to_px(scale).round();
                 cairo_ctx.rectangle(rect.x0, rect.y0, rect.width(), rect.height());
             }
             cairo_ctx.clip();
@@ -818,7 +818,7 @@ impl Window {
             buffers.idle_pixmaps.pop();
         } else {
             for rect in invalid.rects() {
-                let rect = rect.to_px(scale).expand();
+                let rect = rect.to_px(scale).round();
                 let (x, y) = (rect.x0 as i16, rect.y0 as i16);
                 let (w, h) = (rect.width() as u16, rect.height() as u16);
                 self.app
@@ -1386,7 +1386,7 @@ impl PresentData {
             .rects()
             .iter()
             .map(|r| {
-                let r = r.to_px(scale).expand();
+                let r = r.to_px(scale).round();
                 Rectangle {
                     x: r.x0 as i16,
                     y: r.y0 as i16,


### PR DESCRIPTION
the select example in nursery: 
### before
![before](https://user-images.githubusercontent.com/49202620/131440961-5a1fb68c-87ec-4d35-ab22-7aec4f749432.gif)

### after 
![after](https://user-images.githubusercontent.com/49202620/131441009-8e3556d2-7d77-4441-b0b4-6baf271ded02.gif)
