### PR TITLE
Make Parse work better with floats

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,3 +20,4 @@ Marcin Zając
 Laura Gallo
 Tim Murison
 Manmeet Singh
+Simon Fell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - `ClipBox` and `Tabs` handle SCROLL_TO_VIEW ([#2141] by [@xarvic])
 - `EventCtx::submit_notification_without_warning` ([#2141] by [@xarvic])
 - `WidgetPod::requested_layout` ([#2145] by [@xarvic])
+- Make `Parse` work better with floats and similar types ([#2148] by [@superfell])
 
 ### Changed
 
@@ -546,6 +547,7 @@ Last release without a changelog :(
 [@zedseven]: https://github.com/zedseven
 [@Pavel-N]: https://github.com/Pavel-N
 [@maurerdietmar]: https://github.com/maurerdietmar
+[@superfell]: https://github.com/superfell
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611
@@ -834,6 +836,7 @@ Last release without a changelog :(
 [#2117]: https://github.com/linebender/druid/pull/2117
 [#2117]: https://github.com/linebender/druid/pull/2141
 [#2145]: https://github.com/linebender/druid/pull/2145
+[#2148]: https://github.com/linebender/druid/pull/2148
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid/src/widget/parse.rs
+++ b/druid/src/widget/parse.rs
@@ -67,7 +67,7 @@ impl<T: FromStr + Display + Data, W: Widget<String>> Widget<Option<T>> for Parse
             Some(ref x) => {
                 // Its possible that the current self.state already represents the data value
                 // in that case we shouldn't clobber the self.state. This helps deal
-                // with types where parse()/to_string() round trips can loose information
+                // with types where parse()/to_string() round trips can lose information
                 // e.g. with floating point numbers, text of "1.0" becomes "1" in the
                 // round trip, and this makes it impossible to type in the . otherwise
                 match self.state.parse() {

--- a/druid/src/widget/parse.rs
+++ b/druid/src/widget/parse.rs
@@ -64,9 +64,27 @@ impl<T: FromStr + Display + Data, W: Widget<String>> Widget<Option<T>> for Parse
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &Option<T>, data: &Option<T>, env: &Env) {
         let old = match *data {
             None => return, // Don't clobber the input
-            Some(ref x) => mem::replace(&mut self.state, x.to_string()),
+            Some(ref x) => {
+                // Its possible that the current self.state already represents the data value
+                // in that case we shouldn't clobber the self.state. This helps deal
+                // with types where parse()/to_string() round trips can loose information
+                // e.g. with floating point numbers, text of "1.0" becomes "1" in the
+                // round trip, and this makes it impossible to type in the . otherwise
+                match self.state.parse() {
+                    Err(_) => Some(mem::replace(&mut self.state, x.to_string())),
+                    Ok(v) => {
+                        if !Data::same(&v, x) {
+                            Some(mem::replace(&mut self.state, x.to_string()))
+                        } else {
+                            None
+                        }
+                    }
+                }
+            }
         };
-        self.widget.update(ctx, &old, &self.state, env)
+        // if old is None here, that means that self.state hasn't changed
+        let old_data = old.as_ref().unwrap_or(&self.state);
+        self.widget.update(ctx, old_data, &self.state, env)
     }
 
     #[instrument(name = "Parse", level = "trace", skip(self, ctx, bc, _data, env))]


### PR DESCRIPTION
I was using Parse with TextBox that was lens'd to an f32. The editing behavior is odd, starting from a blank text box you can't type 1.5 because when you get to 1. it gets replaced by 1. This happens because round tripping "1." through parse / to_string results in "1".

This PR updates Parse to skip applying the to_string() in the event that the text already parses to the same value as data. This improves the behavior for f32 and any similar types where there is text lost from a parse/to_string round trip.