### PR TITLE
Added strikethrough

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,4 @@ Maximilian Köstler
 Bruno Dupuis
 Christopher Noel Hesse
 Marcin Zając
+Laura Gallo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -514,6 +514,7 @@ Last release without a changelog :(
 [@bjorn]: https://github.com/bjorn
 [@DrGabble]: https://github.com/DrGabble
 [@lisael]: https://github.com/lisael
+[@jenra-uwu]: https://github.com/jenra-uwu
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611
@@ -785,6 +786,7 @@ Last release without a changelog :(
 [#1886]: https://github.com/linebender/druid/pull/1886
 [#1907]: https://github.com/linebender/druid/pull/1907
 [#1929]: https://github.com/linebender/druid/pull/1929
+[#1953]: https://github.com/linebender/druid/pull/1953
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You can find its changes [documented below](#070---2021-01-01).
 
 ### Added
 
+- Strikethrough rich text attribute ([#1953] by [@jenra-uwu])
 - System fonts loaded so that SVG images render text ([#1850] by [@DrGabble])
 - Add `scroll()` method in WidgetExt ([#1600] by [@totsteps])
 - `write!` for `RichTextBuilder` ([#1596] by [@Maan2003])

--- a/druid/examples/markdown_preview.rs
+++ b/druid/examples/markdown_preview.rs
@@ -32,7 +32,7 @@ const WINDOW_TITLE: LocalizedString<AppState> = LocalizedString::new("Minimal Ma
 
 const TEXT: &str = "*Hello* ***world***! This is a `TextBox` where you can \
 		    use limited markdown notation, which is reflected in the \
-		    **styling** of the `Label` on the left.\n\n\
+		    **styling** of the `Label` on the left. ~~Strikethrough even works!~~\n\n\
 		    If you're curious about Druid, a good place to ask questions \
 		    and discuss development work is our [Zulip chat instance], \
 		    in the #druid-help and #druid channels, respectively.\n\n\n\

--- a/druid/examples/markdown_preview.rs
+++ b/druid/examples/markdown_preview.rs
@@ -17,7 +17,7 @@
 // On Windows platform, don't show a console when opening the app.
 #![windows_subsystem = "windows"]
 
-use pulldown_cmark::{Event as ParseEvent, Parser, Tag};
+use pulldown_cmark::{Event as ParseEvent, Options, Parser, Tag};
 
 use druid::text::{AttributesAdder, RichText, RichTextBuilder};
 use druid::widget::prelude::*;
@@ -141,7 +141,7 @@ fn rebuild_rendered_text(text: &str) -> RichText {
     let mut builder = RichTextBuilder::new();
     let mut tag_stack = Vec::new();
 
-    let parser = Parser::new(text);
+    let parser = Parser::new_ext(text, Options::ENABLE_STRIKETHROUGH);
     for event in parser {
         match event {
             ParseEvent::Start(tag) => {
@@ -217,6 +217,9 @@ fn add_attribute_for_tag(tag: &Tag, mut attrs: AttributesAdder) {
         }
         Tag::Strong => {
             attrs.weight(FontWeight::BOLD);
+        }
+        Tag::Strikethrough => {
+            attrs.strikethrough(true);
         }
         Tag::Link(_link_ty, target, _title) => {
             attrs

--- a/druid/src/text/attribute.rs
+++ b/druid/src/text/attribute.rs
@@ -182,7 +182,7 @@ impl AttributeSpans {
         items.extend(
             self.strikethrough
                 .iter()
-                .map(|s| (s.range.clone(), PietAttr::Strikethrough(s.attr)))
+                .map(|s| (s.range.clone(), PietAttr::Strikethrough(s.attr))),
         );
 
         // sort by ascending start order; this is a stable sort

--- a/druid/src/text/attribute.rs
+++ b/druid/src/text/attribute.rs
@@ -39,6 +39,7 @@ pub struct AttributeSpans {
     fg_color: SpanSet<KeyOrValue<Color>>,
     style: SpanSet<FontStyle>,
     underline: SpanSet<bool>,
+    strikethrough: SpanSet<bool>,
     font_descriptor: SpanSet<KeyOrValue<FontDescriptor>>,
 }
 
@@ -100,6 +101,8 @@ pub enum Attribute {
     Style(FontStyle),
     /// Underline.
     Underline(bool),
+    /// Strikethrough
+    Strikethrough(bool),
     /// A [`FontDescriptor`](struct.FontDescriptor.html).
     Descriptor(KeyOrValue<FontDescriptor>),
 }
@@ -131,6 +134,7 @@ impl AttributeSpans {
             Attribute::TextColor(attr) => self.fg_color.add(Span::new(range, attr)),
             Attribute::Style(attr) => self.style.add(Span::new(range, attr)),
             Attribute::Underline(attr) => self.underline.add(Span::new(range, attr)),
+            Attribute::Strikethrough(attr) => self.strikethrough.add(Span::new(range, attr)),
             Attribute::Descriptor(attr) => self.font_descriptor.add(Span::new(range, attr)),
         }
     }
@@ -174,6 +178,11 @@ impl AttributeSpans {
             self.underline
                 .iter()
                 .map(|s| (s.range.clone(), PietAttr::Underline(s.attr))),
+        );
+        items.extend(
+            self.strikethrough
+                .iter()
+                .map(|s| (s.range.clone(), PietAttr::Strikethrough(s.attr)))
         );
 
         // sort by ascending start order; this is a stable sort
@@ -254,7 +263,7 @@ impl<T: Clone> SpanSet<T> {
     ///
     /// `new_len` is the length of the inserted text.
     //TODO: we could be smarter here about just extending the existing spans
-    //as requred for insertions in the interior of a span.
+    //as required for insertions in the interior of a span.
     //TODO: this isn't currently used; it should be used if we use spans with
     //some editable type.
     // the branches are much more readable without sharing code
@@ -322,7 +331,7 @@ impl Attribute {
         Attribute::FontSize(size.into())
     }
 
-    /// Create a new forground color attribute.
+    /// Create a new foreground color attribute.
     pub fn text_color(color: impl Into<KeyOrValue<Color>>) -> Self {
         Attribute::TextColor(color.into())
     }
@@ -345,6 +354,11 @@ impl Attribute {
     /// Create a new underline attribute.
     pub fn underline(underline: bool) -> Self {
         Attribute::Underline(underline)
+    }
+
+    /// Create a new strikethrough attribute.
+    pub fn strikethrough(strikethrough: bool) -> Self {
+        Attribute::Strikethrough(strikethrough)
     }
 
     /// Create a new `FontDescriptor` attribute.

--- a/druid/src/text/rich_text.rs
+++ b/druid/src/text/rich_text.rs
@@ -202,7 +202,7 @@ impl AttributesAdder<'_> {
         self
     }
 
-    /// Add a forground color attribute.
+    /// Add a foreground color attribute.
     pub fn text_color(&mut self, color: impl Into<KeyOrValue<Color>>) -> &mut Self {
         self.add_attr(Attribute::text_color(color));
         self
@@ -229,6 +229,12 @@ impl AttributesAdder<'_> {
     /// Add a underline attribute.
     pub fn underline(&mut self, underline: bool) -> &mut Self {
         self.add_attr(Attribute::underline(underline));
+        self
+    }
+
+    /// Add a strikethrough attribute.
+    pub fn strikethrough(&mut self, strikethrough: bool) -> &mut Self {
+        self.add_attr(Attribute::Strikethrough(strikethrough));
         self
     }
 


### PR DESCRIPTION
This pull request adds strikethrough to druid and updates the markdown example to use `~~this syntax~~` for ~~strikethrough~~.