### PR TITLE
Fix click event handling of switch widget

### DIFF
--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -112,7 +112,7 @@ impl Widget<bool> for Switch {
                     if self.knob_dragged {
                         // toggle value when dragging if knob has been moved far enough
                         *data = self.knob_pos.x > switch_width / 2.;
-                    } else if ctx.is_active() {
+                    } else {
                         // toggle value on click
                         *data = !*data;
                     }


### PR DESCRIPTION
In the mouse click event handling of widget switch:
```rust
            Event::MouseUp(_) => {
                if !ctx.is_disabled() {
                    if self.knob_dragged {
                        // toggle value when dragging if knob has been moved far enough
                        *data = self.knob_pos.x > switch_width / 2.;
                    } else if ctx.is_active() {
                        // toggle value on click
                        *data = !*data;
                    }
                }
```
which checks the active state of ctx.