### PR TITLE
Build on OpenBSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - X11: detect keyboard layout ([#1779] by [@Maan2003])
 - WindowDesc::with_config ([#1929] by [@Maan2003])
 - `Notification::route` ([#1978] by [@xarvic])
+- Build on OpenBSD ([#1993] by [@klemensn])
 
 ### Changed
 
@@ -521,6 +522,7 @@ Last release without a changelog :(
 [@DrGabble]: https://github.com/DrGabble
 [@lisael]: https://github.com/lisael
 [@jenra-uwu]: https://github.com/jenra-uwu
+[@klemensn]: https://github.com/klemensn
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611
@@ -797,6 +799,7 @@ Last release without a changelog :(
 [#1953]: https://github.com/linebender/druid/pull/1953
 [#1967]: https://github.com/linebender/druid/pull/1967
 [#1978]: https://github.com/linebender/druid/pull/1978
+[#1993]: https://github.com/linebender/druid/pull/1993
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ druid = { git = "https://github.com/linebender/druid.git" }
 On Linux, Druid requires gtk+3; see [GTK installation page].
 (On ubuntu-based distro, running `sudo apt-get install libgtk-3-dev` from the terminal will do the job.)
 
+#### OpenBSD
+
+On OpenBSD, Druid requires gtk+3;  install from packages:
+```sh
+pkg_add gtk+3
+```
 
 Alternatively, there is an X11 backend available, although it is currently
 [missing quite a few features](https://github.com/linebender/druid/issues?q=is%3Aopen+is%3Aissue+label%3Ashell%2Fx11+label%3Amissing).
@@ -152,7 +158,7 @@ Druid relies on the [Piet library] for drawing and text layout. Piet is a 2D gra
 abstraction with multiple backends: `piet-direct2d`, `piet-coregraphics`, `piet-cairo`,
 `piet-web`, and `piet-svg` are currently available, and a GPU backend is planned.
 In terms of Druid platform support via Piet, macOS uses `piet-coregraphics`,
-Linux uses `piet-cairo`, Windows uses `piet-direct2d`, and web uses `piet-web`.
+Linux and OpenBSD use `piet-cairo`, Windows uses `piet-direct2d`, and web uses `piet-web`.
 
 ```rust
 use druid::kurbo::{BezPath, Point, Rect};

--- a/docs/src/setup.md
+++ b/docs/src/setup.md
@@ -24,6 +24,12 @@ sudo dnf install gtk3-devel glib2-devel
 
 See [GTK installation page] for more installation instructions.
 
+### OpenBSD
+On OpenBSD, Druid requires gtk+3;  install from packages:
+```no_compile
+pkg_add gtk+3
+```
+
 ## Starting a project
 Starting a project is as easy as creating an empty application with
 ```no_compile

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -75,7 +75,7 @@ core-graphics = "0.22.0"
 foreign-types = "0.3.2"
 bitflags = "1.2.1"
 
-[target.'cfg(target_os="linux")'.dependencies]
+[target.'cfg(any(target_os="linux", target_os="openbsd"))'.dependencies]
 # TODO(x11/dependencies): only use feature "xcb" if using X11
 cairo-rs = { version = "0.14.0", default_features = false, features = ["xcb"] }
 cairo-sys-rs = { version = "0.14.0", default_features = false, optional = true }

--- a/druid-shell/build.rs
+++ b/druid-shell/build.rs
@@ -7,7 +7,9 @@ fn main() {
     use std::env;
     use std::path::PathBuf;
 
-    if env::var("CARGO_CFG_TARGET_OS").unwrap() != "linux" {
+    if env::var("CARGO_CFG_TARGET_OS").unwrap() != "linux"
+        || env::var("CARGO_CFG_TARGET_OS").unwrap() != "openbsd"
+    {
         return;
     }
 

--- a/druid-shell/build.rs
+++ b/druid-shell/build.rs
@@ -8,7 +8,7 @@ fn main() {
     use std::path::PathBuf;
 
     if env::var("CARGO_CFG_TARGET_OS").unwrap() != "linux"
-        || env::var("CARGO_CFG_TARGET_OS").unwrap() != "openbsd"
+        && env::var("CARGO_CFG_TARGET_OS").unwrap() != "openbsd"
     {
         return;
     }

--- a/druid-shell/src/backend/mod.rs
+++ b/druid-shell/src/backend/mod.rs
@@ -28,18 +28,18 @@ pub use mac::*;
 #[cfg(target_os = "macos")]
 pub(crate) mod shared;
 
-#[cfg(all(feature = "x11", target_os = "linux"))]
+#[cfg(all(feature = "x11", any(target_os = "linux", target_os = "openbsd")))]
 mod x11;
-#[cfg(all(feature = "x11", target_os = "linux"))]
+#[cfg(all(feature = "x11", any(target_os = "linux", target_os = "openbsd")))]
 pub use x11::*;
-#[cfg(all(feature = "x11", target_os = "linux"))]
+#[cfg(all(feature = "x11", any(target_os = "linux", target_os = "openbsd")))]
 pub(crate) mod shared;
 
-#[cfg(all(not(feature = "x11"), target_os = "linux"))]
+#[cfg(all(not(feature = "x11"), any(target_os = "linux", target_os = "openbsd")))]
 mod gtk;
-#[cfg(all(not(feature = "x11"), target_os = "linux"))]
+#[cfg(all(not(feature = "x11"), any(target_os = "linux", target_os = "openbsd")))]
 pub use self::gtk::*;
-#[cfg(all(not(feature = "x11"), target_os = "linux"))]
+#[cfg(all(not(feature = "x11"), any(target_os = "linux", target_os = "openbsd")))]
 pub(crate) mod shared;
 
 #[cfg(target_arch = "wasm32")]

--- a/druid-shell/src/backend/shared/keyboard.rs
+++ b/druid-shell/src/backend/shared/keyboard.rs
@@ -17,7 +17,10 @@
 #[allow(unused)]
 use keyboard_types::{Code, Location};
 
-#[cfg(any(all(feature = "x11", target_os = "linux"), target_os = "macos"))]
+#[cfg(any(
+    all(feature = "x11", any(target_os = "linux", target_os = "openbsd")),
+    target_os = "macos"
+))]
 /// Map key code to location.
 ///
 /// The logic for this is adapted from InitKeyEvent in TextInputHandler (in the Mozilla
@@ -51,7 +54,7 @@ pub fn code_to_location(code: Code) -> Location {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "openbsd"))]
 /// Map hardware keycode to code.
 ///
 /// In theory, the hardware keycode is device dependent, but in

--- a/druid-shell/src/backend/shared/mod.rs
+++ b/druid-shell/src/backend/shared/mod.rs
@@ -15,7 +15,7 @@
 //! Logic that is shared by more than one backend.
 
 cfg_if::cfg_if! {
-    if #[cfg(any(target_os = "macos", target_os = "linux"))] {
+    if #[cfg(any(target_os = "macos", target_os = "linux", target_os = "openbsd"))] {
         mod keyboard;
         pub use keyboard::*;
     }

--- a/druid-shell/src/clipboard.rs
+++ b/druid-shell/src/clipboard.rs
@@ -224,7 +224,7 @@ cfg_if::cfg_if! {
     } else {
         impl ClipboardFormat {
             cfg_if::cfg_if! {
-                if #[cfg(target_os = "linux")] {
+                if #[cfg(any(target_os = "linux", target_os = "openbsd"))] {
                     // trial and error; this is the most supported string type for gtk?
                     pub const TEXT: &'static str = "UTF8_STRING";
                 } else {

--- a/druid-shell/src/dialog.rs
+++ b/druid-shell/src/dialog.rs
@@ -37,7 +37,7 @@ pub struct FileInfo {
 }
 
 /// Type of file dialog.
-#[cfg(not(all(target_os = "linux", feature = "x11")))]
+#[cfg(not(all(any(target_os = "linux", target_os = "openbsd"), feature = "x11")))]
 #[derive(Clone, Copy, PartialEq)]
 pub enum FileDialogType {
     /// File open dialog.

--- a/druid-shell/src/hotkey.rs
+++ b/druid-shell/src/hotkey.rs
@@ -126,13 +126,13 @@ impl HotKey {
 pub enum SysMods {
     None,
     Shift,
-    /// Command on macOS, and Ctrl on windows/linux
+    /// Command on macOS, and Ctrl on windows/linux/OpenBSD
     Cmd,
-    /// Command + Alt on macOS, Ctrl + Alt on windows/linux
+    /// Command + Alt on macOS, Ctrl + Alt on windows/linux/OpenBSD
     AltCmd,
-    /// Command + Shift on macOS, Ctrl + Shift on windows/linux
+    /// Command + Shift on macOS, Ctrl + Shift on windows/linux/OpenBSD
     CmdShift,
-    /// Command + Alt + Shift on macOS, Ctrl + Alt + Shift on windows/linux
+    /// Command + Alt + Shift on macOS, Ctrl + Alt + Shift on windows/linux/OpenBSD
     AltCmdShift,
 }
 

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -36,7 +36,7 @@
 // Rename `gtk_rs` back to `gtk`.
 // This allows us to use `gtk` as the feature name.
 // The `target_os` requirement is there to exclude anything `wasm` like.
-#[cfg(all(target_os = "linux", feature = "gtk"))]
+#[cfg(all(any(target_os = "linux", target_os = "openbsd"), feature = "gtk"))]
 extern crate gtk_rs as gtk;
 
 // Reexport the version of `image` we are using.

--- a/druid-shell/src/platform/mod.rs
+++ b/druid-shell/src/platform/mod.rs
@@ -14,7 +14,7 @@
 
 //! Platorm specific extensions.
 
-#[cfg(any(doc, target_os = "linux"))]
+#[cfg(any(doc, any(target_os = "linux", target_os = "openbsd")))]
 pub mod linux;
 
 #[cfg(any(doc, target_os = "macos"))]

--- a/druid/examples/markdown_preview.rs
+++ b/druid/examples/markdown_preview.rs
@@ -239,7 +239,7 @@ fn make_menu<T: Data>(_window_id: Option<WindowId>, _app_state: &AppState, _env:
     {
         base = base.entry(druid::platform_menus::mac::application::default())
     }
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(any(target_os = "windows", target_os = "linux", target_os = "openbsd"))]
     {
         base = base.entry(druid::platform_menus::win::file::default());
     }

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -199,7 +199,7 @@ fn make_menu(_: Option<WindowId>, state: &State, _: &Env) -> Menu<State> {
     {
         base = druid::platform_menus::mac::menu_bar();
     }
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(any(target_os = "windows", target_os = "linux", target_os = "openbsd"))]
     {
         base = base.entry(druid::platform_menus::win::file::default());
     }

--- a/druid/examples/textbox.rs
+++ b/druid/examples/textbox.rs
@@ -98,7 +98,7 @@ fn make_menu<T: Data>(_window: Option<WindowId>, _data: &AppState, _env: &Env) -
     {
         base = base.entry(druid::platform_menus::mac::application::default())
     }
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(any(target_os = "windows", target_os = "linux", target_os = "openbsd"))]
     {
         base = base.entry(druid::platform_menus::win::file::default());
     }

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -15,7 +15,7 @@
 //! Simple data-oriented GUI.
 //!
 //! Druid lets you build simple interactive graphical applications that
-//! can be deployed on Windows, macOS, Linux, and the web.
+//! can be deployed on Windows, macOS, Linux, OpenBSD and the web.
 //!
 //! Druid is built on top of [`druid-shell`], which implements all of the
 //! lower-level, platform-specific code, providing a common abstraction
@@ -97,7 +97,7 @@
 //!          which is made available via the [`im` module].
 //! * `svg` - Scalable Vector Graphics for icons and other scalable images using the [`usvg` crate].
 //! * `image` - Bitmap image support using the [`image` crate].
-//! * `x11` - Work-in-progress X11 Linux backend instead of GTK.
+//! * `x11` - Work-in-progress X11 for Linux and OpenBSD backend instead of GTK.
 //!
 //! Features can be added with `cargo`. For example, in your `Cargo.toml`:
 //! ```no_compile

--- a/druid/src/menu/mod.rs
+++ b/druid/src/menu/mod.rs
@@ -170,7 +170,7 @@ impl<T: Data> MenuManager<T> {
         #[cfg(target_os = "macos")]
         return Some(MenuManager::new(|_, _, _| sys::mac::application::default()));
 
-        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        #[cfg(any(target_os = "windows", target_os = "linux", target_os = "openbsd"))]
         return None;
 
         // we want to explicitly handle all platforms; log if a platform is missing.

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -33,7 +33,11 @@ use crate::{
 use super::LabelText;
 
 const CURSOR_BLINK_DURATION: Duration = Duration::from_millis(500);
-const MAC_OR_LINUX: bool = cfg!(any(target_os = "macos", target_os = "linux"));
+const MAC_OR_LINUX_OR_OBSD: bool = cfg!(any(
+    target_os = "macos",
+    target_os = "linux",
+    target_os = "openbsd"
+));
 
 /// When we scroll after editing or movement, we show a little extra of the document.
 const SCROLL_TO_INSETS: Insets = Insets::uniform_xy(40.0, 0.0);
@@ -513,7 +517,7 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
                 ctx.request_paint();
             }
             LifeCycle::FocusChanged(false) => {
-                if self.text().can_write() && MAC_OR_LINUX && !self.multiline {
+                if self.text().can_write() && MAC_OR_LINUX_OR_OBSD && !self.multiline {
                     let selection = self.text().borrow().selection();
                     let selection = Selection::new(selection.active, selection.active);
                     let _ = self.text_mut().borrow_mut().set_selection(selection);


### PR DESCRIPTION
Just like Linux, OpenBSD is sufficiently supported using GTK+3.

No platform specific changes required to successfully run the examples
and real-world applications like Psst (spotify GUI client).

The pre-push hook mentioned in CONTRIBUTING.md runs sucessfully on
OpenBSD/amd64 7.0 (after pointing druid to a ported version of piet in
.cargo/config.toml to allow building in the first place), i.e. no lint
or build failure.