### PR TITLE
Fix the ListIter implementation for Vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - Move macOS only function to Mac extension trait ([#1863] by [@Maan2003])
 - x11: Only query atoms once instead of per window ([#1865] by [@psychon])
 - remove prefix from platform extension traits ([#1873] by [@Maan2003])
+- `ListIter` implementations for `Arc<Vec<T>>`, `(S, Arc<Vec<T>>)`, `Arc<VecDequeue<T>>` and `(S, Arc<VecDequeue<T>>)` ([#1967] by [@xarvic])
 
 ### Deprecated
 
@@ -99,6 +100,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - X11 backend now uses the platform locale ([#1756] by [@Maan2003])
 - `Either` and `Tab` widgets were still propagating events to hidden widgets ([#1860] by [@lisael])
 - RichText: Invalidate layout on Env change ([#1907] by [@Maan2003])
+- `ListIter` implementations for `Vector<T>` and `(S, Vector<T>)` ([#1967] by [@xarvic])
 
 ### Visual
 
@@ -784,6 +786,8 @@ Last release without a changelog :(
 [#1886]: https://github.com/linebender/druid/pull/1886
 [#1907]: https://github.com/linebender/druid/pull/1907
 [#1929]: https://github.com/linebender/druid/pull/1929
+[#1929]: https://github.com/linebender/druid/pull/1967
+
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -17,8 +17,8 @@
 use std::cmp::Ordering;
 use std::collections::VecDeque;
 use std::f64;
-use std::sync::Arc;
 use std::ops::Deref;
+use std::sync::Arc;
 
 use tracing::{instrument, trace};
 
@@ -28,7 +28,10 @@ use crate::im::{OrdMap, Vector};
 use crate::kurbo::{Point, Rect, Size};
 
 use crate::debug_state::DebugState;
-use crate::{widget::Axis, BoxConstraints, Data, Env, Event, EventCtx, KeyOrValue, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, UpdateCtx, Widget, WidgetPod};
+use crate::{
+    widget::Axis, BoxConstraints, Data, Env, Event, EventCtx, KeyOrValue, LayoutCtx, LifeCycle,
+    LifeCycleCtx, PaintCtx, UpdateCtx, Widget, WidgetPod,
+};
 
 /// A list widget for a variable-size collection of items.
 pub struct List<T> {
@@ -125,9 +128,9 @@ impl<T: Data> ListIter<T> for Vector<T> {
 //with how the List Widget handles the reordering of its data.
 #[cfg(feature = "im")]
 impl<K, V> ListIter<V> for OrdMap<K, V>
-    where
-        K: Data + Ord,
-        V: Data,
+where
+    K: Data + Ord,
+    V: Data,
 {
     fn for_each(&self, mut cb: impl FnMut(&V, usize)) {
         for (i, item) in self.iter().enumerate() {
@@ -199,7 +202,7 @@ impl<T: Data> ListIter<T> for Arc<Vec<T>> {
                 match &mut new_data {
                     Some(vec) => {
                         vec[i] = d;
-                    },
+                    }
                     None => {
                         let mut new = (**self).clone();
                         new[i] = d;
@@ -240,7 +243,7 @@ impl<S: Data, T: Data> ListIter<(S, T)> for (S, Arc<Vec<T>>) {
                 match &mut new_data {
                     Some(vec) => {
                         vec[i] = d.1;
-                    },
+                    }
                     None => {
                         let mut new = self.1.deref().clone();
                         new[i] = d.1;
@@ -277,7 +280,7 @@ impl<T: Data> ListIter<T> for Arc<VecDeque<T>> {
                 match &mut new_data {
                     Some(vec) => {
                         vec[i] = d;
-                    },
+                    }
                     None => {
                         let mut new = (**self).clone();
                         new[i] = d;
@@ -318,7 +321,7 @@ impl<S: Data, T: Data> ListIter<(S, T)> for (S, Arc<VecDeque<T>>) {
                 match &mut new_data {
                     Some(vec) => {
                         vec[i] = d.1;
-                    },
+                    }
                     None => {
                         let mut new = self.1.deref().clone();
                         new[i] = d.1;


### PR DESCRIPTION
This PR fixes the `ListIter` implementation for `Vector` and makes the implementation for `Arc<Vec<...>>` more efficient.

The old implementation used `iter_mut()` on `Vector` which makes a deep copy of the Vector, therefore `Data::same` returned always `false`