### PR TITLE
Cache layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - `ClipBox::managed`, `Notification::warn_if_ununsed` and `Notification::warn_if_ununsed_set` ([#2141] by [@xarvic])
 - `ClipBox` and `Tabs` handle SCROLL_TO_VIEW ([#2141] by [@xarvic])
 - `EventCtx::submit_notification_without_warning` ([#2141] by [@xarvic])
+- `WidgetPod::requested_layout` ([#2145] by [@xarvic])
 
 ### Changed
 
@@ -95,6 +96,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - `AppDelegate::window_added` now receives the new window's `WindowHandle`. ([#2119] by [@zedseven])
 - Removed line of code that prevented window miximalization. ([#2113] by [@Pavel-N])
 - Dont warn about unhandled `Notification`s which have `known_target` set to false ([#2141] by [@xarvic])
+- `ClipBox`, `Flex`, `List` and `Split` only call layout on children which need it ([#2145] by [@xarvic]) 
 
 ### Deprecated
 
@@ -831,6 +833,7 @@ Last release without a changelog :(
 [#2111]: https://github.com/linebender/druid/pull/2111
 [#2117]: https://github.com/linebender/druid/pull/2117
 [#2117]: https://github.com/linebender/druid/pull/2141
+[#2145]: https://github.com/linebender/druid/pull/2145
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid/src/box_constraints.rs
+++ b/druid/src/box_constraints.rs
@@ -34,7 +34,7 @@ use crate::kurbo::Size;
 /// [`layout`]: trait.Widget.html#tymethod.layout
 /// [Flutter BoxConstraints]: https://api.flutter.dev/flutter/rendering/BoxConstraints-class.html
 /// [rounded away from zero]: struct.Size.html#method.expand
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BoxConstraints {
     min: Size,
     max: Size,

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -243,6 +243,11 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
         self.state.id
     }
 
+    /// This widget or any of its children has requested layout
+    pub fn layout_requested(&self) -> bool {
+        self.state.needs_layout
+    }
+
     /// Set the layout [`Rect`].
     ///
     /// This is soft-deprecated; you should use [`set_origin`] instead for new code.

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -682,7 +682,6 @@ impl<T: Data> Widget<T> for Flex<T> {
         for child in &mut self.children {
             match child {
                 Child::Fixed { widget, alignment } => {
-
                     // The BoxConstrains of fixed-children only depends on the BoxConstrains of the
                     // Flex widget.
                     let child_size = if bc_changed || widget.layout_requested() {
@@ -746,7 +745,6 @@ impl<T: Data> Widget<T> for Flex<T> {
                     flex,
                     alignment,
                 } => {
-
                     // The BoxConstrains of flex-children depends on the size of every sibling, which
                     // received layout earlier. Therefore we use any_changed.
                     let child_size = if any_changed || widget.layout_requested() {

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -142,6 +142,7 @@ pub struct Flex<T> {
     main_alignment: MainAxisAlignment,
     fill_major_axis: bool,
     children: Vec<Child<T>>,
+    old_bc: BoxConstraints,
 }
 
 /// Optional parameters for an item in a [`Flex`] container (row or column).
@@ -375,6 +376,7 @@ impl<T: Data> Flex<T> {
             cross_alignment: CrossAxisAlignment::Center,
             main_alignment: MainAxisAlignment::Start,
             fill_major_axis: false,
+            old_bc: BoxConstraints::tight(Size::ZERO),
         }
     }
 
@@ -668,28 +670,49 @@ impl<T: Data> Widget<T> for Flex<T> {
         let mut max_below_baseline = 0f64;
         let mut any_use_baseline = false;
 
+        // indicates that the box constrains for the following children have changed. Therefore they
+        // have to calculate layout again.
+        let bc_changed = self.old_bc != *bc;
+        let mut any_changed = bc_changed;
+        self.old_bc = *bc;
+
         // Measure non-flex children.
         let mut major_non_flex = 0.0;
         let mut flex_sum = 0.0;
         for child in &mut self.children {
             match child {
                 Child::Fixed { widget, alignment } => {
-                    let alignment = alignment.unwrap_or(self.cross_alignment);
-                    any_use_baseline |= alignment == CrossAxisAlignment::Baseline;
 
-                    let child_bc =
-                        self.direction
-                            .constraints(&loosened_bc, 0.0, std::f64::INFINITY);
-                    let child_size = widget.layout(ctx, &child_bc, data, env);
+                    // The BoxConstrains of fixed-children only depends on the BoxConstrains of the
+                    // Flex widget.
+                    let child_size = if bc_changed || widget.layout_requested() {
+                        let alignment = alignment.unwrap_or(self.cross_alignment);
+                        any_use_baseline |= alignment == CrossAxisAlignment::Baseline;
+
+                        let old_size = widget.layout_rect().size();
+                        let child_bc =
+                            self.direction
+                                .constraints(&loosened_bc, 0.0, std::f64::INFINITY);
+                        let child_size = widget.layout(ctx, &child_bc, data, env);
+
+                        if child_size.width.is_infinite() {
+                            tracing::warn!("A non-Flex child has an infinite width.");
+                        }
+
+                        if child_size.height.is_infinite() {
+                            tracing::warn!("A non-Flex child has an infinite height.");
+                        }
+
+                        if old_size != child_size {
+                            any_changed = true;
+                        }
+
+                        child_size
+                    } else {
+                        widget.layout_rect().size()
+                    };
+
                     let baseline_offset = widget.baseline_offset();
-
-                    if child_size.width.is_infinite() {
-                        tracing::warn!("A non-Flex child has an infinite width.");
-                    }
-
-                    if child_size.height.is_infinite() {
-                        tracing::warn!("A non-Flex child has an infinite height.");
-                    }
 
                     major_non_flex += self.direction.major(child_size).expand();
                     minor = minor.max(self.direction.minor(child_size).expand());
@@ -723,15 +746,30 @@ impl<T: Data> Widget<T> for Flex<T> {
                     flex,
                     alignment,
                 } => {
-                    let alignment = alignment.unwrap_or(self.cross_alignment);
-                    any_use_baseline |= alignment == CrossAxisAlignment::Baseline;
 
-                    let desired_major = (*flex) * px_per_flex + remainder;
-                    let actual_major = desired_major.round();
-                    remainder = desired_major - actual_major;
+                    // The BoxConstrains of flex-children depends on the size of every sibling, which
+                    // received layout earlier. Therefore we use any_changed.
+                    let child_size = if any_changed || widget.layout_requested() {
+                        let alignment = alignment.unwrap_or(self.cross_alignment);
+                        any_use_baseline |= alignment == CrossAxisAlignment::Baseline;
 
-                    let child_bc = self.direction.constraints(&loosened_bc, 0.0, actual_major);
-                    let child_size = widget.layout(ctx, &child_bc, data, env);
+                        let desired_major = (*flex) * px_per_flex + remainder;
+                        let actual_major = desired_major.round();
+                        remainder = desired_major - actual_major;
+
+                        let old_size = widget.layout_rect().size();
+                        let child_bc = self.direction.constraints(&loosened_bc, 0.0, actual_major);
+                        let child_size = widget.layout(ctx, &child_bc, data, env);
+
+                        if old_size != child_size {
+                            any_changed = true;
+                        }
+
+                        child_size
+                    } else {
+                        widget.layout_rect().size()
+                    };
+
                     let baseline_offset = widget.baseline_offset();
 
                     major_flex += self.direction.major(child_size).expand();
@@ -796,8 +834,13 @@ impl<T: Data> Widget<T> for Flex<T> {
                                 .direction
                                 .pack(self.direction.major(child_size), minor_dim)
                                 .into();
-                            let child_bc = BoxConstraints::tight(fill_size);
-                            widget.layout(ctx, &child_bc, data, env);
+                            if widget.layout_rect().size() != fill_size {
+                                let child_bc = BoxConstraints::tight(fill_size);
+                                //TODO: this is the second call of layout on the same child, which
+                                // is bad, because it can lead to exponential increase in layout calls
+                                // when used multiple times in the widget hierarchy.
+                                widget.layout(ctx, &child_bc, data, env);
+                            }
                             0.0
                         }
                         _ => {

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -39,6 +39,7 @@ pub struct List<T> {
     children: Vec<WidgetPod<T, Box<dyn Widget<T>>>>,
     axis: Axis,
     spacing: KeyOrValue<f64>,
+    old_bc: BoxConstraints,
 }
 
 impl<T: Data> List<T> {
@@ -50,6 +51,7 @@ impl<T: Data> List<T> {
             children: Vec::new(),
             axis: Axis::Vertical,
             spacing: KeyOrValue::Concrete(0.),
+            old_bc: BoxConstraints::tight(Size::ZERO),
         }
     }
 
@@ -395,6 +397,11 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
         let mut minor = axis.minor(bc.min());
         let mut major_pos = 0.0;
         let mut paint_rect = Rect::ZERO;
+
+        //
+        let mut any_changed = self.old_bc != *bc;
+        self.old_bc = *bc;
+
         let mut children = self.children.iter_mut();
         let child_bc = axis.constraints(bc, 0., f64::INFINITY);
         data.for_each(|child_data, _| {
@@ -404,7 +411,13 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
                     return;
                 }
             };
-            let child_size = child.layout(ctx, &child_bc, child_data, env);
+
+            let child_size = if child.layout_requested() {
+                child.layout(ctx, &child_bc, child_data, env)
+            } else {
+                child.layout_rect().size()
+            };
+
             let child_pos: Point = axis.pack(major_pos, 0.).into();
             child.set_origin(ctx, child_data, env, child_pos);
             paint_rect = paint_rect.union(child.paint_rect());

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -398,8 +398,7 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
         let mut major_pos = 0.0;
         let mut paint_rect = Rect::ZERO;
 
-        //
-        let mut any_changed = self.old_bc != *bc;
+        let mut bc_changed = self.old_bc != *bc;
         self.old_bc = *bc;
 
         let mut children = self.children.iter_mut();
@@ -412,7 +411,7 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
                 }
             };
 
-            let child_size = if child.layout_requested() {
+            let child_size = if bc_changed || child.layout_requested() {
                 child.layout(ctx, &child_bc, child_data, env)
             } else {
                 child.layout_rect().size()

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -398,7 +398,7 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
         let mut major_pos = 0.0;
         let mut paint_rect = Rect::ZERO;
 
-        let mut bc_changed = self.old_bc != *bc;
+        let bc_changed = self.old_bc != *bc;
         self.old_bc = *bc;
 
         let mut children = self.children.iter_mut();


### PR DESCRIPTION
This PR changes the implementation of layout for widgets with multiple children. Now these widgets only call `layout` on children which need a layout call. Either because `WidgetPod::requested_layout` is set or because their `BoxConstrains` have changed.
