### PR TITLE
Fix missing top-level menu title on macOS

### DIFF
--- a/druid-shell/src/backend/mac/menu.rs
+++ b/druid-shell/src/backend/mac/menu.rs
@@ -75,6 +75,7 @@ impl Menu {
         unsafe {
             let menu_item = NSMenuItem::alloc(nil).autorelease();
             let title = make_nsstring(&strip_access_key(text));
+            let () = msg_send![menu.menu, setTitle: title];
             let () = msg_send![menu_item, setTitle: title];
             if !enabled {
                 let () = msg_send![menu_item, setEnabled: NO];


### PR DESCRIPTION
The pull request #2061 has fixed missing sub menu titles but breaks top-level menu titles, so I add back this line to enable setting title to top-level menus.

Fixed issue #2074.