### PR TITLE
Fix missing import in gtk/window.rs

### DIFF
--- a/druid-shell/src/backend/gtk/window.rs
+++ b/druid-shell/src/backend/gtk/window.rs
@@ -44,7 +44,7 @@ use instant::Duration;
 use tracing::{error, warn};
 
 #[cfg(feature = "raw-win-handle")]
-use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+use raw_window_handle::{unix::XcbHandle, HasRawWindowHandle, RawWindowHandle};
 
 use crate::kurbo::{Insets, Point, Rect, Size, Vec2};
 use crate::piet::{Piet, PietText, RenderContext};


### PR DESCRIPTION
Cherry-picked from jpochyla/druid@a9522f5 .

Otherwise building jpochyla/psst on Linux or OpenBSD fails:
```
error[E0433]: failed to resolve: use of undeclared type `XcbHandle`
   --> /home/kn/src/druid/druid-shell/src/backend/gtk/window.rs:118:30
    |
118 |         RawWindowHandle::Xcb(XcbHandle::empty())
    |                              ^^^^^^^^^ not found in this scope
    |
```

This code was introduced in 2da53f040625b57e3e7741ceba1d261e19b07359 which
seems to target Windows and Mac but not Linux, so I assume that is why it
went unnoticed.
