### PR TITLE
Do not panic in Application::try_global if Application is not created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - RichText: Invalidate layout on Env change ([#1907] by [@Maan2003])
 - GTK: fix using gdk before initialising it ([#1946] by [@JAicewizard])
 - `ListIter` implementations for `Vector<T>` and `(S, Vector<T>)` ([#1967] by [@xarvic])
+- Do not panic in Application::try_global if Application is not created ([#1996] by [@Maan2003])
 
 ### Visual
 
@@ -802,6 +803,7 @@ Last release without a changelog :(
 [#1976]: https://github.com/linebender/druid/pull/1976
 [#1978]: https://github.com/linebender/druid/pull/1978
 [#1993]: https://github.com/linebender/druid/pull/1993
+[#1996]: https://github.com/linebender/druid/pull/1996
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid-shell/src/application.rs
+++ b/druid-shell/src/application.rs
@@ -121,7 +121,7 @@ impl Application {
     /// [`new`]: #method.new
     /// [`run`]: #method.run
     pub fn try_global() -> Option<Application> {
-        util::assert_main_thread();
+        util::assert_main_thread_or_main_unclaimed();
         GLOBAL_APP.with(|global_app| global_app.borrow().clone())
     }
 

--- a/druid-shell/src/util.rs
+++ b/druid-shell/src/util.rs
@@ -32,10 +32,27 @@ fn current_thread_id() -> u64 {
 /// # Panics
 ///
 /// Panics when called from a non-main thread.
+#[allow(dead_code)]
 pub fn assert_main_thread() {
     let thread_id = current_thread_id();
     let main_thread_id = MAIN_THREAD_ID.load(Ordering::Acquire);
     if thread_id != main_thread_id {
+        panic!(
+            "Main thread assertion failed {} != {}",
+            thread_id, main_thread_id
+        );
+    }
+}
+
+/// Assert that the current thread is the registered main thread or main thread is not claimed.
+///
+/// # Panics
+///
+/// Panics when called from a non-main thread and main thread is claimed.
+pub fn assert_main_thread_or_main_unclaimed() {
+    let thread_id = current_thread_id();
+    let main_thread_id = MAIN_THREAD_ID.load(Ordering::Acquire);
+    if thread_id != main_thread_id && main_thread_id != 0 {
         panic!(
             "Main thread assertion failed {} != {}",
             thread_id, main_thread_id

--- a/druid-shell/src/util.rs
+++ b/druid-shell/src/util.rs
@@ -27,23 +27,6 @@ fn current_thread_id() -> u64 {
     unsafe { mem::transmute(thread::current().id()) }
 }
 
-/// Assert that the current thread is the registered main thread.
-///
-/// # Panics
-///
-/// Panics when called from a non-main thread.
-#[allow(dead_code)]
-pub fn assert_main_thread() {
-    let thread_id = current_thread_id();
-    let main_thread_id = MAIN_THREAD_ID.load(Ordering::Acquire);
-    if thread_id != main_thread_id {
-        panic!(
-            "Main thread assertion failed {} != {}",
-            thread_id, main_thread_id
-        );
-    }
-}
-
 /// Assert that the current thread is the registered main thread or main thread is not claimed.
 ///
 /// # Panics

--- a/druid-shell/src/util.rs
+++ b/druid-shell/src/util.rs
@@ -32,7 +32,7 @@ fn current_thread_id() -> u64 {
 /// # Panics
 ///
 /// Panics when called from a non-main thread and main thread is claimed.
-pub fn assert_main_thread_or_main_unclaimed() {
+pub(crate) fn assert_main_thread_or_main_unclaimed() {
     let thread_id = current_thread_id();
     let main_thread_id = MAIN_THREAD_ID.load(Ordering::Acquire);
     if thread_id != main_thread_id && main_thread_id != 0 {
@@ -48,7 +48,7 @@ pub fn assert_main_thread_or_main_unclaimed() {
 /// # Panics
 ///
 /// Panics if the main thread has already been claimed by another thread.
-pub fn claim_main_thread() {
+pub(crate) fn claim_main_thread() {
     let thread_id = current_thread_id();
     let old_thread_id =
         MAIN_THREAD_ID.compare_exchange(0, thread_id, Ordering::AcqRel, Ordering::Acquire);
@@ -70,7 +70,7 @@ pub fn claim_main_thread() {
 /// # Panics
 ///
 /// Panics if the main thread status is owned by another thread.
-pub fn release_main_thread() {
+pub(crate) fn release_main_thread() {
     let thread_id = current_thread_id();
     let old_thread_id =
         MAIN_THREAD_ID.compare_exchange(thread_id, 0, Ordering::AcqRel, Ordering::Acquire);


### PR DESCRIPTION
`Application::try_global` called `assert_main_thread` but before Application is created the main thread is unclaimed.
I think there was no way for `Application::try_global` to return None.

Added `assert_main_thread_or_main_unclaimed` that does not panic if main thread is unclaimed.

Fixes #1995