### PR TITLE
Windows tooltip changes

### DIFF
--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -1387,12 +1387,18 @@ impl WindowBuilder {
                         dwStyle = WS_POPUP;
                         dwExStyle = WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW;
                         focusable = false;
-                        let scaled_sub_window_point = WindowBuilder::scale_sub_window_position(
-                            self.position,
-                            parent_window_handle.get_scale(),
-                        );
-                        pos_x = scaled_sub_window_point.x as i32;
-                        pos_y = scaled_sub_window_point.y as i32;
+                        if let Some(point_in_window_coord) = self.position {
+                            let screen_point = parent_window_handle.get_position()
+                                + point_in_window_coord.to_vec2();
+                            let scaled_tooltip_point = WindowBuilder::scale_sub_window_position(
+                                Some(screen_point),
+                                parent_window_handle.get_scale(),
+                            );
+                            pos_x = scaled_tooltip_point.x as i32;
+                            pos_y = scaled_tooltip_point.y as i32;
+                        } else {
+                            warn!("No position provided for tooltip!");
+                        }
                     }
                     WindowLevel::DropDown(_) => {
                         dwStyle = WS_CHILD;

--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -1353,6 +1353,8 @@ impl WindowBuilder {
                 present_strategy: self.present_strategy,
             };
 
+            // TODO: pos_x and pos_y are only scaled for windows with parents. But they need to be
+            // scaled for windows without parents too.
             let (mut pos_x, mut pos_y) = match self.position {
                 Some(pos) => (pos.x as i32, pos.y as i32),
                 None => (CW_USEDEFAULT, CW_USEDEFAULT),

--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -1391,7 +1391,7 @@ impl WindowBuilder {
                             let screen_point = parent_window_handle.get_position()
                                 + point_in_window_coord.to_vec2();
                             let scaled_tooltip_point = WindowBuilder::scale_sub_window_position(
-                                Some(screen_point),
+                                screen_point,
                                 parent_window_handle.get_scale(),
                             );
                             pos_x = scaled_tooltip_point.x as i32;
@@ -1517,22 +1517,13 @@ impl WindowBuilder {
     /// When creating a sub-window, we need to scale its position with respect to its parent.
     /// If there is any error while scaling, log it as a warn and show sub-window in top left corner of screen/window.
     fn scale_sub_window_position(
-        un_scaled_sub_window_position: Option<Point>,
+        un_scaled_sub_window_position: Point,
         parent_window_scale: Result<Scale, crate::Error>,
     ) -> Point {
-        match (un_scaled_sub_window_position, parent_window_scale) {
-            (Some(point), Ok(s)) => point.to_px(s),
-            (None, Ok(_)) => {
-                warn!("No position");
-                Point::new(0., 0.)
-            }
-            (Some(_), Err(r)) => {
-                warn!("Error with scale: {:?}", r);
-                Point::new(0., 0.)
-            }
-            (None, Err(r)) => {
-                warn!("No position");
-                warn!("Error with scale: {:?}", r);
+        match parent_window_scale {
+            Ok(s) => un_scaled_sub_window_position.to_px(s),
+            Err(e) => {
+                warn!("Error with scale: {:?}", e);
                 Point::new(0., 0.)
             }
         }

--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -1377,7 +1377,7 @@ impl WindowBuilder {
                 None => (0 as HMENU, None, false),
             };
 
-            let mut dwStyle = WS_OVERLAPPEDWINDOW | WS_CLIPCHILDREN;
+            let mut dwStyle = WS_OVERLAPPEDWINDOW;
             let mut dwExStyle: DWORD = 0;
             let mut focusable = true;
             if let Some(level) = self.level {

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -15,7 +15,6 @@
 //! Platform independent window types.
 
 use std::any::Any;
-use std::fmt;
 use std::time::Duration;
 
 use crate::application::Application;
@@ -159,17 +158,6 @@ pub enum WindowLevel {
     DropDown(WindowHandle),
     /// A modal dialog
     Modal(WindowHandle),
-}
-
-impl fmt::Debug for WindowLevel {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            WindowLevel::AppWindow => write!(f, "AppWindow"),
-            WindowLevel::Tooltip(_) => write!(f, "ToolTip"),
-            WindowLevel::DropDown(_) => write!(f, "DropDown"),
-            WindowLevel::Modal(_) => write!(f, "Modal"),
-        }
-    }
 }
 
 /// Contains the different states a Window can be in.

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -480,8 +480,11 @@ impl WindowBuilder {
 
     /// Sets the initial window position in [display points], relative to the origin of the
     /// virtual screen.
+    /// For sub-windows like [tooltips] and [dropdowns], this position must be in window co-ordinates.
     ///
     /// [display points]: crate::Scale
+    /// [tooltips]: crate::WindowLevel::Tooltip
+    /// [dropdowns]: crate::WindowLevel::DropDown
     pub fn set_position(&mut self, position: Point) {
         self.0.set_position(position);
     }

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -478,13 +478,12 @@ impl WindowBuilder {
         self.0.set_transparent(transparent)
     }
 
-    /// Sets the initial window position in [display points], relative to the origin of the
-    /// virtual screen.
-    /// For sub-windows like [tooltips] and [dropdowns], this position must be in window co-ordinates.
+    /// Sets the initial window position in display points.
+    /// For windows with a parent, the position is relative to the parent.
+    /// For windows without a parent, it is relative to the origin of the virtual screen.
+    /// See also [set_level]
     ///
-    /// [display points]: crate::Scale
-    /// [tooltips]: crate::WindowLevel::Tooltip
-    /// [dropdowns]: crate::WindowLevel::DropDown
+    /// [set_level]: crate::WindowBuilder::set_level
     pub fn set_position(&mut self, position: Point) {
         self.0.set_position(position);
     }

--- a/druid/examples/sub_window.rs
+++ b/druid/examples/sub_window.rs
@@ -74,7 +74,7 @@ enum TooltipState {
         last_move: Instant,
         timer_expire: Instant,
         token: TimerToken,
-        window_pos: Point,
+        position_in_window_coordinates: Point,
     },
     Fresh,
 }
@@ -105,7 +105,7 @@ impl<T, W: Widget<T>> Controller<T, W> for TooltipController {
                     last_move: now,
                     timer_expire: now + wait_duration,
                     token: ctx.request_timer(wait_duration),
-                    window_pos: me.window_pos,
+                    position_in_window_coordinates: me.window_pos,
                 }),
                 _ => None,
             },
@@ -113,7 +113,7 @@ impl<T, W: Widget<T>> Controller<T, W> for TooltipController {
                 last_move,
                 timer_expire,
                 token,
-                window_pos,
+                position_in_window_coordinates,
             } => match event {
                 Event::MouseMove(me) if ctx.is_hot() => {
                     let (cur_token, cur_expire) = if *timer_expire - now < resched_dur {
@@ -125,7 +125,7 @@ impl<T, W: Widget<T>> Controller<T, W> for TooltipController {
                         last_move: now,
                         timer_expire: cur_expire,
                         token: cur_token,
-                        window_pos: me.window_pos,
+                        position_in_window_coordinates: me.window_pos,
                     })
                 }
                 Event::Timer(tok) if tok == token => {
@@ -138,17 +138,22 @@ impl<T, W: Widget<T>> Controller<T, W> for TooltipController {
                             last_move: *last_move,
                             timer_expire: deadline,
                             token: ctx.request_timer(wait_for),
-                            window_pos: *window_pos,
+                            position_in_window_coordinates: *position_in_window_coordinates,
                         })
                     } else {
+                        let tooltip_position_in_window_coordinates =
+                            (position_in_window_coordinates.to_vec2() + cursor_size.to_vec2())
+                                .to_point();
+                        let tooltip_position_in_screen_coordinates = ctx
+                            .window_coordinates_to_screen_coordinates(
+                                tooltip_position_in_window_coordinates,
+                            );
                         let win_id = ctx.new_sub_window(
                             WindowConfig::default()
                                 .show_titlebar(false)
                                 .window_size_policy(WindowSizePolicy::Content)
                                 .set_level(WindowLevel::Tooltip(ctx.window().clone()))
-                                .set_position(
-                                    (window_pos.to_vec2() + cursor_size.to_vec2()).to_point(),
-                                ),
+                                .set_position(tooltip_position_in_screen_coordinates),
                             Label::<()>::new(self.tip.clone()),
                             (),
                             env.clone(),
@@ -168,7 +173,7 @@ impl<T, W: Widget<T>> Controller<T, W> for TooltipController {
                             last_move: now,
                             timer_expire: now + wait_duration,
                             token: ctx.request_timer(wait_duration),
-                            window_pos: me.window_pos,
+                            position_in_window_coordinates: me.window_pos,
                         })
                     }
                     _ => None,

--- a/druid/examples/sub_window.rs
+++ b/druid/examples/sub_window.rs
@@ -144,16 +144,12 @@ impl<T, W: Widget<T>> Controller<T, W> for TooltipController {
                         let tooltip_position_in_window_coordinates =
                             (position_in_window_coordinates.to_vec2() + cursor_size.to_vec2())
                                 .to_point();
-                        let tooltip_position_in_screen_coordinates = ctx
-                            .window_coordinates_to_screen_coordinates(
-                                tooltip_position_in_window_coordinates,
-                            );
                         let win_id = ctx.new_sub_window(
                             WindowConfig::default()
                                 .show_titlebar(false)
                                 .window_size_policy(WindowSizePolicy::Content)
                                 .set_level(WindowLevel::Tooltip(ctx.window().clone()))
-                                .set_position(tooltip_position_in_screen_coordinates),
+                                .set_position(tooltip_position_in_window_coordinates),
                             Label::<()>::new(self.tip.clone()),
                             (),
                             env.clone(),

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -53,7 +53,7 @@ pub enum WindowSizePolicy {
 
 /// Window configuration that can be applied to a WindowBuilder, or to an existing WindowHandle.
 /// It does not include anything related to app data.
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
 pub struct WindowConfig {
     pub(crate) size_policy: WindowSizePolicy,
     pub(crate) size: Option<Size>,

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -212,6 +212,17 @@ impl_context_method!(
             content_origin + self.to_window(widget_point).to_vec2()
         }
 
+        /// Convert a point in window coordinate space to the screen's.
+        /// See the [`Screen`] module
+        ///
+        /// [`Screen`]: crate::shell::Screen
+        pub fn window_coordinates_to_screen_coordinates(
+            &self,
+            point_in_window_coordinates: Point,
+        ) -> Point {
+            self.window().get_position() + point_in_window_coordinates.to_vec2()
+        }
+
         /// The "hot" (aka hover) status of a widget.
         ///
         /// A widget is "hot" when the mouse is hovered over it. Widgets will

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -212,17 +212,6 @@ impl_context_method!(
             content_origin + self.to_window(widget_point).to_vec2()
         }
 
-        /// Convert a point in window coordinate space to the screen's.
-        /// See the [`Screen`] module
-        ///
-        /// [`Screen`]: crate::shell::Screen
-        pub fn window_coordinates_to_screen_coordinates(
-            &self,
-            point_in_window_coordinates: Point,
-        ) -> Point {
-            self.window().get_position() + point_in_window_coordinates.to_vec2()
-        }
-
         /// The "hot" (aka hover) status of a widget.
         ///
         /// A widget is "hot" when the mouse is hovered over it. Widgets will


### PR DESCRIPTION
Tooltips were introduced in #1919. But they weren't working correctly Windows. Some issues (seen in `sub_window.rs` example) were:
* Tooltips opened up in a different location. 
* The closable/drag-able window was broken as well.
This PR fixes everything related to tooltip on Windows. Handles scaling issue as well. 

Related Zulip [topic](https://xi.zulipchat.com/#narrow/stream/147926-druid/topic/Tooltip.20broken.20in.20Windows).