### PR TITLE
fix dropdown position for gtk backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - Tabs: allow getting and setting the tab index of a Tabs widget ([#2082] by [@rjwittams]
 - `RangeSlider` and `Annotated` ([#1979] by [@xarvic])
 - Add `Checkbox::from_label` constructor ([#2111] by [@maurerdietmar])
+- fix content_insets for gtk backend ([#2117] by [@maurerdietmar])
 
 ### Changed
 
@@ -817,6 +818,7 @@ Last release without a changelog :(
 [#2064]: https://github.com/linebender/druid/pull/2064
 [#1979]: https://github.com/linebender/druid/pull/1979
 [#2111]: https://github.com/linebender/druid/pull/2111
+[#2117]: https://github.com/linebender/druid/pull/2117
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid-shell/src/backend/gtk/window.rs
+++ b/druid-shell/src/backend/gtk/window.rs
@@ -1009,25 +1009,33 @@ impl WindowHandle {
         }
     }
 
-    /// The GTK implementation of content_insets differs from, e.g., the Windows one in that it
-    /// doesn't try to account for window decorations. Depending on the platform, GTK might not
-    /// even be aware of the size of the window decorations. And anyway, GTK's `Window::resize`
-    /// function [tries not to include] the window decorations, so it makes sense not to include
-    /// them here either.
-    ///
-    /// [tries not to include]: https://developer.gnome.org/gtk3/stable/GtkWidget.html#geometry-management
     pub fn content_insets(&self) -> Insets {
         if let Some(state) = self.state.upgrade() {
             let scale = state.scale.get();
             let (width_px, height_px) = state.window.size();
             let alloc_px = state.drawing_area.allocation();
-            let window = Size::new(width_px as f64, height_px as f64).to_dp(scale);
-            let alloc = Rect::from_origin_size(
-                (alloc_px.x as f64, alloc_px.y as f64),
-                (alloc_px.width as f64, alloc_px.height as f64),
-            )
-            .to_dp(scale);
-            window.to_rect() - alloc
+            let menu_height_px = height_px - alloc_px.height;
+
+            if let Some(window) = state.window.window() {
+                let frame = window.frame_extents();
+                let (pos_x, pos_y) = window.position();
+                Insets::new(
+                    (pos_x - frame.x) as f64,
+                    (pos_y - frame.y + menu_height_px) as f64,
+                    (frame.x + frame.width - (pos_x + width_px)) as f64,
+                    (frame.y + frame.height - (pos_y + height_px)) as f64,
+                )
+                .to_dp(scale)
+                .nonnegative()
+            } else {
+                let window = Size::new(width_px as f64, height_px as f64).to_dp(scale);
+                let alloc = Rect::from_origin_size(
+                    (alloc_px.x as f64, alloc_px.y as f64),
+                    (alloc_px.width as f64, alloc_px.height as f64),
+                )
+                .to_dp(scale);
+                window.to_rect() - alloc
+            }
         } else {
             Insets::ZERO
         }


### PR DESCRIPTION
We need to position internal windows (dropdowns, tooltips) relative
to the content area.

Signed-off-by: Dietmar Maurer <dietmar@proxmox.com>