### PR TITLE
decouple buffers from surface.

### DIFF
--- a/druid-shell/src/backend/wayland/application.rs
+++ b/druid-shell/src/backend/wayland/application.rs
@@ -16,12 +16,10 @@
 
 use super::{
     clipboard::Clipboard, error::Error, events::WaylandSource, keyboard, pointers, surfaces,
-    surfaces::buffers::Mmap, window::WindowHandle,
+    window::WindowHandle,
 };
 
-use crate::{
-    backend, backend::shared::xkb, keyboard_types::KeyState, kurbo, mouse, AppHandler, TimerToken,
-};
+use crate::{backend, kurbo, mouse, AppHandler, TimerToken};
 
 use calloop;
 

--- a/druid-shell/src/backend/wayland/surfaces/layershell.rs
+++ b/druid-shell/src/backend/wayland/surfaces/layershell.rs
@@ -218,7 +218,12 @@ impl Surface {
                         .inner
                         .wl_surface
                         .update_dimensions(dim.width as u32, dim.height as u32);
-                    handle.inner.wl_surface.inner.buffers.request_paint();
+                    handle
+                        .inner
+                        .wl_surface
+                        .inner
+                        .buffers
+                        .request_paint(&handle.inner.wl_surface.inner);
                 }
                 _ => tracing::info!("unimplemented event {:?} {:?} {:?}", a1, event, a2),
             }

--- a/druid-shell/src/backend/wayland/surfaces/popup.rs
+++ b/druid-shell/src/backend/wayland/surfaces/popup.rs
@@ -96,7 +96,7 @@ impl Surface {
                     xdg_surface.ack_configure(serial);
                     let dim = wl_surface.inner.logical_size.get();
                     wl_surface.inner.handler.borrow_mut().size(dim);
-                    wl_surface.inner.buffers.request_paint();
+                    wl_surface.inner.buffers.request_paint(&wl_surface.inner);
                 }
                 _ => tracing::warn!("unhandled xdg_surface event {:?}", event),
             }

--- a/druid-shell/src/backend/wayland/surfaces/toplevel.rs
+++ b/druid-shell/src/backend/wayland/surfaces/toplevel.rs
@@ -64,7 +64,7 @@ impl Surface {
                         xdg_surface.ack_configure(serial);
                         let dim = wl_surface.inner.logical_size.get();
                         wl_surface.inner.handler.borrow_mut().size(dim);
-                        wl_surface.inner.buffers.request_paint();
+                        wl_surface.inner.buffers.request_paint(&wl_surface.inner);
                     }
                     _ => tracing::warn!("unhandled xdg_surface event {:?}", event),
                 }


### PR DESCRIPTION
removes the need to use some unsafe code.