### PR TITLE
wayland: remove top level decorator and other wlrootisms.

### DIFF
--- a/druid-shell/src/backend/wayland/application.rs
+++ b/druid-shell/src/backend/wayland/application.rs
@@ -252,10 +252,6 @@ impl Application {
             wayland: std::rc::Rc::new(env),
         });
 
-        for m in outputs::current()? {
-            appdata.outputs.borrow_mut().insert(m.id(), m);
-        }
-
         // Collect the supported image formats.
         wl_shm.quick_assign(with_cloned!(appdata; move |d1, event, d3| {
             tracing::debug!("shared memory events {:?} {:?} {:?}", d1, event, d3);

--- a/druid-shell/src/backend/wayland/display.rs
+++ b/druid-shell/src/backend/wayland/display.rs
@@ -145,7 +145,7 @@ pub(super) fn new(dispatcher: Dispatcher) -> Result<Environment, error::Error> {
     // computation, network, ... This is good practice for all back-ends: it will improve
     // responsiveness.
     xdg_base.quick_assign(|xdg_base, event, ctx| {
-        tracing::info!(
+        tracing::debug!(
             "global xdg_base events {:?} {:?} {:?}",
             xdg_base,
             event,

--- a/druid-shell/src/backend/wayland/outputs/mod.rs
+++ b/druid-shell/src/backend/wayland/outputs/mod.rs
@@ -135,6 +135,7 @@ pub struct Mode {
 
 #[derive(Clone, Debug)]
 pub struct Meta {
+    pub output: Option<wl_output::WlOutput>,
     pub gid: u32,
     pub name: String,
     pub description: String,
@@ -153,6 +154,7 @@ pub struct Meta {
 impl Default for Meta {
     fn default() -> Self {
         Self {
+            output: None,
             gid: Default::default(),
             name: Default::default(),
             description: Default::default(),

--- a/druid-shell/src/backend/wayland/outputs/output.rs
+++ b/druid-shell/src/backend/wayland/outputs/output.rs
@@ -63,6 +63,7 @@ pub fn detect(
                             }
 
                             xdgmeta.modify(&mut m);
+                            m.output = Some(output.detach());
 
                             if let Err(cause) = outputstx.send(outputs::Event::Located(m)) {
                                 tracing::warn!("unable to transmit output {:?}", cause);

--- a/druid-shell/src/backend/wayland/surfaces/layershell.rs
+++ b/druid-shell/src/backend/wayland/surfaces/layershell.rs
@@ -194,7 +194,7 @@ impl Surface {
     ) -> Self {
         let compositor = CompositorHandle::new(c);
         let wl_surface = surface::Surface::new(compositor.clone(), handler, kurbo::Size::ZERO);
-        let ls_surface = compositor.zwlr_layershell_v1().get_layer_surface(
+        let ls_surface = compositor.zwlr_layershell_v1().unwrap().get_layer_surface(
             &wl_surface.inner.wl_surface.borrow(),
             None,
             config.layer,
@@ -320,15 +320,18 @@ impl Outputs for Surface {
             .wl_surface
             .replace(surface::Surface::replace(&sdata));
         let sdata = self.inner.wl_surface.borrow().inner.clone();
-        let replacedlayershell =
-            self.inner
-                .ls_surface
-                .replace(sdata.compositor.zwlr_layershell_v1().get_layer_surface(
+        let replacedlayershell = self.inner.ls_surface.replace(
+            sdata
+                .compositor
+                .zwlr_layershell_v1()
+                .unwrap()
+                .get_layer_surface(
                     &self.inner.wl_surface.borrow().inner.wl_surface.borrow(),
                     None,
                     self.inner.config.layer,
                     self.inner.config.namespace.to_string(),
-                ));
+                ),
+        );
 
         Surface::initialize(self);
         replacedlayershell.destroy();

--- a/druid-shell/src/backend/wayland/surfaces/mod.rs
+++ b/druid-shell/src/backend/wayland/surfaces/mod.rs
@@ -1,6 +1,5 @@
 use wayland_client::protocol::wl_shm::WlShm;
 use wayland_client::{self as wlc, protocol::wl_surface::WlSurface};
-use wayland_protocols::unstable::xdg_decoration::v1::client::zxdg_decoration_manager_v1::ZxdgDecorationManagerV1;
 use wayland_protocols::wlr::unstable::layer_shell::v1::client::zwlr_layer_shell_v1::ZwlrLayerShellV1;
 use wayland_protocols::xdg_shell::client::xdg_popup;
 use wayland_protocols::xdg_shell::client::xdg_positioner;
@@ -29,8 +28,7 @@ pub trait Compositor {
     fn get_xdg_surface(&self, surface: &wlc::Main<WlSurface>)
         -> wlc::Main<xdg_surface::XdgSurface>;
     fn get_xdg_positioner(&self) -> wlc::Main<xdg_positioner::XdgPositioner>;
-    fn zxdg_decoration_manager_v1(&self) -> wlc::Main<ZxdgDecorationManagerV1>;
-    fn zwlr_layershell_v1(&self) -> wlc::Main<ZwlrLayerShellV1>;
+    fn zwlr_layershell_v1(&self) -> Option<wlc::Main<ZwlrLayerShellV1>>;
 }
 
 pub trait Decor {
@@ -157,19 +155,13 @@ impl Compositor for CompositorHandle {
         }
     }
 
-    fn zxdg_decoration_manager_v1(&self) -> wlc::Main<ZxdgDecorationManagerV1> {
+    fn zwlr_layershell_v1(&self) -> Option<wlc::Main<ZwlrLayerShellV1>> {
         match self.inner.upgrade() {
             None => {
-                panic!("unable to acquire underlying compositor to acquire the decoration manager")
-            }
-            Some(c) => c.zxdg_decoration_manager_v1(),
-        }
-    }
-
-    fn zwlr_layershell_v1(&self) -> wlc::Main<ZwlrLayerShellV1> {
-        match self.inner.upgrade() {
-            None => {
-                panic!("unable to acquire underlying compositor to acquire the layershell manager")
+                tracing::warn!(
+                    "unable to acquire underyling compositor to acquire the layershell manager"
+                );
+                None
             }
             Some(c) => c.zwlr_layershell_v1(),
         }


### PR DESCRIPTION
resolves obvious issues with running on a mutter wayland compositor.

fundamentally this allows druid applications to render on mutter using wayland.

fixes #2126 