### PR TITLE
Set button border radius for each corner separately

### DIFF
--- a/druid/src/env.rs
+++ b/druid/src/env.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 
 use crate::localization::L10nManager;
 use crate::text::FontDescriptor;
-use crate::{ArcStr, Color, Data, Insets, Point, Rect, Size, RoundedRectRadii};
+use crate::{ArcStr, Color, Data, Insets, Point, Rect, RoundedRectRadii, Size};
 
 /// An environment passed down through all widget traversals.
 ///

--- a/druid/src/env.rs
+++ b/druid/src/env.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 
 use crate::localization::L10nManager;
 use crate::text::FontDescriptor;
-use crate::{ArcStr, Color, Data, Insets, Point, Rect, Size};
+use crate::{ArcStr, Color, Data, Insets, Point, Rect, Size, RoundedRectRadii};
 
 /// An environment passed down through all widget traversals.
 ///
@@ -107,6 +107,7 @@ pub enum Value {
     UnsignedInt(u64),
     String(ArcStr),
     Font(FontDescriptor),
+    RoundedRectRadii(RoundedRectRadii),
     Other(Arc<dyn Any + Send + Sync>),
 }
 // ANCHOR_END: value_type
@@ -453,6 +454,7 @@ impl Value {
                 | (UnsignedInt(_), UnsignedInt(_))
                 | (String(_), String(_))
                 | (Font(_), Font(_))
+                | (RoundedRectRadii(_), RoundedRectRadii(_))
         )
     }
 }
@@ -470,6 +472,7 @@ impl Debug for Value {
             Value::UnsignedInt(x) => write!(f, "UnsignedInt {}", x),
             Value::String(s) => write!(f, "String {:?}", s),
             Value::Font(font) => write!(f, "Font {:?}", font),
+            Value::RoundedRectRadii(radius) => write!(f, "RoundedRectRadii {:?}", radius),
             Value::Other(other) => write!(f, "{:?}", other),
         }
     }
@@ -613,6 +616,7 @@ impl_value_type!(Size, Size);
 impl_value_type!(Insets, Insets);
 impl_value_type!(ArcStr, String);
 impl_value_type!(FontDescriptor, Font);
