### PR TITLE
wayland: cleanup popup implementation refactor.

### DIFF
--- a/druid-shell/src/backend/wayland/clipboard.rs
+++ b/druid-shell/src/backend/wayland/clipboard.rs
@@ -106,7 +106,10 @@ pub struct Manager {
 }
 
 impl Manager {
-    pub(super) fn new(display: &wl::Display, gm: &wl::GlobalManager) -> Result<Self, waylanderr::Error> {
+    pub(super) fn new(
+        display: &wl::Display,
+        gm: &wl::GlobalManager,
+    ) -> Result<Self, waylanderr::Error> {
         let m = gm
             .instantiate_exact::<wl_data_device_manager::WlDataDeviceManager>(3)
             .map_err(|e| waylanderr::Error::global("wl_data_device_manager", 1, e))?;
@@ -257,13 +260,15 @@ impl Clipboard {
     pub fn get_string(&self) -> Option<String> {
         vec![Clipboard::UTF8, Clipboard::TEXT, Clipboard::UTF8_STRING]
             .iter()
-            .find_map(|mimetype| match std::str::from_utf8(&self.inner.receive(*mimetype)?) {
-                Ok(s) => Some(s.to_string()),
-                Err(cause) => {
-                    tracing::error!("clipboard unable to retrieve utf8 content {:?}", cause);
-                    None
+            .find_map(
+                |mimetype| match std::str::from_utf8(&self.inner.receive(*mimetype)?) {
+                    Ok(s) => Some(s.to_string()),
+                    Err(cause) => {
+                        tracing::error!("clipboard unable to retrieve utf8 content {:?}", cause);
+                        None
+                    }
                 },
-            })
+            )
     }
 
     /// Given a list of supported clipboard types, returns the supported type which has

--- a/druid-shell/src/backend/wayland/mod.rs
+++ b/druid-shell/src/backend/wayland/mod.rs
@@ -16,7 +16,6 @@
 
 pub mod application;
 pub mod clipboard;
-pub mod dialog;
 pub mod error;
 mod events;
 pub mod keyboard;
@@ -24,7 +23,6 @@ pub mod menu;
 pub mod pointers;
 pub mod screen;
 pub mod surfaces;
-pub mod util;
 pub mod window;
 
 /// Little enum to make it clearer what some return values mean.

--- a/druid-shell/src/backend/wayland/pointers.rs
+++ b/druid-shell/src/backend/wayland/pointers.rs
@@ -107,6 +107,7 @@ pub(crate) enum PointerEvent {
 }
 
 /// An enum that we will convert into the different callbacks.
+#[derive(Debug)]
 pub(crate) enum MouseEvtKind {
     Move(mouse::MouseEvent),
     Up(mouse::MouseEvent),

--- a/druid-shell/src/backend/wayland/surfaces/mod.rs
+++ b/druid-shell/src/backend/wayland/surfaces/mod.rs
@@ -2,6 +2,7 @@ use wayland_client::protocol::wl_shm::WlShm;
 use wayland_client::{self as wlc, protocol::wl_surface::WlSurface};
 use wayland_protocols::unstable::xdg_decoration::v1::client::zxdg_decoration_manager_v1::ZxdgDecorationManagerV1;
 use wayland_protocols::wlr::unstable::layer_shell::v1::client::zwlr_layer_shell_v1::ZwlrLayerShellV1;
+use wayland_protocols::xdg_shell::client::xdg_popup;
 use wayland_protocols::xdg_shell::client::xdg_positioner;
 use wayland_protocols::xdg_shell::client::xdg_surface;
 
@@ -43,17 +44,11 @@ impl dyn Decor {
 }
 
 pub trait Popup {
-    fn popup_impl(&self, popup: &popup::Surface) -> Result<(), error::Error>;
-}
-
-pub struct PopupHandle {
-    inner: std::sync::Arc<dyn Popup>,
-}
-
-impl PopupHandle {
-    fn popup(&self, p: &popup::Surface) -> Result<(), error::Error> {
-        self.inner.popup_impl(p)
-    }
+    fn surface<'a>(
+        &self,
+        popup: &'a wlc::Main<xdg_surface::XdgSurface>,
+        pos: &'a wlc::Main<xdg_positioner::XdgPositioner>,
+    ) -> Result<wlc::Main<xdg_popup::XdgPopup>, error::Error>;
 }
 
 pub(super) trait Outputs {
@@ -73,7 +68,6 @@ pub trait Handle {
     fn get_idle_handle(&self) -> idle::Handle;
     fn get_scale(&self) -> Scale;
     fn run_idle(&self);
-    fn popup(&self, popup: &popup::Surface) -> Result<(), error::Error>;
     fn release(&self);
     fn data(&self) -> Option<std::sync::Arc<surface::Data>>;
 }

--- a/druid-shell/src/backend/wayland/surfaces/toplevel.rs
+++ b/druid-shell/src/backend/wayland/surfaces/toplevel.rs
@@ -6,12 +6,14 @@ use wayland_protocols::xdg_shell::client::xdg_toplevel;
 use crate::kurbo;
 use crate::window;
 
+use super::error;
 use super::surface;
 use super::Compositor;
 use super::CompositorHandle;
 use super::Decor;
 use super::Handle;
 use super::Outputs;
+use super::Popup;
 
 struct Inner {
     wl_surface: surface::Surface,
@@ -137,6 +139,17 @@ impl Surface {
     }
 }
 
+impl Popup for Surface {
+    fn surface<'a>(
+        &self,
+        popup: &'a wlc::Main<xdg_surface::XdgSurface>,
+        pos: &'a wlc::Main<wayland_protocols::xdg_shell::client::xdg_positioner::XdgPositioner>,
+    ) -> Result<wlc::Main<wayland_protocols::xdg_shell::client::xdg_popup::XdgPopup>, error::Error>
+    {
+        Ok(popup.get_popup(Some(&self.inner.xdg_surface), pos))
+    }
+}
+
 impl Decor for Surface {
     fn inner_set_title(&self, title: String) {
         self.inner.xdg_toplevel.set_title(title);
@@ -170,5 +183,11 @@ impl From<Surface> for Box<dyn Decor> {
 impl From<Surface> for Box<dyn Outputs> {
     fn from(s: Surface) -> Box<dyn Outputs> {
         Box::new(s.inner.wl_surface.clone()) as Box<dyn Outputs>
+    }
+}
+
+impl From<Surface> for Box<dyn Popup> {
+    fn from(s: Surface) -> Self {
+        Box::new(s) as Box<dyn Popup>
     }
 }

--- a/druid-shell/src/dialog.rs
+++ b/druid-shell/src/dialog.rs
@@ -37,7 +37,7 @@ pub struct FileInfo {
 }
 
 /// Type of file dialog.
-#[cfg(not(all(target_os = "linux", feature = "x11")))]
+#[cfg(not(any(all(feature = "x11", target_os = "linux"), feature = "wayland")))]
 #[derive(Clone, Copy, PartialEq)]
 pub enum FileDialogType {
     /// File open dialog.


### PR DESCRIPTION
only piece I have left at this point is the screen implementation which i need to make some improvements to before I open a PR it.

after that I'll do a rebase against master for the wayland branch. I *think* at that point it'll be close enough to mainline. PRs after the screen stuff should be minor enhancements, bug fixes (I have 1 or 2 things I might fix), or code cleanup.

still a few small odds an ends to make it feature complete (but i havent needed them so... here we are. =)).
- bunch of the window builder API stuff needs to be wired up, titles, resizable, etc. these are small though and should be easily implemented as needed.
- tooltips, and modal window levels need to be implemented. but they should be identical to the dropdowns with a different positioning configuration.
- menus/dialog stuff. these can be shared with x11 i think?
- keymapping issues (copy/paste not generating the correct keystroke of x11/wayland).

should I create issues for these things?