### PR TITLE
decouple window handles from wayland id.

### DIFF
--- a/druid-shell/src/backend/shared/xkb/mod.rs
+++ b/druid-shell/src/backend/shared/xkb/mod.rs
@@ -104,6 +104,7 @@ impl Context {
     ///
     /// Because `xkb` has a `critical` error, each rust error maps to 1 above (e.g. error ->
     /// critical, warn -> error etc.)
+    #[allow(unused)]
     pub fn set_log_level(&self, level: tracing::Level) {
         use tracing::Level;
         let level = match level {

--- a/druid-shell/src/backend/wayland/application.rs
+++ b/druid-shell/src/backend/wayland/application.rs
@@ -16,19 +16,16 @@
 
 use super::{
     clipboard::Clipboard, error::Error, events::WaylandSource, keyboard, pointers, surfaces,
-    surfaces::buffers::Mmap, window::WindowHandle,
+    window::WindowHandle,
 };
 
-use crate::{
-    backend, backend::shared::xkb, keyboard_types::KeyState, kurbo, mouse, AppHandler, TimerToken,
-};
+use crate::{backend, kurbo, mouse, AppHandler, TimerToken};
 
 use calloop;
 
 use std::{
     cell::{Cell, RefCell},
     collections::{BTreeMap, BinaryHeap},
-    num::NonZeroU32,
     rc::Rc,
     time::{Duration, Instant},
 };
@@ -54,14 +51,14 @@ use wayland_protocols::xdg_shell::client::xdg_surface;
 use wayland_protocols::xdg_shell::client::xdg_wm_base::{self, XdgWmBase};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct Timer(backend::shared::Timer<u32>);
+pub(crate) struct Timer(backend::shared::Timer<u64>);
 
 impl Timer {
-    pub(crate) fn new(id: u32, deadline: Instant) -> Self {
+    pub(crate) fn new(id: u64, deadline: Instant) -> Self {
         Self(backend::shared::Timer::new(deadline, id))
     }
 
-    pub(crate) fn id(self) -> u32 {
+    pub(crate) fn id(self) -> u64 {
         self.0.data
     }
 
@@ -120,14 +117,14 @@ pub(crate) struct ApplicationData {
     // pub(super) surfaces: RefCell<im::OrdMap<u32, std::sync::Arc<surfaces::surface::Data>>>,
 
     /// Handles to any surfaces that have been created.
-    pub(super) handles: RefCell<im::OrdMap<u32, WindowHandle>>,
+    pub(super) handles: RefCell<im::OrdMap<u64, WindowHandle>>,
 
     /// Available pixel formats
     pub(super) formats: RefCell<Vec<wl_shm::Format>>,
     /// Close flag
     pub(super) shutdown: Cell<bool>,
     /// The currently active surface, if any (by wayland object ID)
-    pub(super) active_surface_id: RefCell<std::collections::VecDeque<NonZeroU32>>,
+    pub(super) active_surface_id: RefCell<std::collections::VecDeque<u64>>,
     // Stuff for timers
     /// A calloop event source for timers. We always set it to fire at the next set timer, if any.
     pub(super) timer_handle: calloop::timer::TimerHandle<TimerToken>,
@@ -474,11 +471,13 @@ impl ApplicationData {
         Ok(())
     }
 
-    fn current_window_id(&self) -> u32 {
-        match self.active_surface_id.borrow().get(0) {
-            Some(u) => u.get(),
-            None => 0,
-        }
+    fn current_window_id(&self) -> u64 {
+        static DEFAULT: u64 = 0 as u64;
+        self.active_surface_id
+            .borrow()
+            .get(0)
+            .unwrap_or_else(|| &DEFAULT)
+            .clone()
     }
 
     pub(super) fn initial_window_size(&self, defaults: kurbo::Size) -> kurbo::Size {
@@ -561,14 +560,8 @@ impl ApplicationData {
     }
 
     /// Shallow clones surfaces so we can modify it during iteration.
-    fn handles_iter(&self) -> impl Iterator<Item = (u32, WindowHandle)> {
+    fn handles_iter(&self) -> impl Iterator<Item = (u64, WindowHandle)> {
         self.handles.borrow().clone().into_iter()
-        // make sure the borrow gets dropped.
-        // let surfaces = {
-        //     let surfaces = self.surfaces.borrow();
-        //     surfaces.clone()
-        // };
-        // surfaces.into_iter()
     }
 
     fn idle_repaint<'a>(loophandle: calloop::LoopHandle<'a, std::sync::Arc<ApplicationData>>) {

--- a/druid-shell/src/backend/wayland/surfaces/mod.rs
+++ b/druid-shell/src/backend/wayland/surfaces/mod.rs
@@ -19,6 +19,8 @@ pub mod popup;
 pub mod surface;
 pub mod toplevel;
 
+pub const GLOBAL_ID: crate::Counter = crate::Counter::new();
+
 pub trait Compositor {
     fn output(&self, id: &u32) -> Option<application::Output>;
     fn create_surface(&self) -> wlc::Main<WlSurface>;
@@ -56,7 +58,6 @@ impl PopupHandle {
 
 // handle on given surface.
 pub trait Handle {
-    fn wayland_surface_id(&self) -> u32;
     fn get_size(&self) -> kurbo::Size;
     fn set_size(&self, dim: kurbo::Size);
     fn request_anim_frame(&self);
@@ -159,17 +160,6 @@ impl Compositor for CompositorHandle {
         }
     }
 
-    // fn get_xdg_popup(
-    //     &self,
-    //     pos: &wlc::Main<xdg_positioner::XdgPositioner>,
-    //     parent: Option<&xdg_surface::XdgSurface>,
-    // ) -> wlc::Main<xdg_popup::XdgPopup> {
-    //     match self.inner.upgrade() {
-    //         None => panic!("unable to acquire underyling compositor to acquire xdg popup surface"),
-    //         Some(c) => c.get_xdg_popup(pos, parent),
-    //     }
-    // }
-
     fn zxdg_decoration_manager_v1(&self) -> wlc::Main<ZxdgDecorationManagerV1> {
         match self.inner.upgrade() {
             None => {
@@ -187,8 +177,4 @@ impl Compositor for CompositorHandle {
             Some(c) => c.zwlr_layershell_v1(),
         }
     }
-}
-
-pub fn id(s: impl Into<u32>) -> u32 {
-    s.into()
 }

--- a/druid-shell/src/backend/wayland/surfaces/surface.rs
+++ b/druid-shell/src/backend/wayland/surfaces/surface.rs
@@ -113,10 +113,6 @@ impl Handle {
 }
 
 impl SurfaceHandle for Handle {
-    fn wayland_surface_id(&self) -> u32 {
-        self.inner.wayland_surface_id()
-    }
-
     fn get_size(&self) -> kurbo::Size {
         self.inner.get_size()
     }
@@ -583,11 +579,6 @@ impl Decor for Dead {
 }
 
 impl SurfaceHandle for Dead {
-    fn wayland_surface_id(&self) -> u32 {
-        tracing::warn!("wayland_surface_id invoked on a dead surface");
-        0
-    }
-
     fn get_size(&self) -> kurbo::Size {
         kurbo::Size::ZERO
     }


### PR DESCRIPTION
allows for us to replace inner surfaces dynamically. (necessary for
layershells).