+impl_value_type!(RoundedRectRadii, RoundedRectRadii);
 
 impl<T: 'static + Send + Sync> From<Arc<T>> for Value {
     fn from(this: Arc<T>) -> Value {

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -184,7 +184,7 @@ mod win_handler;
 mod window;
 
 // Types from kurbo & piet that are required by public API.
-pub use kurbo::{Affine, Insets, Point, Rect, Size, Vec2};
+pub use kurbo::{Affine, Insets, Point, Rect, Size, Vec2, RoundedRectRadii};
 pub use piet::{Color, ImageBuf, LinearGradient, RadialGradient, RenderContext, UnitPoint};
 
 // these are the types from shell that we expose; others we only use internally.

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -184,7 +184,7 @@ mod win_handler;
 mod window;
 
 // Types from kurbo & piet that are required by public API.
-pub use kurbo::{Affine, Insets, Point, Rect, Size, Vec2, RoundedRectRadii};
+pub use kurbo::{Affine, Insets, Point, Rect, RoundedRectRadii, Size, Vec2};
 pub use piet::{Color, ImageBuf, LinearGradient, RadialGradient, RenderContext, UnitPoint};
 
 // these are the types from shell that we expose; others we only use internally.

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -34,7 +34,7 @@ pub const PLACEHOLDER_COLOR: Key<Color> = Key::new("org.linebender.druid.theme.p
 
 pub const PRIMARY_LIGHT: Key<Color> = Key::new("org.linebender.druid.theme.primary_light");
 pub const PRIMARY_DARK: Key<Color> = Key::new("org.linebender.druid.theme.primary_dark");
-pub const PROGRESS_BAR_RADIUS: Key<f64> =
+pub const PROGRESS_BAR_RADIUS: Key<RoundedRectRadii> =
     Key::new("org.linebender.druid.theme.progress_bar_radius");
 pub const BACKGROUND_LIGHT: Key<Color> = Key::new("org.linebender.druid.theme.background_light");
 pub const BACKGROUND_DARK: Key<Color> = Key::new("org.linebender.druid.theme.background_dark");
@@ -86,7 +86,7 @@ pub const WIDE_WIDGET_WIDTH: Key<f64> = Key::new("org.linebender.druid.theme.lon
 pub const BORDERED_WIDGET_HEIGHT: Key<f64> =
     Key::new("org.linebender.druid.theme.bordered_widget_height");
 
-pub const TEXTBOX_BORDER_RADIUS: Key<f64> =
+pub const TEXTBOX_BORDER_RADIUS: Key<RoundedRectRadii> =
     Key::new("org.linebender.druid.theme.textbox_border_radius");
 pub const TEXTBOX_BORDER_WIDTH: Key<f64> =
     Key::new("org.linebender.druid.theme.textbox_border_width");
@@ -112,7 +112,8 @@ pub const SCROLLBAR_FADE_DELAY: Key<u64> =
     Key::new("org.linebender.druid.theme.scrollbar_fade_time");
 pub const SCROLLBAR_WIDTH: Key<f64> = Key::new("org.linebender.druid.theme.scrollbar_width");
 pub const SCROLLBAR_PAD: Key<f64> = Key::new("org.linebender.druid.theme.scrollbar_pad");
-pub const SCROLLBAR_RADIUS: Key<f64> = Key::new("org.linebender.druid.theme.scrollbar_radius");
+pub const SCROLLBAR_RADIUS: Key<RoundedRectRadii> =
+    Key::new("org.linebender.druid.theme.scrollbar_radius");
 pub const SCROLLBAR_EDGE_WIDTH: Key<f64> =
     Key::new("org.linebender.druid.theme.scrollbar_edge_width");
 /// Minimum length for any scrollbar to be when measured on that

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -50,7 +50,8 @@ pub const DISABLED_BUTTON_DARK: Key<Color> =
     Key::new("org.linebender.druid.theme.disabled_button_dark");
 pub const DISABLED_BUTTON_LIGHT: Key<Color> =
     Key::new("org.linebender.druid.theme.disabled_button_light");
-pub const BUTTON_BORDER_RADIUS: Key<RoundedRectRadii> = Key::new("org.linebender.druid.theme.button_radius");
+pub const BUTTON_BORDER_RADIUS: Key<RoundedRectRadii> =
+    Key::new("org.linebender.druid.theme.button_radius");
 pub const BUTTON_BORDER_WIDTH: Key<f64> =
     Key::new("org.linebender.druid.theme.button_border_width");
 pub const BORDER_DARK: Key<Color> = Key::new("org.linebender.druid.theme.border_dark");

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -16,6 +16,8 @@
 
 #![allow(missing_docs)]
 
+use crate::kurbo::RoundedRectRadii;
+
 use crate::piet::Color;
 
 use crate::{Env, FontDescriptor, FontFamily, FontStyle, FontWeight, Insets, Key};
@@ -48,7 +50,7 @@ pub const DISABLED_BUTTON_DARK: Key<Color> =
     Key::new("org.linebender.druid.theme.disabled_button_dark");
 pub const DISABLED_BUTTON_LIGHT: Key<Color> =
     Key::new("org.linebender.druid.theme.disabled_button_light");
-pub const BUTTON_BORDER_RADIUS: Key<f64> = Key::new("org.linebender.druid.theme.button_radius");
+pub const BUTTON_BORDER_RADIUS: Key<RoundedRectRadii> = Key::new("org.linebender.druid.theme.button_radius");
 pub const BUTTON_BORDER_WIDTH: Key<f64> =
     Key::new("org.linebender.druid.theme.button_border_width");
 pub const BORDER_DARK: Key<Color> = Key::new("org.linebender.druid.theme.border_dark");


### PR DESCRIPTION
This PR sets the type of BUTTON_BORDER_RADIUS to RoundedRectRadii, which makes it able to set button border radius for each corner separately.