### PR TITLE
Convert relative links to absolute in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ Druid's existing functionality and widgets. Check [druid_widget_nursery](https:/
 
 ## Screenshots
 
-[![calc.rs example](https://raw.githubusercontent.com/linebender/druid/screenshots/images/0.6.0/calc.png)](./druid/examples/calc.rs)
-[![flex.rs example](https://raw.githubusercontent.com/linebender/druid/screenshots/images/0.6.0/flex.png)](./druid/examples/flex.rs)
-[![custom_widget.rs example](https://raw.githubusercontent.com/linebender/druid/screenshots/images/0.6.0/custom_widget.png)](./druid/examples/custom_widget.rs)
+[![calc.rs example](https://raw.githubusercontent.com/linebender/druid/screenshots/images/0.6.0/calc.png)](/druid/examples/calc.rs)
+[![flex.rs example](https://raw.githubusercontent.com/linebender/druid/screenshots/images/0.6.0/flex.png)](/druid/examples/flex.rs)
+[![custom_widget.rs example](https://raw.githubusercontent.com/linebender/druid/screenshots/images/0.6.0/custom_widget.png)](/druid/examples/custom_widget.rs)
 
 ## Using Druid
 
@@ -298,7 +298,7 @@ The main authors are Raph Levien and Colin Rofls, with much support from an
 active and friendly community.
 
 [Runebender]: https://github.com/linebender/runebender
-[the examples folder]: ./druid/examples
+[the examples folder]: /druid/examples
 [Piet library]: https://github.com/linebender/piet
 [custom_widget]: /druid/examples/custom_widget.rs
 [basic utility and layout widgets]: /druid/src/widget


### PR DESCRIPTION
This fixes a bug, where some of the links in the readme would break, if accessed from the symlinked version in the [./druid](https://github.com/linebender/druid/tree/master/druid) subdirectory on Github.