### PR TITLE
Align: try to keep baseline offset

### DIFF
--- a/druid/src/widget/align.rs
+++ b/druid/src/widget/align.rs
@@ -129,6 +129,13 @@ impl<T: Data> Widget<T> for Align<T> {
 
         let my_insets = self.child.compute_parent_paint_insets(my_size);
         ctx.set_paint_insets(my_insets);
+        if self.height_factor.is_some() {
+            let baseline_offset = self.child.baseline_offset();
+            if baseline_offset > 0f64 {
+                ctx.set_baseline_offset(baseline_offset + extra_height / 2.0);
+            }
+        }
+
         trace!(
             "Computed layout: origin={}, size={}, insets={:?}",
             origin,

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -198,6 +198,11 @@ impl<T: Data> Widget<T> for Container<T> {
 
         let my_insets = self.child.compute_parent_paint_insets(my_size);
         ctx.set_paint_insets(my_insets);
+        let baseline_offset = self.child.baseline_offset();
+        if baseline_offset > 0f64 {
+            ctx.set_baseline_offset(baseline_offset + border_width);
+        }
+
         trace!("Computed layout: size={}, insets={:?}", my_size, my_insets);
         my_size
     }

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -666,7 +666,7 @@ impl<T: Data> Widget<T> for Flex<T> {
         // these two are calculated but only used if we're baseline aligned
         let mut max_above_baseline = 0f64;
         let mut max_below_baseline = 0f64;
-        let mut any_use_baseline = self.cross_alignment == CrossAxisAlignment::Baseline;
+        let mut any_use_baseline = false;
 
         // Measure non-flex children.
         let mut major_non_flex = 0.0;
@@ -674,7 +674,8 @@ impl<T: Data> Widget<T> for Flex<T> {
         for child in &mut self.children {
             match child {
                 Child::Fixed { widget, alignment } => {
-                    any_use_baseline &= *alignment == Some(CrossAxisAlignment::Baseline);
+                    let alignment = alignment.unwrap_or(self.cross_alignment);
+                    any_use_baseline |= alignment == CrossAxisAlignment::Baseline;
 
                     let child_bc =
                         self.direction
@@ -717,7 +718,14 @@ impl<T: Data> Widget<T> for Flex<T> {
         // Measure flex children.
         for child in &mut self.children {
             match child {
-                Child::Flex { widget, flex, .. } => {
+                Child::Flex {
+                    widget,
+                    flex,
+                    alignment,
+                } => {
+                    let alignment = alignment.unwrap_or(self.cross_alignment);
+                    any_use_baseline |= alignment == CrossAxisAlignment::Baseline;
+
                     let desired_major = (*flex) * px_per_flex + remainder;
                     let actual_major = desired_major.round();
                     remainder = desired_major - actual_major;

--- a/druid/src/widget/padding.rs
+++ b/druid/src/widget/padding.rs
@@ -106,6 +106,10 @@ impl<T: Data, W: Widget<T>> Widget<T> for Padding<T, W> {
         let my_size = Size::new(size.width + hpad, size.height + vpad);
         let my_insets = self.child.compute_parent_paint_insets(my_size);
         ctx.set_paint_insets(my_insets);
+        let baseline_offset = self.child.baseline_offset();
+        if baseline_offset > 0f64 {
+            ctx.set_baseline_offset(baseline_offset + insets.y1);
+        }
         trace!("Computed layout: size={}, insets={:?}", my_size, my_insets);
         my_size
     }


### PR DESCRIPTION
Keep the baseline offset when height does not change (horizontal align).
This avoids alignment problems when used inside a horizontal Flex box.

Signed-off-by: Dietmar Maurer <dietmar@proxmox.com>