### PR TITLE
Make set_window_state accept &self

### DIFF
--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -204,7 +204,7 @@ impl WindowHandle {
     }
 
     /// Sets the state of the window.
-    pub fn set_window_state(&mut self, state: WindowState) {
+    pub fn set_window_state(&self, state: WindowState) {
         self.0.set_window_state(state);
     }
 


### PR DESCRIPTION
This PR makes `WindowHandle::set_window_state` accept `&self` instead of `&mut self` for consistency with other `set_*` functions (which in turn allows setting window state from `Widget::event`)