### PR TITLE
fix timers if backend reused TimerTokens

### DIFF
--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -244,8 +244,8 @@ impl<T: Data> Window<T> {
 
         let event = match event {
             Event::Timer(token) => {
-                if let Some(widget_id) = self.timers.get(&token) {
-                    Event::Internal(InternalEvent::RouteTimer(token, *widget_id))
+                if let Some(widget_id) = self.timers.remove(&token) {
+                    Event::Internal(InternalEvent::RouteTimer(token, widget_id))
                 } else {
                     error!("No widget found for timer {:?}", token);
                     return Handled::No;
@@ -298,12 +298,6 @@ impl<T: Data> Window<T> {
             }
             Handled::from(ctx.is_handled)
         };
-
-        // Clean up the timer token and do it immediately after the event handling
-        // because the token may be reused and re-added in a lifecycle pass below.
-        if let Event::Internal(InternalEvent::RouteTimer(token, _)) = event {
-            self.timers.remove(&token);
-        }
 
         if let Some(cursor) = &widget_state.cursor {
             self.handle.set_cursor(cursor);


### PR DESCRIPTION
need to remove the timer token before sending Timer event to widgets.
if widget requests timer in this event and shell reuses the TimerToken.
After the event we will remove this TimerToken and the token of new timer
will be removed.

Fixes #1998 
