### PR TITLE
Send the `WindowHandle` with `AppDelegate::window_added`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - Add parent windows to non-main windows. (Coordinate space is now from their origin) ([#1919] by [@JAicewizard])
 - `ListIter` implementations for `Arc<Vec<T>>`, `(S, Arc<Vec<T>>)`, `Arc<VecDequeue<T>>` and `(S, Arc<VecDequeue<T>>)` ([#1967] by [@xarvic])
 - Closures passed to `Label::new` can now return any type that implements `Into<ArcStr>` ([#2064] by [@jplatte])
+- `AppDelegate::window_added` now receives the new window's `WindowHandle`. ([#2119] by [@zedseven])
 
 ### Deprecated
 
@@ -532,6 +533,7 @@ Last release without a changelog :(
 [@klemensn]: https://github.com/klemensn
 [@agentsim]: https://github.com/agentsim
 [@jplatte]: https://github.com/jplatte
+[@zedseven]: https://github.com/zedseven
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611
@@ -814,6 +816,7 @@ Last release without a changelog :(
 [#2036]: https://github.com/linebender/druid/pull/2036
 [#2064]: https://github.com/linebender/druid/pull/2064
 [#1979]: https://github.com/linebender/druid/pull/1979
+[#2119]: https://github.com/linebender/druid/pull/2119
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -24,7 +24,7 @@ use druid::widget::{
 use druid::Target::Global;
 use druid::{
     commands as sys_cmds, AppDelegate, AppLauncher, Application, Color, Command, Data, DelegateCtx,
-    Handled, LocalizedString, Menu, MenuItem, Target, WindowDesc, WindowId,
+    Handled, LocalizedString, Menu, MenuItem, Target, WindowDesc, WindowHandle, WindowId,
 };
 use tracing::info;
 
@@ -170,6 +170,7 @@ impl AppDelegate<State> for Delegate {
     fn window_added(
         &mut self,
         id: WindowId,
+        _handle: WindowHandle,
         _data: &mut State,
         _env: &Env,
         _ctx: &mut DelegateCtx,

--- a/druid/src/app_delegate.rs
+++ b/druid/src/app_delegate.rs
@@ -18,7 +18,7 @@ use std::any::{Any, TypeId};
 
 use crate::{
     commands, core::CommandQueue, ext_event::ExtEventHost, Command, Data, Env, Event, ExtEventSink,
-    Handled, SingleUse, Target, WindowDesc, WindowId,
+    Handled, SingleUse, Target, WindowDesc, WindowHandle, WindowId,
 };
 
 /// A context passed in to [`AppDelegate`] functions.
@@ -128,7 +128,15 @@ pub trait AppDelegate<T: Data> {
     /// The handler for window creation events.
     /// This function is called after a window has been added,
     /// allowing you to customize the window creation behavior of your app.
-    fn window_added(&mut self, id: WindowId, data: &mut T, env: &Env, ctx: &mut DelegateCtx) {}
+    fn window_added(
+        &mut self,
+        id: WindowId,
+        handle: WindowHandle,
+        data: &mut T,
+        env: &Env,
+        ctx: &mut DelegateCtx,
+    ) {
+    }
 
     /// The handler for window deletion events.
     /// This function is called after a window has been removed.

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -244,7 +244,7 @@ impl<T: Data> InnerAppState<T> {
 
     fn connect(&mut self, id: WindowId, handle: WindowHandle) {
         self.windows
-            .connect(id, handle, self.ext_event_host.make_sink());
+            .connect(id, handle.clone(), self.ext_event_host.make_sink());
 
         // If the external event host has no handle, it cannot wake us
         // when an event arrives.
@@ -252,7 +252,7 @@ impl<T: Data> InnerAppState<T> {
             self.set_ext_event_idle_handler(id);
         }
 
-        self.with_delegate(|del, data, env, ctx| del.window_added(id, data, env, ctx));
+        self.with_delegate(|del, data, env, ctx| del.window_added(id, handle, data, env, ctx));
     }
 
     /// Called after this window has been closed by the platform.


### PR DESCRIPTION
Closes  #2116.

Mostly just applying @sjoshid's recommendations and updating the one example that used `window_added`.

This is a breaking change.