### PR TITLE
Updated Scroll_to_View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ You can find its changes [documented below](#070---2021-01-01).
 - `RangeSlider` and `Annotated` ([#1979] by [@xarvic])
 - Add `Checkbox::from_label` constructor ([#2111] by [@maurerdietmar])
 - fix content_insets for gtk backend ([#2117] by [@maurerdietmar])
+- `ClipBox::managed`, `Notification::known_target` and `Notification::has_known_target` ([#2141] by [@xarvic])
+- `ClipBox` and `Tabs` handle SCROLL_TO_VIEW ([#2141] by [@xarvic])
+- `EventCtx::submit_notification_unknown_target` ([#2141] by [@xarvic])
 
 ### Changed
 
@@ -91,6 +94,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - Closures passed to `Label::new` can now return any type that implements `Into<ArcStr>` ([#2064] by [@jplatte])
 - `AppDelegate::window_added` now receives the new window's `WindowHandle`. ([#2119] by [@zedseven])
 - Removed line of code that prevented window miximalization. ([#2113] by [@Pavel-N])
+- Dont warn about unhandled `Notification`s which have `known_target` set to false ([#2141] by [@xarvic])
 
 ### Deprecated
 
@@ -826,8 +830,9 @@ Last release without a changelog :(
 [#2119]: https://github.com/linebender/druid/pull/2119
 [#2111]: https://github.com/linebender/druid/pull/2111
 [#2117]: https://github.com/linebender/druid/pull/2117
+[#2117]: https://github.com/linebender/druid/pull/2141
 
-[Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
+[Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...masteru
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/linebender/druid/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/linebender/druid/compare/v0.4.0...v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -832,7 +832,7 @@ Last release without a changelog :(
 [#2117]: https://github.com/linebender/druid/pull/2117
 [#2117]: https://github.com/linebender/druid/pull/2141
 
-[Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...masteru
+[Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/linebender/druid/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/linebender/druid/compare/v0.4.0...v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,9 +66,9 @@ You can find its changes [documented below](#070---2021-01-01).
 - `RangeSlider` and `Annotated` ([#1979] by [@xarvic])
 - Add `Checkbox::from_label` constructor ([#2111] by [@maurerdietmar])
 - fix content_insets for gtk backend ([#2117] by [@maurerdietmar])
-- `ClipBox::managed`, `Notification::known_target` and `Notification::has_known_target` ([#2141] by [@xarvic])
+- `ClipBox::managed`, `Notification::warn_if_ununsed` and `Notification::warn_if_ununsed_set` ([#2141] by [@xarvic])
 - `ClipBox` and `Tabs` handle SCROLL_TO_VIEW ([#2141] by [@xarvic])
-- `EventCtx::submit_notification_unknown_target` ([#2141] by [@xarvic])
+- `EventCtx::submit_notification_without_warning` ([#2141] by [@xarvic])
 
 ### Changed
 

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -347,7 +347,7 @@ pub mod sys {
     /// a new `SCROLL_TO_VIEW` notification with the same region relative to the new child position.
     ///
     /// When building a new widget using ClipBox take a look at [`ClipBox::managed`] and
-    /// [`ClipBox::default_scroll_to_view_handling`].
+    /// [`Viewport::default_scroll_to_view_handling`].
     ///
     /// [`scroll_to_view`]: crate::EventCtx::scroll_to_view()
     /// [`scroll_area_to_view`]: crate::EventCtx::scroll_area_to_view()

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -352,7 +352,7 @@ pub mod sys {
     /// [`scroll_to_view`]: crate::EventCtx::scroll_to_view()
     /// [`scroll_area_to_view`]: crate::EventCtx::scroll_area_to_view()
     /// [`ClipBox::managed`]: crate::widget::ClipBox::managed()
-    /// [`ClipBox::default_scroll_to_view_handling`]: crate::widget::ClipBox::default_scroll_to_view_handling()
+    /// [`Viewport::default_scroll_to_view_handling`]: crate::widget::Viewport::default_scroll_to_view_handling()
     pub const SCROLL_TO_VIEW: Selector<Rect> = Selector::new("druid-builtin.scroll-to");
 
     /// A change that has occured to text state, and needs to be

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -104,7 +104,7 @@ pub struct Notification {
     payload: Arc<dyn Any>,
     source: WidgetId,
     route: WidgetId,
-    known_target: bool,
+    warn_if_unused: bool,
 }
 
 /// A wrapper type for [`Command`] payloads that should only be used once.
@@ -435,7 +435,7 @@ impl Command {
             payload: self.payload,
             source,
             route: source,
-            known_target: true,
+            warn_if_unused: true,
         }
     }
 
@@ -558,17 +558,17 @@ impl Notification {
         self.source
     }
 
-    /// If set to false this notification will not produce a warning when reaching the root widget.
+    /// Builder-style method to set warn_if_unused.
     ///
     /// The default is true.
-    pub fn known_target(mut self, known_target: bool) -> Self {
-        self.known_target = known_target;
+    pub fn warn_if_unused(mut self, warn_if_unused: bool) -> Self {
+        self.warn_if_unused = warn_if_unused;
         self
     }
 
-    /// Returns whether this notification was sent to a specific widget.
-    pub fn has_known_target(&self) -> bool {
-        self.known_target
+    /// Returns whether there should be a warning when no widget handles this notification.
+    pub fn warn_if_unused_set(&self) -> bool {
+        self.warn_if_unused
     }
 
     /// Change the route id

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -548,20 +548,20 @@ impl EventCtx<'_, '_> {
         self.notifications.push_back(note);
     }
 
-    /// Submit a [`Notification`] with unknown target.
+    /// Submit a [`Notification`] without warning.
     ///
-    /// In contrast to [`submit_notification`], calling this method will result in an
+    /// In contrast to [`submit_notification`], calling this method will not result in an
     /// "unhandled notification" warning.
     ///
     /// [`submit_notification`]: crate::EventCtx::submit_notification
     //TODO: decide if we should use a known_target flag on submit_notification instead,
     // which would be a breaking change.
-    pub fn submit_notification_unknown_target(&mut self, note: impl Into<Command>) {
+    pub fn submit_notification_without_warning(&mut self, note: impl Into<Command>) {
         trace!("submit_notification");
         let note = note
             .into()
             .into_notification(self.widget_state.id)
-            .known_target(false);
+            .warn_if_unused(false);
         self.notifications.push_back(note);
     }
 

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -465,8 +465,11 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
     ///
     /// If the widget is [`hidden`], this method has no effect.
     ///
+    /// This functionality is achieved by sending a [`SCROLL_TO_VIEW`] notification.
+    ///
     /// [`Scroll`]: crate::widget::Scroll
     /// [`hidden`]: crate::Event::should_propagate_to_hidden
+    /// [`SCROLL_TO_VIEW`]: crate::commands::SCROLL_TO_VIEW
     pub fn scroll_to_view(&mut self) {
         self.scroll_area_to_view(self.size().to_rect())
     }
@@ -542,6 +545,20 @@ impl EventCtx<'_, '_> {
     pub fn submit_notification(&mut self, note: impl Into<Command>) {
         trace!("submit_notification");
         let note = note.into().into_notification(self.widget_state.id);
+        self.notifications.push_back(note);
+    }
+
+    /// Submit a [`Notification`] with unknown target.
+    ///
+    /// In contrast to [`submit_notification`], calling this method will result in an
+    /// "unhandled notification" warning.
+    ///
+    /// [`submit_notification`]: crate::EventCtx::submit_notification
+    //TODO: decide if we should use a known_target flag on submit_notification instead,
+    // which would be a breaking change.
+    pub fn submit_notification_unknown_target(&mut self, note: impl Into<Command>) {
+        trace!("submit_notification");
+        let note = note.into().into_notification(self.widget_state.id).known_target(false);
         self.notifications.push_back(note);
     }
 
@@ -716,7 +733,7 @@ impl EventCtx<'_, '_> {
     /// [`hidden`]: crate::Event::should_propagate_to_hidden
     pub fn scroll_area_to_view(&mut self, area: Rect) {
         //TODO: only do something if this widget is not hidden
-        self.submit_notification(SCROLL_TO_VIEW.with(area + self.window_origin().to_vec2()));
+        self.submit_notification_unknown_target(SCROLL_TO_VIEW.with(area + self.window_origin().to_vec2()));
     }
 }
 

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -736,7 +736,7 @@ impl EventCtx<'_, '_> {
     /// [`hidden`]: crate::Event::should_propagate_to_hidden
     pub fn scroll_area_to_view(&mut self, area: Rect) {
         //TODO: only do something if this widget is not hidden
-        self.submit_notification_unknown_target(
+        self.submit_notification_without_warning(
             SCROLL_TO_VIEW.with(area + self.window_origin().to_vec2()),
         );
     }

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -558,7 +558,10 @@ impl EventCtx<'_, '_> {
     // which would be a breaking change.
     pub fn submit_notification_unknown_target(&mut self, note: impl Into<Command>) {
         trace!("submit_notification");
-        let note = note.into().into_notification(self.widget_state.id).known_target(false);
+        let note = note
+            .into()
+            .into_notification(self.widget_state.id)
+            .known_target(false);
         self.notifications.push_back(note);
     }
 
@@ -733,7 +736,9 @@ impl EventCtx<'_, '_> {
     /// [`hidden`]: crate::Event::should_propagate_to_hidden
     pub fn scroll_area_to_view(&mut self, area: Rect) {
         //TODO: only do something if this widget is not hidden
-        self.submit_notification_unknown_target(SCROLL_TO_VIEW.with(area + self.window_origin().to_vec2()));
+        self.submit_notification_unknown_target(
+            SCROLL_TO_VIEW.with(area + self.window_origin().to_vec2()),
+        );
     }
 }
 

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -849,7 +849,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                     // Submit the SCROLL_TO notification if it was used from a update or lifecycle
                     // call.
                     let rect = cmd.get_unchecked(SCROLL_TO_VIEW);
-                    inner_ctx.submit_notification_unknown_target(SCROLL_TO_VIEW.with(*rect));
+                    inner_ctx.submit_notification_without_warning(SCROLL_TO_VIEW.with(*rect));
                     ctx.is_handled = true;
                 }
                 _ => {

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -849,7 +849,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                     // Submit the SCROLL_TO notification if it was used from a update or lifecycle
                     // call.
                     let rect = cmd.get_unchecked(SCROLL_TO_VIEW);
-                    inner_ctx.submit_notification(SCROLL_TO_VIEW.with(*rect));
+                    inner_ctx.submit_notification_unknown_target(SCROLL_TO_VIEW.with(*rect));
                     ctx.is_handled = true;
                 }
                 _ => {

--- a/druid/src/widget/clip_box.rs
+++ b/druid/src/widget/clip_box.rs
@@ -123,6 +123,11 @@ impl Viewport {
         let new_origin = self.view_origin + Vec2::new(delta_x, delta_y);
         self.pan_to(new_origin)
     }
+
+    pub fn default_scroll_to_view_handling(&mut self, ctx: &mut EventCtx, global_highlight_rect: Rect) {
+        let global_viewport_rect = self.viewport_size().to_rect() + ctx.window_origin().to_vec2();
+
+    }
 }
 
 /// A widget exposing a rectangular view into its child, which can be used as a building block for
@@ -345,19 +350,7 @@ impl<T, W: Widget<T>> ClipBox<T, W> {
     ) -> bool {
         let mut viewport_changed = false;
         self.with_port(|port| {
-            let global_content_offset = ctx.window_origin().to_vec2() - port.view_origin.to_vec2();
-            let content_highlight_rect = global_highlight_rect - global_content_offset;
 
-            if port.pan_to_visible(content_highlight_rect) {
-                ctx.request_paint();
-                viewport_changed = true;
-            }
-
-            // This is a new value since view_origin has changed in the meantime
-            let global_content_offset = ctx.window_origin().to_vec2() - port.view_origin.to_vec2();
-            ctx.submit_notification(
-                SCROLL_TO_VIEW.with(content_highlight_rect + global_content_offset),
-            );
         });
         viewport_changed
     }

--- a/druid/src/widget/clip_box.rs
+++ b/druid/src/widget/clip_box.rs
@@ -366,7 +366,7 @@ impl<T, W: Widget<T>> ClipBox<T, W> {
         let global_viewport_rect = self.viewport_size().to_rect() + ctx.window_origin().to_vec2();
         let clipped_highlight_rect = global_highlight_rect.intersect(global_viewport_rect);
 
-        if clipped_highlight_rect.size() > 0.0 {
+        if clipped_highlight_rect.area() > 0.0 {
             ctx.submit_notification(SCROLL_TO_VIEW.with(clipped_highlight_rect));
         }
     }
@@ -389,7 +389,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for ClipBox<T, W> {
             let viewport = ctx.size().to_rect();
             let force_event = self.child.is_hot() || self.child.has_active();
             if let Some(child_event) =
-            event.transform_scroll(self.viewport_origin().to_vec2(), viewport, force_event)
+                event.transform_scroll(self.viewport_origin().to_vec2(), viewport, force_event)
             {
                 self.child.event(ctx, &child_event, data, env);
             }

--- a/druid/src/widget/clip_box.rs
+++ b/druid/src/widget/clip_box.rs
@@ -18,7 +18,7 @@ use crate::kurbo::{Affine, Point, Rect, Size, Vec2};
 use crate::widget::prelude::*;
 use crate::widget::Axis;
 use crate::{Data, WidgetPod};
-use tracing::{instrument, trace, info, warn};
+use tracing::{info, instrument, trace, warn};
 
 /// Represents the size and position of a rectangular "viewport" into a larger area.
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
@@ -132,12 +132,21 @@ impl Viewport {
     /// [`SCROLL_TO_VIEW`]: crate::commands::SCROLL_TO_VIEW
     /// [`scroll_to_view`]: crate::EventCtx::scroll_to_view()
     /// [`scroll_area_to_view`]: crate::EventCtx::scroll_area_to_view()
-    pub fn default_scroll_to_view_handling(&mut self, ctx: &mut EventCtx, global_highlight_rect: Rect) -> bool {
+    pub fn default_scroll_to_view_handling(
+        &mut self,
+        ctx: &mut EventCtx,
+        global_highlight_rect: Rect,
+    ) -> bool {
         let mut viewport_changed = false;
         let global_content_offset = ctx.window_origin().to_vec2() - self.view_origin.to_vec2();
-        let mut content_highlight_rect = global_highlight_rect - global_content_offset;
+        let content_highlight_rect = global_highlight_rect - global_content_offset;
 
-        if self.content_size.to_rect().intersect(content_highlight_rect) != content_highlight_rect {
+        if self
+            .content_size
+            .to_rect()
+            .intersect(content_highlight_rect)
+            != content_highlight_rect
+        {
             warn!("tried to bring area outside of the content to view!");
         }
 
@@ -161,7 +170,12 @@ impl Viewport {
     /// [`SCROLL_TO_VIEW`]: crate::commands::SCROLL_TO_VIEW
     /// [`scroll_to_view`]: crate::EventCtx::scroll_to_view()
     /// [`scroll_area_to_view`]: crate::EventCtx::scroll_area_to_view()
-    pub fn fixed_scroll_to_view_handling(&self, ctx: &mut EventCtx, global_highlight_rect: Rect, source: WidgetId) {
+    pub fn fixed_scroll_to_view_handling(
+        &self,
+        ctx: &mut EventCtx,
+        global_highlight_rect: Rect,
+        source: WidgetId,
+    ) {
         let global_viewport_rect = self.view_rect() + ctx.window_origin().to_vec2();
         let clipped_highlight_rect = global_highlight_rect.intersect(global_viewport_rect);
 
@@ -397,7 +411,11 @@ impl<T: Data, W: Widget<T>> Widget<T> for ClipBox<T, W> {
                     // to this ClipBox's viewport.
                     ctx.set_handled();
                     self.with_port(|port| {
-                        port.fixed_scroll_to_view_handling(ctx, *global_highlight_rect, notification.source());
+                        port.fixed_scroll_to_view_handling(
+                            ctx,
+                            *global_highlight_rect,
+                            notification.source(),
+                        );
                     });
                 }
             }

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -195,8 +195,8 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                 if let Event::Notification(notification) = event {
                     if let Some(&global_highlight_rect) = notification.get(SCROLL_TO_VIEW) {
                         ctx.set_handled();
-                        let view_port_changed = port
-                            .default_scroll_to_view_handling(ctx, global_highlight_rect);
+                        let view_port_changed =
+                            port.default_scroll_to_view_handling(ctx, global_highlight_rect);
                         if view_port_changed {
                             scroll_component
                                 .reset_scrollbar_fade(|duration| ctx.request_timer(duration), env);
@@ -205,8 +205,6 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                 }
             }
         });
-
-
     }
 
     #[instrument(name = "Scroll", level = "trace", skip(self, ctx, event, data, env))]

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -46,7 +46,7 @@ impl<T, W: Widget<T>> Scroll<T, W> {
     /// [horizontal](#method.horizontal) methods to limit scrolling to a specific axis.
     pub fn new(child: W) -> Scroll<T, W> {
         Scroll {
-            clip: ClipBox::new(child).managed(),
+            clip: ClipBox::managed(child),
             scroll_component: ScrollComponent::new(),
         }
     }
@@ -189,23 +189,24 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
         // scrolling.
         self.clip.with_port(|port| {
             scroll_component.handle_scroll(port, ctx, event, env);
-        });
 
-        if !self.scroll_component.are_bars_held() {
-            // We only scroll to the component if the user is not trying to move the scrollbar.
-            if let Event::Notification(notification) = event {
-                if let Some(&global_highlight_rect) = notification.get(SCROLL_TO_VIEW) {
-                    ctx.set_handled();
-                    let view_port_changed = self
-                        .clip
-                        .default_scroll_to_view_handling(ctx, global_highlight_rect);
-                    if view_port_changed {
-                        self.scroll_component
-                            .reset_scrollbar_fade(|duration| ctx.request_timer(duration), env);
+            if !scroll_component.are_bars_held() {
+                // We only scroll to the component if the user is not trying to move the scrollbar.
+                if let Event::Notification(notification) = event {
+                    if let Some(&global_highlight_rect) = notification.get(SCROLL_TO_VIEW) {
+                        ctx.set_handled();
+                        let view_port_changed = port
+                            .default_scroll_to_view_handling(ctx, global_highlight_rect);
+                        if view_port_changed {
+                            scroll_component
+                                .reset_scrollbar_fade(|duration| ctx.request_timer(duration), env);
+                        }
                     }
                 }
             }
-        }
+        });
+
+
     }
 
     #[instrument(name = "Scroll", level = "trace", skip(self, ctx, event, data, env))]

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -46,7 +46,7 @@ impl<T, W: Widget<T>> Scroll<T, W> {
     /// [horizontal](#method.horizontal) methods to limit scrolling to a specific axis.
     pub fn new(child: W) -> Scroll<T, W> {
         Scroll {
-            clip: ClipBox::new(child),
+            clip: ClipBox::new(child).managed(),
             scroll_component: ScrollComponent::new(),
         }
     }

--- a/druid/src/widget/tabs.rs
+++ b/druid/src/widget/tabs.rs
@@ -26,6 +26,7 @@ use crate::kurbo::{Circle, Line};
 use crate::widget::prelude::*;
 use crate::widget::{Axis, Flex, Label, LabelText, LensScopeTransfer, Painter, Scope, ScopePolicy};
 use crate::{theme, Affine, Data, Insets, Lens, Point, SingleUse, WidgetExt, WidgetPod};
+use crate::commands::SCROLL_TO_VIEW;
 
 type TabsScope<TP> = Scope<TabsScopePolicy<TP>, Box<dyn Widget<TabsState<TP>>>>;
 type TabBodyPod<TP> = WidgetPod<<TP as TabsPolicy>::Input, <TP as TabsPolicy>::BodyWidget>;
@@ -579,12 +580,21 @@ impl<TP: TabsPolicy> TabsBody<TP> {
 impl<TP: TabsPolicy> Widget<TabsState<TP>> for TabsBody<TP> {
     #[instrument(name = "TabsBody", level = "trace", skip(self, ctx, event, data, env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut TabsState<TP>, env: &Env) {
-        if event.should_propagate_to_hidden() {
-            for child in self.child_pods() {
+        if let Event::Notification(notification) = event {
+            if notification.is(SCROLL_TO_VIEW) &&
+                Some(notification.route()) != self.active_child(data).map(|w|w.id())
+            {
+                // Ignore SCROLL_TO_VIEW requests from every widget except the active.
+                ctx.set_handled();
+            }
+        } else {
+            if event.should_propagate_to_hidden() {
+                for child in self.child_pods() {
+                    child.event(ctx, event, &mut data.inner, env);
+                }
+            } else if let Some(child) = self.active_child(data) {
                 child.event(ctx, event, &mut data.inner, env);
             }
-        } else if let Some(child) = self.active_child(data) {
-            child.event(ctx, event, &mut data.inner, env);
         }
 
         if let (Some(t_state), Event::AnimFrame(interval)) = (&mut self.transition_state, event) {

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -290,11 +290,13 @@ impl<T: Data> Window<T> {
                 self.root.event(&mut ctx, &event, data, env);
             }
 
+            ctx.notifications.retain(|n|n.has_known_target());
             if !ctx.notifications.is_empty() {
                 info!("{} unhandled notifications:", ctx.notifications.len());
                 for (i, n) in ctx.notifications.iter().enumerate() {
                     info!("{}: {:?}", i, n);
                 }
+                info!("if this was intended use EventCtx::submit_notification_unknown_target instead");
             }
             Handled::from(ctx.is_handled)
         };

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -290,7 +290,7 @@ impl<T: Data> Window<T> {
                 self.root.event(&mut ctx, &event, data, env);
             }
 
-            ctx.notifications.retain(|n| n.has_known_target());
+            ctx.notifications.retain(|n| n.warn_if_unused_set());
             if !ctx.notifications.is_empty() {
                 info!("{} unhandled notifications:", ctx.notifications.len());
                 for (i, n) in ctx.notifications.iter().enumerate() {

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -290,13 +290,15 @@ impl<T: Data> Window<T> {
                 self.root.event(&mut ctx, &event, data, env);
             }
 
-            ctx.notifications.retain(|n|n.has_known_target());
+            ctx.notifications.retain(|n| n.has_known_target());
             if !ctx.notifications.is_empty() {
                 info!("{} unhandled notifications:", ctx.notifications.len());
                 for (i, n) in ctx.notifications.iter().enumerate() {
                     info!("{}: {:?}", i, n);
                 }
-                info!("if this was intended use EventCtx::submit_notification_unknown_target instead");
+                info!(
+                    "if this was intended use EventCtx::submit_notification_unknown_target instead"
+                );
             }
             Handled::from(ctx.is_handled)
         };


### PR DESCRIPTION
This PR adds that `ClipBox` and `Tabs` can handle `scroll_to_view`.

- ClipBox discards scroll_to_view_requests for hidden areas unless `managed()` was called.
- Tabs discards all scroll_to_view requests which originate from hidden widgets.
- `Notification` now has a `known_target` flag. When set to false there will be no warning even if the notification reaches the root widget.