### PR TITLE
wayland: layershell memoize original display.

### DIFF
--- a/druid-shell/src/backend/wayland/clipboard.rs
+++ b/druid-shell/src/backend/wayland/clipboard.rs
@@ -92,7 +92,7 @@ impl std::fmt::Debug for Inner {
 
 #[derive(Debug, Clone)]
 pub struct Manager {
-    inner: std::sync::Arc<Inner>,
+    inner: std::rc::Rc<Inner>,
 }
 
 impl Manager {
@@ -114,7 +114,7 @@ impl Manager {
         });
 
         Ok(Self {
-            inner: std::sync::Arc::new(Inner {
+            inner: std::rc::Rc::new(Inner {
                 wobj: m,
                 wdsobj: ds,
                 display: display.clone(),

--- a/druid-shell/src/backend/wayland/display.rs
+++ b/druid-shell/src/backend/wayland/display.rs
@@ -116,7 +116,7 @@ impl GlobalEventDispatch for std::sync::Arc<Environment> {
     }
 }
 
-pub(super) fn new(dispatcher: Dispatcher) -> Result<std::sync::Arc<Environment>, error::Error> {
+pub(super) fn new(dispatcher: Dispatcher) -> Result<Environment, error::Error> {
     let dispatcher = std::sync::Arc::new(dispatcher);
     let d = wlc::Display::connect_to_env()?;
 
@@ -157,13 +157,13 @@ pub(super) fn new(dispatcher: Dispatcher) -> Result<std::sync::Arc<Environment>,
         }
     });
 
-    let env = std::sync::Arc::new(Environment {
+    let env = Environment {
         queue: std::rc::Rc::new(std::cell::RefCell::new(queue)),
         display: d,
         registry,
         xdg_base,
         dispatcher,
-    });
+    };
 
     Ok(env)
 }

--- a/druid-shell/src/backend/wayland/events.rs
+++ b/druid-shell/src/backend/wayland/events.rs
@@ -16,14 +16,14 @@ use super::{application, window};
 
 /// A wrapper around the wayland event queue that calloop knows how to select.
 pub(crate) struct WaylandSource {
-    appdata: std::sync::Arc<application::ApplicationData>,
+    appdata: std::sync::Arc<application::Data>,
     queue: Rc<RefCell<EventQueue>>,
     fd: Generic<Fd>,
 }
 
 impl WaylandSource {
     /// Wrap an `EventQueue` as a `WaylandSource`.
-    pub fn new(appdata: std::sync::Arc<application::ApplicationData>) -> WaylandSource {
+    pub fn new(appdata: std::sync::Arc<application::Data>) -> WaylandSource {
         let queue = appdata.wayland.queue.clone();
         let fd = queue.borrow().display().get_connection_fd();
         WaylandSource {
@@ -41,7 +41,7 @@ impl WaylandSource {
         impl FnMut(
             window::WindowHandle,
             &mut Rc<RefCell<EventQueue>>,
-            &mut std::sync::Arc<application::ApplicationData>,
+            &mut std::sync::Arc<application::Data>,
         ) -> io::Result<u32>,
     > {
         Dispatcher::new(self, |_winhandle, queue, appdata| {

--- a/druid-shell/src/backend/wayland/keyboard.rs
+++ b/druid-shell/src/backend/wayland/keyboard.rs
@@ -8,7 +8,7 @@ use crate::text;
 use crate::KeyEvent;
 use crate::Modifiers;
 
-use super::application::ApplicationData;
+use super::application::Data;
 use super::surfaces::buffers;
 use crate::backend::shared::xkb;
 
@@ -357,7 +357,7 @@ impl Manager {
     // TODO turn struct into a calloop event source.
     pub(super) fn events<'a>(
         &self,
-        handle: &'a calloop::LoopHandle<std::sync::Arc<ApplicationData>>,
+        handle: &'a calloop::LoopHandle<std::sync::Arc<Data>>,
     ) {
         let rx = self.inner.apprx.borrow_mut().take().unwrap();
         handle

--- a/druid-shell/src/backend/wayland/keyboard.rs
+++ b/druid-shell/src/backend/wayland/keyboard.rs
@@ -113,14 +113,12 @@ impl Keyboard {
             _ => panic!("unrecognised key event"),
         };
 
-        let mut event = self
-            .xkb_state
-            .borrow_mut()
-            .as_mut()
-            .unwrap()
-            .key_event(keystroke.key, keystate);
+        let mut event = self.xkb_state.borrow_mut().as_mut().unwrap().key_event(
+            keystroke.key,
+            keystate,
+            keystroke.repeat,
+        );
         event.mods = self.xkb_mods.get();
-        event.repeat = keystroke.repeat;
 
         if let Err(cause) = keystroke.queue.send(event) {
             tracing::error!("failed to send druid key event: {:?}", cause);
@@ -355,10 +353,7 @@ impl Manager {
     }
 
     // TODO turn struct into a calloop event source.
-    pub(super) fn events<'a>(
-        &self,
-        handle: &'a calloop::LoopHandle<std::sync::Arc<Data>>,
-    ) {
+    pub(super) fn events<'a>(&self, handle: &'a calloop::LoopHandle<std::sync::Arc<Data>>) {
         let rx = self.inner.apprx.borrow_mut().take().unwrap();
         handle
             .insert_source(rx, {

--- a/druid-shell/src/backend/wayland/outputs/output.rs
+++ b/druid-shell/src/backend/wayland/outputs/output.rs
@@ -74,7 +74,7 @@ pub fn detect(
                     if interface.as_str() != "wl_output" {
                         return;
                     }
-                    tracing::info!("output removed event {:?} {:?}", registry, interface);
+                    tracing::debug!("output removed event {:?} {:?}", registry, interface);
                 }
             };
         }
@@ -134,6 +134,10 @@ impl XdgMeta {
     }
 
     fn modify(&self, meta: &mut outputs::Meta) {
+        if !self.handled {
+            return;
+        }
+
         let state = self.state.borrow();
         meta.name = state.name.clone();
         meta.description = state.description.clone();

--- a/druid-shell/src/backend/wayland/pointers.rs
+++ b/druid-shell/src/backend/wayland/pointers.rs
@@ -9,7 +9,7 @@ use crate::keyboard::Modifiers;
 use crate::kurbo::{Point, Vec2};
 use crate::mouse;
 
-use super::application::ApplicationData;
+use super::application::Data;
 
 // Button constants (linux specific)
 const BTN_LEFT: u32 = 0x110;
@@ -226,7 +226,7 @@ impl Pointer {
     }
 
     pub(super) fn consume(
-        appdata: std::sync::Arc<ApplicationData>,
+        appdata: std::sync::Arc<Data>,
         source: wl_pointer::WlPointer,
         event: wl_pointer::Event,
     ) {

--- a/druid-shell/src/backend/wayland/surfaces/surface.rs
+++ b/druid-shell/src/backend/wayland/surfaces/surface.rs
@@ -68,6 +68,10 @@ impl Surface {
         Self { inner: current }
     }
 
+    pub(super) fn output(&self) -> Option<outputs::Meta> {
+        self.inner.output()
+    }
+
     pub(super) fn request_paint(&self) {
         self.inner.buffers.request_paint(&self.inner);
     }
@@ -247,6 +251,13 @@ pub struct Data {
 }
 
 impl Data {
+    pub(crate) fn output(&self) -> Option<outputs::Meta> {
+        match self.outputs.borrow().iter().find(|_| true) {
+            None => None,
+            Some(id) => self.compositor.output(*id),
+        }
+    }
+
     #[track_caller]
     pub(crate) fn with_handler<T, F: FnOnce(&mut dyn window::WinHandler) -> T>(
         &self,

--- a/druid-shell/src/backend/wayland/surfaces/toplevel.rs
+++ b/druid-shell/src/backend/wayland/surfaces/toplevel.rs
@@ -75,7 +75,7 @@ impl Surface {
                     height,
                     states,
                 } => {
-                    tracing::trace!(
+                    tracing::debug!(
                         "configure event {:?} {:?} {:?} {:?}",
                         width,
                         height,

--- a/druid-shell/src/backend/wayland/window.rs
+++ b/druid-shell/src/backend/wayland/window.rs
@@ -19,11 +19,7 @@ use wayland_protocols::xdg_shell::client::xdg_positioner;
 use wayland_protocols::xdg_shell::client::xdg_surface;
 
 use super::application::{self, Timer};
-use super::{
-    error::Error,
-    menu::Menu,
-    outputs, surfaces,
-};
+use super::{error::Error, menu::Menu, outputs, surfaces};
 
 use crate::{
     dialog::FileDialogOptions,

--- a/druid-shell/src/backend/wayland/window.rs
+++ b/druid-shell/src/backend/wayland/window.rs
@@ -18,8 +18,8 @@ use wayland_protocols::xdg_shell::client::xdg_popup;
 use wayland_protocols::xdg_shell::client::xdg_positioner;
 use wayland_protocols::xdg_shell::client::xdg_surface;
 
+use super::application::{self, Timer};
 use super::{
-    application::{Application, ApplicationData, Timer},
     error::Error,
     menu::Menu,
     outputs, surfaces,
@@ -46,7 +46,7 @@ struct Inner {
     pub(super) surface: Box<dyn surfaces::Handle>,
     pub(super) outputs: Box<dyn surfaces::Outputs>,
     pub(super) popup: Box<dyn surfaces::Popup>,
-    pub(super) appdata: std::sync::Weak<ApplicationData>,
+    pub(super) appdata: std::sync::Weak<application::Data>,
 }
 
 #[derive(Clone)]
@@ -80,7 +80,7 @@ impl WindowHandle {
         decor: impl Into<Box<dyn surfaces::Decor>>,
         surface: impl Into<Box<dyn surfaces::Handle>>,
         popup: impl Into<Box<dyn surfaces::Popup>>,
-        appdata: impl Into<std::sync::Weak<ApplicationData>>,
+        appdata: impl Into<std::sync::Weak<application::Data>>,
     ) -> Self {
         Self {
             inner: std::sync::Arc::new(Inner {
@@ -314,7 +314,7 @@ pub struct CustomCursor;
 
 /// Builder abstraction for creating new windows
 pub(crate) struct WindowBuilder {
-    appdata: std::sync::Weak<ApplicationData>,
+    appdata: std::sync::Weak<application::Data>,
     handler: Option<Box<dyn WinHandler>>,
     title: String,
     menu: Option<Menu>,
@@ -329,7 +329,7 @@ pub(crate) struct WindowBuilder {
 }
 
 impl WindowBuilder {
-    pub fn new(app: Application) -> WindowBuilder {
+    pub fn new(app: application::Application) -> WindowBuilder {
         WindowBuilder {
             appdata: std::sync::Arc::downgrade(&app.data),
             handler: None,
@@ -461,7 +461,7 @@ impl WindowBuilder {
     }
 
     pub(super) fn initial_window_size(
-        appdata: &ApplicationData,
+        appdata: &application::Data,
         defaults: kurbo::Size,
     ) -> kurbo::Size {
         // compute the initial window size.
@@ -493,13 +493,13 @@ pub mod layershell {
     use crate::window::WinHandler;
 
     use super::WindowHandle;
-    use crate::backend::wayland::application::{Application, ApplicationData};
+    use crate::backend::wayland::application::{Application, Data};
     use crate::backend::wayland::error::Error;
     use crate::backend::wayland::surfaces;
 
     /// Builder abstraction for creating new windows
     pub(crate) struct Builder {
-        appdata: std::sync::Weak<ApplicationData>,
+        appdata: std::sync::Weak<Data>,
         winhandle: Option<Box<dyn WinHandler>>,
         pub(crate) config: surfaces::layershell::Config,
     }
@@ -573,14 +573,14 @@ pub mod popup {
 
     use super::WindowBuilder;
     use super::WindowHandle;
-    use crate::backend::wayland::application::{Application, ApplicationData};
+    use crate::backend::wayland::application::{Application, Data};
     use crate::backend::wayland::error::Error;
     use crate::backend::wayland::surfaces;
 
     pub(super) fn create(
         parent: &WindowHandle,
         config: &surfaces::popup::Config,
-        wappdata: std::sync::Weak<ApplicationData>,
+        wappdata: std::sync::Weak<Data>,
         winhandle: Option<Box<dyn WinHandler>>,
     ) -> Result<WindowHandle, ShellError> {
         let appdata = match wappdata.upgrade() {

--- a/druid-shell/src/backend/x11/application.rs
+++ b/druid-shell/src/backend/x11/application.rs
@@ -544,9 +544,11 @@ impl Application {
                     .context("KEY_PRESS - failed to get window")?;
                 let hw_keycode = ev.detail;
                 let mut state = borrow_mut!(self.state)?;
-                let key_event = state
-                    .xkb_state
-                    .key_event(hw_keycode as _, keyboard_types::KeyState::Down);
+                let key_event = state.xkb_state.key_event(
+                    hw_keycode as _,
+                    keyboard_types::KeyState::Down,
+                    false,
+                );
 
                 w.handle_key_event(key_event);
             }
@@ -556,9 +558,10 @@ impl Application {
                     .context("KEY_PRESS - failed to get window")?;
                 let hw_keycode = ev.detail;
                 let mut state = borrow_mut!(self.state)?;
-                let key_event = state
-                    .xkb_state
-                    .key_event(hw_keycode as _, keyboard_types::KeyState::Up);
+                let key_event =
+                    state
+                        .xkb_state
+                        .key_event(hw_keycode as _, keyboard_types::KeyState::Up, false);
 
                 w.handle_key_event(key_event);
             }


### PR DESCRIPTION
when displays become unavailable (powered off, sleep, etc) and then
become available again we want to remember which output we were initial
created against so we properly restore to that display.

- fixes handling updates for windows that are not active.
- fixes #2112 