### PR TITLE
Allow dynamic LabelText closure to return different types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - Remove `set_level` on windows ([#1919] by [@JAicewizard])
 - Add parent windows to non-main windows. (Coordinate space is now from their origin) ([#1919] by [@JAicewizard])
 - `ListIter` implementations for `Arc<Vec<T>>`, `(S, Arc<Vec<T>>)`, `Arc<VecDequeue<T>>` and `(S, Arc<VecDequeue<T>>)` ([#1967] by [@xarvic])
+- Closures passed to `Label::new` can now return any type that implements `Into<ArcStr>` ([#2064] by [@jplatte])
 
 ### Deprecated
 
@@ -525,6 +526,7 @@ Last release without a changelog :(
 [@lisael]: https://github.com/lisael
 [@jenra-uwu]: https://github.com/jenra-uwu
 [@klemensn]: https://github.com/klemensn
+[@jplatte]: https://github.com/jplatte
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611
@@ -804,6 +806,7 @@ Last release without a changelog :(
 [#1978]: https://github.com/linebender/druid/pull/1978
 [#1993]: https://github.com/linebender/druid/pull/1993
 [#1996]: https://github.com/linebender/druid/pull/1996
+[#2064]: https://github.com/linebender/druid/pull/2064
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid/examples/game_of_life.rs
+++ b/druid/examples/game_of_life.rs
@@ -373,8 +373,8 @@ fn make_widget() -> impl Widget<AppData> {
                         .with_flex_child(
                             // pause / resume button
                             Button::new(|data: &bool, _: &Env| match data {
-                                true => "Resume".into(),
-                                false => "Pause".into(),
+                                true => "Resume",
+                                false => "Pause",
                             })
                             .on_click(|ctx, data: &mut bool, _: &Env| {
                                 *data = !*data;

--- a/druid/examples/value_formatting/src/widgets.rs
+++ b/druid/examples/value_formatting/src/widgets.rs
@@ -193,7 +193,7 @@ impl<W: Widget<AppData>> Controller<AppData, W> for RootController {
     ) {
         match event {
             Event::Command(cmd) if cmd.is(EDIT_BEGAN) => {
-                let widget_id = cmd.get_unchecked(EDIT_BEGAN).clone();
+                let widget_id = *cmd.get_unchecked(EDIT_BEGAN);
                 data.active_message = match widget_id {
                     DOLLAR_ERROR_WIDGET => Some(DOLLAR_EXPLAINER),
                     EURO_ERROR_WIDGET => Some(EURO_EXPLAINER),
@@ -205,7 +205,7 @@ impl<W: Widget<AppData>> Controller<AppData, W> for RootController {
                 data.active_textbox = Some(widget_id);
             }
             Event::Command(cmd) if cmd.is(EDIT_FINISHED) => {
-                let finished_id = cmd.get_unchecked(EDIT_FINISHED).clone();
+                let finished_id = *cmd.get_unchecked(EDIT_FINISHED);
                 if data.active_textbox == Some(finished_id) {
                     data.active_textbox = None;
                     data.active_message = None;
@@ -241,10 +241,10 @@ impl ValidationDelegate for TextBoxErrorDelegate {
                 ctx.submit_command(CLEAR_ERROR.to(self.target));
             }
             TextBoxEvent::PartiallyInvalid(err) if self.sends_partial_errors => {
-                ctx.submit_command(SHOW_ERROR.with(err.to_owned()).to(self.target));
+                ctx.submit_command(SHOW_ERROR.with(err).to(self.target));
             }
             TextBoxEvent::Invalid(err) => {
-                ctx.submit_command(SHOW_ERROR.with(err.to_owned()).to(self.target));
+                ctx.submit_command(SHOW_ERROR.with(err).to(self.target));
             }
             TextBoxEvent::Cancel | TextBoxEvent::Complete => {
                 ctx.submit_command(CLEAR_ERROR.to(self.target));


### PR DESCRIPTION
This should decrease copying (especially if the user-provided closure returns `Arc<str>` or something that can be converted to it without copying) and make comparisons in `resolve` faster.