### PR TITLE
add start_console_logging(bool) which accepts a flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - `Event::WindowScale` to notify widgets of the window's scale changes. ([#2335] by [@xStrom])
 - `Ctx::scale` method to all contexts for widgets to easily access the window's scale. ([#2335] by [@xStrom])
 - Add a public constructor to `StringCursor` ([#2319] by [@benoitryder])
+- App: add start_console_logging(bool) which accepts a flag. ([#2102] by [@ratmice])
 
 ### Changed
 
@@ -580,6 +581,7 @@ Last release without a changelog :(
 [@benoitryder]: https://github.com/benoitryder
 [@sprocklem]: https://github.com/sprocklem
 [@cbondurant]: https://github.com/cbondurant
+[@ratmice]: https://github.com/ratmice
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611
@@ -863,6 +865,7 @@ Last release without a changelog :(
 [#2036]: https://github.com/linebender/druid/pull/2036
 [#2064]: https://github.com/linebender/druid/pull/2064
 [#1979]: https://github.com/linebender/druid/pull/1979
+[#2102]: https://github.com/linebender/druid/pull/2102
 [#2119]: https://github.com/linebender/druid/pull/2119
 [#2111]: https://github.com/linebender/druid/pull/2111
 [#2117]: https://github.com/linebender/druid/pull/2117

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -190,9 +190,17 @@ impl<T: Data> AppLauncher<T> {
     ///
     /// # Panics
     ///
-    /// Panics if the subscriber fails to initialize, for example if a `tracing`/`tracing_wasm`
-    /// global logger was already set.
-    pub fn log_to_console(self) -> Self {
+    /// Panics if `enable` is `true` and the subscriber fails to initialize,
+    /// for example if a `tracing`/`tracing_wasm` global logger was already set.
+    ///
+    /// Never panics when `enable` is `false`, or have any other side effect.
+    ///
+    /// Passing in false is useful if you want to enable a global logger as feature
+    /// but log to console otherwise.
+    pub fn start_console_logging(self, enable: bool) -> Self {
+        if !enable {
+            return self;
+        }
         #[cfg(not(target_arch = "wasm32"))]
         {
             use tracing_subscriber::prelude::*;
@@ -219,6 +227,10 @@ impl<T: Data> AppLauncher<T> {
         self
     }
 
+    /// Calls `start_console_logging` with `true`.
+    pub fn log_to_console(self) -> Self {
+        self.start_console_logging(true)
+    }
     /// Use custom localization resource
     ///
     /// `resources` is a list of file names that contain strings. `base_dir`


### PR DESCRIPTION
Simple patch;

Noticed that when feature gating another logger, it seemed like it would be easier if `log_to_console` took a bool.
Because it occurs in a builder call chain, there doesn't really seem to be a convenient place for `cfg` based conditional compilation.

Not really important though