### PR TITLE
Move text_registrations and timers from WidgetState to Context State

### DIFF
--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -16,7 +16,7 @@
 
 use std::{
     any::{Any, TypeId},
-    collections::VecDeque,
+    collections::{HashMap, VecDeque},
     ops::{Deref, DerefMut},
     rc::Rc,
     time::Duration,
@@ -60,6 +60,8 @@ pub(crate) struct ContextState<'a> {
     /// The id of the widget that currently has focus.
     pub(crate) focus_widget: Option<WidgetId>,
     pub(crate) root_app_data_type: TypeId,
+    pub(crate) timers: &'a mut HashMap<TimerToken, WidgetId>,
+    pub(crate) text_registrations: &'a mut Vec<TextFieldRegistration>,
 }
 
 /// A mutable context provided to event handling methods of widgets.
@@ -758,7 +760,7 @@ impl LifeCycleCtx<'_, '_> {
             document: Rc::new(document),
             widget_id: self.widget_id(),
         };
-        self.widget_state.text_registrations.push(registration);
+        self.state.text_registrations.push(registration);
     }
 }
 
@@ -892,6 +894,8 @@ impl<'a> ContextState<'a> {
         window: &'a WindowHandle,
         window_id: WindowId,
         focus_widget: Option<WidgetId>,
+        timers: &'a mut HashMap<TimerToken, WidgetId>,
+        text_registrations: &'a mut Vec<TextFieldRegistration>,
     ) -> Self {
         ContextState {
             command_queue,
@@ -899,6 +903,8 @@ impl<'a> ContextState<'a> {
             window,
             window_id,
             focus_widget,
+            timers,
+            text_registrations,
             text: window.text(),
             root_app_data_type: TypeId::of::<T>(),
         }
@@ -910,10 +916,10 @@ impl<'a> ContextState<'a> {
             .push_back(command.default_to(self.window_id.into()));
     }
 
-    fn request_timer(&self, widget_state: &mut WidgetState, deadline: Duration) -> TimerToken {
+    fn request_timer(&mut self, widget_state: &mut WidgetState, deadline: Duration) -> TimerToken {
         trace!("request_timer deadline={:?}", deadline);
         let timer_token = self.window.request_timer(deadline);
-        widget_state.add_timer(timer_token);
+        self.timers.insert(timer_token, widget_state.id);
         timer_token
     }
 }

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -495,7 +495,7 @@ impl_context_method!(
         /// request with the event.
         pub fn request_timer(&mut self, deadline: Duration) -> TimerToken {
             trace!("request_timer deadline={:?}", deadline);
-            self.state.request_timer(&mut self.widget_state, deadline)
+            self.state.request_timer(self.widget_state.id, deadline)
         }
     }
 );
@@ -916,10 +916,10 @@ impl<'a> ContextState<'a> {
             .push_back(command.default_to(self.window_id.into()));
     }
 
-    fn request_timer(&mut self, widget_state: &mut WidgetState, deadline: Duration) -> TimerToken {
+    fn request_timer(&mut self, widget_id: WidgetId, deadline: Duration) -> TimerToken {
         trace!("request_timer deadline={:?}", deadline);
         let timer_token = self.window.request_timer(deadline);
-        self.timers.insert(timer_token, widget_state.id);
+        self.timers.insert(timer_token, widget_id);
         timer_token
     }
 }

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -1440,12 +1440,16 @@ mod tests {
         let window = WindowHandle::default();
         let ext_host = ExtEventHost::default();
         let ext_handle = ext_host.make_sink();
+        let mut timers = Vec::new();
+        let mut text_registrations = HashMap::new();
         let mut state = ContextState::new::<Option<u32>>(
             &mut command_queue,
             &ext_handle,
             &window,
             WindowId::next(),
             None,
+            &mut text_registrations,
+            &mut timers,
         );
 
         let mut ctx = EventCtx {

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -14,7 +14,7 @@
 
 //! The fundamental druid types.
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 use tracing::{info_span, trace, warn};
 
 use crate::bloom::Bloom;
@@ -22,12 +22,10 @@ use crate::command::sys::{CLOSE_WINDOW, SUB_WINDOW_HOST_TO_PARENT, SUB_WINDOW_PA
 use crate::contexts::ContextState;
 use crate::kurbo::{Affine, Insets, Point, Rect, Shape, Size, Vec2};
 use crate::sub_window::SubWindowUpdate;
-use crate::text::TextFieldRegistration;
-use crate::util::ExtendDrain;
 use crate::{
     ArcStr, BoxConstraints, Color, Command, Cursor, Data, Env, Event, EventCtx, InternalEvent,
     InternalLifeCycle, LayoutCtx, LifeCycle, LifeCycleCtx, Notification, PaintCtx, Region,
-    RenderContext, Target, TextLayout, TimerToken, UpdateCtx, Widget, WidgetId, WindowId,
+    RenderContext, Target, TextLayout, UpdateCtx, Widget, WidgetId, WindowId,
 };
 
 /// Our queue type
@@ -149,8 +147,6 @@ pub struct WidgetState {
     pub(crate) request_focus: Option<FocusChange>,
     pub(crate) children: Bloom<WidgetId>,
     pub(crate) children_changed: bool,
-    /// Associate timers with widgets that requested them.
-    pub(crate) timers: HashMap<TimerToken, WidgetId>,
     /// The cursor that was set using one of the context methods.
     pub(crate) cursor_change: CursorChange,
     /// The result of merging up children cursors. This gets cleared when merging state up (unlike
@@ -159,8 +155,6 @@ pub struct WidgetState {
 
     // Port -> Host
     pub(crate) sub_window_hosts: Vec<(WindowId, WidgetId)>,
-
-    pub(crate) text_registrations: Vec<TextFieldRegistration>,
 }
 
 /// Methods by which a widget can attempt to change focus state.
@@ -1246,12 +1240,10 @@ impl WidgetState {
             focus_chain: Vec::new(),
             children: Bloom::new(),
             children_changed: false,
-            timers: HashMap::new(),
             cursor_change: CursorChange::Default,
             cursor: None,
             sub_window_hosts: Vec::new(),
             is_explicitly_disabled_new: false,
-            text_registrations: Vec::new(),
             update_focus_chain: false,
         }
     }
@@ -1263,10 +1255,6 @@ impl WidgetState {
     pub(crate) fn tree_disabled_changed(&self) -> bool {
         self.children_disabled_changed
             || self.is_explicitly_disabled != self.is_explicitly_disabled_new
-    }
-
-    pub(crate) fn add_timer(&mut self, timer_token: TimerToken) {
-        self.timers.insert(timer_token, self.id);
     }
 
     /// Update to incorporate state changes from a child.
@@ -1308,10 +1296,6 @@ impl WidgetState {
         self.children_changed |= child_state.children_changed;
         self.request_update |= child_state.request_update;
         self.request_focus = child_state.request_focus.take().or(self.request_focus);
-        self.timers.extend_drain(&mut child_state.timers);
-        self.text_registrations
-            .append(&mut child_state.text_registrations);
-        self.update_focus_chain |= child_state.update_focus_chain;
 
         // We reset `child_state.cursor` no matter what, so that on the every pass through the tree,
         // things will be recalculated just from `cursor_change`.
@@ -1380,6 +1364,7 @@ mod tests {
     use crate::text::ParseFormatter;
     use crate::widget::{Button, Flex, Scroll, Split, TextBox};
     use crate::{WidgetExt, WindowHandle, WindowId};
+    use std::collections::HashMap;
     use test_env_log::test;
 
     const ID_1: WidgetId = WidgetId::reserved(0);
@@ -1418,12 +1403,16 @@ mod tests {
         let window = WindowHandle::default();
         let ext_host = ExtEventHost::default();
         let ext_handle = ext_host.make_sink();
+        let mut timers = Vec::new();
+        let mut text_registrations = HashMap::new();
         let mut state = ContextState::new::<Option<u32>>(
             &mut command_queue,
             &ext_handle,
             &window,
             WindowId::next(),
             None,
+            &mut text_registrations,
+            &mut timers,
         );
 
         let mut ctx = LifeCycleCtx {

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -1296,6 +1296,7 @@ impl WidgetState {
         self.children_changed |= child_state.children_changed;
         self.request_update |= child_state.request_update;
         self.request_focus = child_state.request_focus.take().or(self.request_focus);
+        self.update_focus_chain |= child_state.update_focus_chain;
 
         // We reset `child_state.cursor` no matter what, so that on the every pass through the tree,
         // things will be recalculated just from `cursor_change`.

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -30,7 +30,6 @@ use crate::core::{CommandQueue, FocusChange, WidgetState};
 use crate::debug_state::DebugState;
 use crate::menu::{MenuItemId, MenuManager};
 use crate::text::TextFieldRegistration;
-use crate::util::ExtendDrain;
 use crate::widget::LabelText;
 use crate::win_handler::RUN_COMMANDS_TOKEN;
 use crate::{
@@ -61,6 +60,7 @@ pub struct Window<T> {
     pub(crate) focus: Option<WidgetId>,
     pub(crate) handle: WindowHandle,
     pub(crate) timers: HashMap<TimerToken, WidgetId>,
+    pub(crate) pending_text_registrations: Vec<TextFieldRegistration>,
     pub(crate) transparent: bool,
     pub(crate) ime_handlers: Vec<(TextFieldToken, TextFieldRegistration)>,
     ext_handle: ExtEventSink,
@@ -92,6 +92,7 @@ impl<T> Window<T> {
             ext_handle,
             ime_handlers: Vec::new(),
             ime_focus_change: None,
+            pending_text_registrations: Vec::new(),
         }
     }
 }
@@ -202,15 +203,12 @@ impl<T: Data> Window<T> {
 
         self.update_focus(widget_state, queue, data, env);
 
-        // Add all the requested timers to the window's timers map.
-        self.timers.extend_drain(&mut widget_state.timers);
-
         // If we need a new paint pass, make sure druid-shell knows it.
         if self.wants_animation_frame() {
             self.handle.request_anim_frame();
         }
         self.invalid.union_with(&widget_state.invalid);
-        for ime_field in widget_state.text_registrations.drain(..) {
+        for ime_field in self.pending_text_registrations.drain(..) {
             let token = self.handle.add_text_field();
             tracing::debug!("{:?} added", token);
             self.ime_handlers.push((token, ime_field));
@@ -268,8 +266,15 @@ impl<T: Data> Window<T> {
 
         let mut widget_state = WidgetState::new(self.root.id(), Some(self.size));
         let is_handled = {
-            let mut state =
-                ContextState::new::<T>(queue, &self.ext_handle, &self.handle, self.id, self.focus);
+            let mut state = ContextState::new::<T>(
+                queue,
+                &self.ext_handle,
+                &self.handle,
+                self.id,
+                self.focus,
+                &mut self.timers,
+                &mut self.pending_text_registrations,
+            );
             let mut notifications = VecDeque::new();
             let mut ctx = EventCtx {
                 state: &mut state,
@@ -332,8 +337,15 @@ impl<T: Data> Window<T> {
         process_commands: bool,
     ) {
         let mut widget_state = WidgetState::new(self.root.id(), Some(self.size));
-        let mut state =
-            ContextState::new::<T>(queue, &self.ext_handle, &self.handle, self.id, self.focus);
+        let mut state = ContextState::new::<T>(
+            queue,
+            &self.ext_handle,
+            &self.handle,
+            self.id,
+            self.focus,
+            &mut self.timers,
+            &mut self.pending_text_registrations,
+        );
         let mut ctx = LifeCycleCtx {
             state: &mut state,
             widget_state: &mut widget_state,
@@ -352,8 +364,15 @@ impl<T: Data> Window<T> {
         self.update_title(data, env);
 
         let mut widget_state = WidgetState::new(self.root.id(), Some(self.size));
-        let mut state =
-            ContextState::new::<T>(queue, &self.ext_handle, &self.handle, self.id, self.focus);
+        let mut state = ContextState::new::<T>(
+            queue,
+            &self.ext_handle,
+            &self.handle,
+            self.id,
+            self.focus,
+            &mut self.timers,
+            &mut self.pending_text_registrations,
+        );
         let mut update_ctx = UpdateCtx {
             widget_state: &mut widget_state,
             state: &mut state,
@@ -438,8 +457,15 @@ impl<T: Data> Window<T> {
 
     fn layout(&mut self, queue: &mut CommandQueue, data: &T, env: &Env) {
         let mut widget_state = WidgetState::new(self.root.id(), Some(self.size));
-        let mut state =
-            ContextState::new::<T>(queue, &self.ext_handle, &self.handle, self.id, self.focus);
+        let mut state = ContextState::new::<T>(
+            queue,
+            &self.ext_handle,
+            &self.handle,
+            self.id,
+            self.focus,
+            &mut self.timers,
+            &mut self.pending_text_registrations,
+        );
         let mut layout_ctx = LayoutCtx {
             state: &mut state,
             widget_state: &mut widget_state,
@@ -491,8 +517,15 @@ impl<T: Data> Window<T> {
         env: &Env,
     ) {
         let widget_state = WidgetState::new(self.root.id(), Some(self.size));
-        let mut state =
-            ContextState::new::<T>(queue, &self.ext_handle, &self.handle, self.id, self.focus);
+        let mut state = ContextState::new::<T>(
+            queue,
+            &self.ext_handle,
+            &self.handle,
+            self.id,
+            self.focus,
+            &mut self.timers,
+            &mut self.pending_text_registrations,
+        );
         let mut ctx = PaintCtx {
             render_ctx: piet,
             state: &mut state,


### PR DESCRIPTION
These just felt like global state. No idea why these were widget local earlier.