### PR TITLE
ExtEventSink::add_idle_callback

### DIFF
--- a/druid/examples/async_event.rs
+++ b/druid/examples/async_event.rs
@@ -25,13 +25,8 @@ use instant::Instant;
 use std::thread;
 use std::time::Duration;
 
-use druid::widget::prelude::*;
-use druid::{AppLauncher, Color, Selector, Target, WidgetExt, WindowDesc};
-
-// If you want to submit commands to an event sink you have to give it some kind
-// of ID. The selector is that, it also assures the accompanying data-type is correct.
-// look at the docs for `Selector` for more detail.
-const SET_COLOR: Selector<Color> = Selector::new("event-example.set-color");
+use druid::widget::Painter;
+use druid::{AppLauncher, Color, RenderContext, Widget, WidgetExt, WindowDesc};
 
 pub fn main() {
     let window = WindowDesc::new(make_ui()).title("External Event Demo");
@@ -75,62 +70,22 @@ fn generate_colors(event_sink: druid::ExtEventSink) {
             (_, _) => Color::rgb8(r, g, b.wrapping_add(3)),
         };
 
-        // We send a command to the event_sink. This command will be
-        // send to the widgets, and widgets or controllers can look for this
-        // event. We give it the data associated with the event and a target.
-        // In this case this is just `Target::Auto`, look at the identity example
-        // for more detail on how to send commands to specific widgets.
-        if event_sink
-            .submit_command(SET_COLOR, color.clone(), Target::Auto)
-            .is_err()
-        {
-            break;
-        }
+        let color_clone = color.clone();
+        // schedule idle callback to change the data
+        event_sink.add_idle_callback(move |data: &mut Color| {
+            *data = color_clone;
+        });
         thread::sleep(Duration::from_millis(20));
     }
 }
 
-/// A widget that displays a color.
-struct ColorWell;
-
-impl Widget<Color> for ColorWell {
-    fn event(&mut self, _ctx: &mut EventCtx, event: &Event, data: &mut Color, _env: &Env) {
-        match event {
-            // This is where we handle our command.
-            Event::Command(cmd) if cmd.is(SET_COLOR) => {
-                // We don't do much data processing in the `event` method.
-                // All we really do is just set the data. This causes a call
-                // to `update` which requests a paint. You can also request a paint
-                // during the event, but this should be reserved for changes to self.
-                // For changes to `Data` always make `update` do the paint requesting.
-                *data = cmd.get_unchecked(SET_COLOR).clone();
-            }
-            _ => (),
-        }
-    }
-
-    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &Color, _: &Env) {}
-
-    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &Color, data: &Color, _: &Env) {
-        if old_data != data {
-            ctx.request_paint()
-        }
-    }
-
-    fn layout(&mut self, _: &mut LayoutCtx, bc: &BoxConstraints, _: &Color, _: &Env) -> Size {
-        bc.max()
-    }
-
-    fn paint(&mut self, ctx: &mut PaintCtx, data: &Color, _env: &Env) {
+fn make_ui() -> impl Widget<Color> {
+    Painter::new(|ctx, data, _env| {
         let rect = ctx.size().to_rounded_rect(5.0);
         ctx.fill(rect, data);
-    }
-}
-
-fn make_ui() -> impl Widget<Color> {
-    ColorWell
-        .fix_width(300.0)
-        .fix_height(300.0)
-        .padding(10.0)
-        .center()
+    })
+    .fix_width(300.0)
+    .fix_height(300.0)
+    .padding(10.0)
+    .center()
 }

--- a/druid/src/ext_event.rs
+++ b/druid/src/ext_event.rs
@@ -127,10 +127,12 @@ impl ExtEventSink {
                 let win_handler = win_handler
                     .as_any()
                     .downcast_mut::<DruidHandler<T>>()
-                    .expect(&format!(
-                        "{} is not the type of root data",
-                        std::any::type_name::<T>()
-                    ));
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "{} is not the type of root data",
+                            std::any::type_name::<T>()
+                        )
+                    });
                 win_handler.app_state.handle_idle_callback(cb);
             });
         }

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -53,7 +53,7 @@ pub(crate) const EXT_EVENT_IDLE_TOKEN: IdleToken = IdleToken::new(2);
 /// it publicly.
 pub struct DruidHandler<T> {
     /// The shared app state.
-    app_state: AppState<T>,
+    pub(crate) app_state: AppState<T>,
     /// The id for the current window.
     window_id: WindowId,
 }
@@ -611,6 +611,12 @@ impl<T: Data> AppState<T> {
             }
             other => tracing::warn!("unexpected idle token {:?}", other),
         }
+    }
+
+    pub(crate) fn handle_idle_callback(&mut self, cb: impl FnOnce(&mut T)) {
+        let mut inner = self.inner.borrow_mut();
+        cb(&mut inner.data);
+        inner.do_update();
     }
 
     fn process_commands(&mut self) {


### PR DESCRIPTION
Sometimes using commands to mutate data from ExtEventSink can be complicated and verbose.
This provides a simpler alternative.