### PR TITLE
rustdoc scrape examples

### DIFF
--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -18,6 +18,7 @@ edition = "2018"
 features = ["im"]
 rustdoc-args = ["--cfg", "docsrs"]
 default-target = "x86_64-pc-windows-msvc"
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples=examples"]
 
 [features]
 default = ["gtk"]


### PR DESCRIPTION
helps a lot because most functions lack doc examples.
[the generated docs](https://maan2003.github.io/druid/druid/trait.WidgetExt.html)