### PR TITLE
Unified origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - Replace `info_span!` with `trace_span!` ([#2203] by [@NickLarsenNZ])
 - `WidgetPod::event` propagates handled mouse events to active children ([#2235] by [@xarvic])
 - changing hot state is now done in `Lifecycle::ChangeViewState` instead of `layout` ([#2149] by [@xarvic])
+- `WidgetPod::set_origin` no longer takes `data` and `env` as parameters. ([#2149] by [@xarvic])
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - Added `compute_max_intrinsic` method to the `Widget` trait, which determines the maximum useful dimension of the widget ([#2172] by [@sjoshid])
 - Windows: Dark mode support for the title bar ([#2196] by [@dristic])
 - `ZStack` widget ([#2235] by [@xarvic])
-- `Lifecycle::ViewStateChanged`, `InternalLifecycle::RouteViewStateChanged`, `ChangeCtx`, and `RequestCtx` ([2149] by [@xarvic])
+- `Lifecycle::ViewStateChanged`, `InternalLifecycle::RouteViewStateChanged`, `ChangeCtx`, and `RequestCtx` ([#2149] by [@xarvic])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - Added `compute_max_intrinsic` method to the `Widget` trait, which determines the maximum useful dimension of the widget ([#2172] by [@sjoshid])
 - Windows: Dark mode support for the title bar ([#2196] by [@dristic])
 - `ZStack` widget ([#2235] by [@xarvic])
+- `Lifecycle::ViewStateChanged`, `InternalLifecycle::RouteViewStateChanged`, `ChangeCtx`, and `RequestCtx` ([2149] by [@xarvic])
 
 ### Changed
 
@@ -105,6 +106,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - `RadioGroup` widgets are now constructed with new `row()`, `column()`, and `for_axis()` methods ([#2157] by [@twitchyliquid64])
 - Replace `info_span!` with `trace_span!` ([#2203] by [@NickLarsenNZ])
 - `WidgetPod::event` propagates handled mouse events to active children ([#2235] by [@xarvic])
+- changing hot state is now done in `Lifecycle::ChangeViewState` instead of `layout` ([#2149] by [@xarvic])
 
 ### Deprecated
 
@@ -853,6 +855,7 @@ Last release without a changelog :(
 [#2117]: https://github.com/linebender/druid/pull/2141
 [#2145]: https://github.com/linebender/druid/pull/2145
 [#2148]: https://github.com/linebender/druid/pull/2148
+[#2149]: https://github.com/linebender/druid/pull/2149
 [#2151]: https://github.com/linebender/druid/pull/2151
 [#2157]: https://github.com/linebender/druid/pull/2157
 [#2158]: https://github.com/linebender/druid/pull/2158

--- a/druid/examples/timer.rs
+++ b/druid/examples/timer.rs
@@ -76,7 +76,7 @@ impl Widget<u32> for TimerWidget {
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &u32, env: &Env) -> Size {
         self.simple_box.layout(ctx, &bc.loosen(), data, env);
-        self.simple_box.set_origin(ctx, data, env, self.pos);
+        self.simple_box.set_origin(ctx, self.pos);
         bc.constrain((500.0, 500.0))
     }
 

--- a/druid/examples/value_formatting/src/widgets.rs
+++ b/druid/examples/value_formatting/src/widgets.rs
@@ -169,7 +169,7 @@ impl<T, W: Widget<Option<ValidationError>>> Widget<T> for ErrorController<W> {
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, _: &T, env: &Env) -> Size {
         let size = self.child.layout(ctx, bc, &self.error, env);
-        self.child.set_origin(ctx, &self.error, env, Point::ZERO);
+        self.child.set_origin(ctx, Point::ZERO);
         size
     }
 

--- a/druid/examples/widget_gallery.rs
+++ b/druid/examples/widget_gallery.rs
@@ -369,7 +369,7 @@ impl<T: Data> Widget<T> for SquaresGrid<T> {
                 data,
                 env,
             );
-            widget.set_origin(ctx, data, env, Point::new(x_position, y_position));
+            widget.set_origin(ctx, Point::new(x_position, y_position));
             // Increment position for the next cell
             x_position += self.cell_size.width + self.spacing;
             // If we can't fit in another cell in this row ...

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -321,7 +321,6 @@ impl_context_trait!(
     }
 );
 
-
 // methods on everyone
 impl_context_method!(
     EventCtx<'_, '_>,

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -343,7 +343,7 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, {
 });
 
 //methods on event, update and layout.
-impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, {
+impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LayoutCtx<'_, '_>, {
     /// Indicate that your view_context has changed.
     ///
     /// Widgets must call this method after changing the clip region of thier children.
@@ -351,7 +351,7 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, {
     pub fn view_context_changed(&mut self) {
         self.widget_state.view_context_changed = true;
     }
-}
+});
 
 // methods on event, update, and lifecycle
 impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, {

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -114,7 +114,6 @@ pub struct UpdateCtx<'a, 'b> {
 pub struct LayoutCtx<'a, 'b> {
     pub(crate) state: &'a mut ContextState<'b>,
     pub(crate) widget_state: &'a mut WidgetState,
-    pub(crate) mouse_pos: Option<Point>,
 }
 
 /// Z-order paint operations with transformations.
@@ -342,6 +341,17 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, {
         self.widget_state.cursor_change = CursorChange::Default;
     }
 });
+
+//methods on event, update and layout.
+impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, {
+    /// Indicate that your view_context has changed.
+    ///
+    /// Widgets must call this method after changing the clip region of thier children.
+    /// The other parts of view_context (cursor_position and global origin) are tracked internally.
+    pub fn view_context_changed(&mut self) {
+        self.widget_state.view_context_changed = true;
+    }
+}
 
 // methods on event, update, and lifecycle
 impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, {

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -194,6 +194,7 @@ pub trait RequestCtx<'b>: CommandCtx<'b> {
     /// Request a [`paint`] pass. See ['request_paint']
     ///
     /// ['request_paint']: EventCtx::request_paint
+    /// [`paint`]: Widget::paint
     fn request_paint(&mut self);
     /// Request a [`paint`] pass for redrawing a rectangle. See [`request_paint_rect`].
     ///

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -184,7 +184,7 @@ pub trait ChangeCtx {
     /// Returns the state of the widget.
     ///
     /// This method should only be used by the framework to do mergeups.
-    fn state<'a>(&'a mut self) -> State<'a>;
+    fn state(&mut self) -> State;
 }
 
 /// Convenience trait for invalidation and request methods available on multiple contexts.
@@ -257,7 +257,7 @@ impl_context_trait!(
             Self::request_timer(self, deadline)
         }
 
-        fn state<'a>(&'a mut self) -> State<'a> {
+        fn state(&mut self) -> State {
             State {
                 //state: &mut *self.state,
                 widget_state: &mut *self.widget_state,

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -1075,18 +1075,6 @@ impl<'a, 'b> LayoutCtx<'a, 'b> {
         trace!("set_baseline_offset {}", baseline);
         self.widget_state.baseline_offset = baseline
     }
-
-    /// Creates a new LayoutCtx for a widget that maybe is hidden by another widget.
-    ///
-    /// If ignore is `true` the child will not set its hot state to `true` even if the cursor
-    /// is inside its bounds.
-    pub fn ignore_hot<'c>(&'c mut self, ignore: bool) -> LayoutCtx<'c, 'b> {
-        LayoutCtx {
-            state: self.state,
-            widget_state: self.widget_state,
-            mouse_pos: if ignore { None } else { self.mouse_pos },
-        }
-    }
 }
 
 impl PaintCtx<'_, '_, '_> {

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -161,8 +161,10 @@ pub struct State<'a, 'b> {
 
 /// Convenience trait for code generic over contexts.
 ///
-/// Methods to do with commands and timers.
-/// Available to all contexts but PaintCtx.
+/// Methods that deal with commands and timers.
+/// Available to all contexts but [`PaintCtx`].
+///
+/// [`PaintCtx`](PaintCtx)
 pub trait ChangeCtx<'b> {
     /// Submit a [`Command`] to be run after this event is handled. See [`submit_command`].
     ///
@@ -446,7 +448,7 @@ impl_context_method!(
         /// Returns `true` if either this specific widget or any one of its descendants is focused.
         /// To check if only this specific widget is focused use [`is_focused`],
         ///
-        /// [`is_focused`]: #method.is_focused
+        /// [`is_focused`]: crate::EventCtx::is_focused
         pub fn has_focus(&self) -> bool {
             self.widget_state.has_focus
         }
@@ -463,7 +465,7 @@ impl_context_method!(
         /// For an example the decrease button of a counter of type `usize` should be disabled if the
         /// value is `0`.
         ///
-        /// [`set_disabled`]: EventCtx::set_disabled
+        /// [`set_disabled`]: crate::EventCtx::set_disabled
         pub fn is_disabled(&self) -> bool {
             self.widget_state.is_disabled()
         }
@@ -478,10 +480,10 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, {
     /// cursor, the child widget's cursor will take precedence. (If that isn't what you want, use
     /// [`override_cursor`] instead.)
     ///
-    /// [`clear_cursor`]: EventCtx::clear_cursor
-    /// [`override_cursor`]: EventCtx::override_cursor
-    /// [`hot`]: EventCtx::is_hot
-    /// [`active`]: EventCtx::is_active
+    /// [`clear_cursor`]: crate::EventCtx::clear_cursor
+    /// [`override_cursor`]: crate::EventCtx::override_cursor
+    /// [`hot`]: crate::EventCtx::is_hot
+    /// [`active`]: crate::EventCtx::is_active
     pub fn set_cursor(&mut self, cursor: &Cursor) {
         trace!("set_cursor {:?}", cursor);
         self.widget_state.cursor_change = CursorChange::Set(cursor.clone());
@@ -493,10 +495,10 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, {
     /// effect when this widget is either [`hot`] or [`active`]. This will override the cursor
     /// preferences of a child widget. (If that isn't what you want, use [`set_cursor`] instead.)
     ///
-    /// [`clear_cursor`]: EventCtx::clear_cursor
-    /// [`set_cursor`]: EventCtx::override_cursor
-    /// [`hot`]: EventCtx::is_hot
-    /// [`active`]: EventCtx::is_active
+    /// [`clear_cursor`]: crate::EventCtx::clear_cursor
+    /// [`set_cursor`]: crate::EventCtx::set_cursor
+    /// [`hot`]: crate::EventCtx::is_hot
+    /// [`active`]: crate::EventCtx::is_active
     pub fn override_cursor(&mut self, cursor: &Cursor) {
         trace!("override_cursor {:?}", cursor);
         self.widget_state.cursor_change = CursorChange::Override(cursor.clone());
@@ -506,20 +508,26 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, {
     ///
     /// This undoes the effect of [`set_cursor`] and [`override_cursor`].
     ///
-    /// [`override_cursor`]: EventCtx::override_cursor
-    /// [`set_cursor`]: EventCtx::set_cursor
+    /// [`override_cursor`]: crate::EventCtx::override_cursor
+    /// [`set_cursor`]: crate::EventCtx::set_cursor
     pub fn clear_cursor(&mut self) {
         trace!("clear_cursor");
         self.widget_state.cursor_change = CursorChange::Default;
     }
 });
 
-//methods on event, update and layout.
+// methods on event, update and layout.
 impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LayoutCtx<'_, '_>, {
-    /// Indicate that your view_context has changed.
+    /// Indicate that your [`ViewContext`] has changed.
     ///
-    /// Widgets must call this method after changing the clip region of thier children.
-    /// The other parts of view_context (cursor_position and global origin) are tracked internally.
+    /// This event is sent after layout is done and before paint is called. Note that you can still
+    /// receive this event even if there was no prior call to layout.
+    ///
+    /// Widgets must call this method after changing the clip region of their children.
+    /// Changes to the other parts of [`ViewContext`] (cursor position and global origin) are tracked
+    /// internally.
+    ///
+    /// [`ViewContext`]: crate::ViewContext
     pub fn view_context_changed(&mut self) {
         self.widget_state.view_context_changed = true;
     }

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -52,7 +52,7 @@ macro_rules! impl_context_method {
 }
 
 /// A macro for implementing context traits for multiple contexts.
-macro_rules! impl_context_trait{
+macro_rules! impl_context_trait {
     ($tr:ty => $ty:ty,  { $($method:item)+ } ) => {
         impl<'b> $tr for $ty { $($method)+ }
     };
@@ -154,6 +154,9 @@ pub struct PaintCtx<'a, 'b, 'c> {
 
 /// The state of a widget and its global context.
 pub struct State<'a, 'b> {
+    // currently the only method using the State struct is set_origin.
+    // the context state is included into this struct to signal that its also valid to change the
+    // context_state of widget from a context trait.
     #[allow(dead_code)]
     pub(crate) state: &'a mut ContextState<'b>,
     pub(crate) widget_state: &'a mut WidgetState,

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -577,7 +577,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         // set its origin.
         let child_mouse_pos = ctx
             .mouse_pos
-            .map(|pos| pos - self.layout_rect().origin().to_vec2() + self.viewport_offset());
+            .map(|pos| pos - self.layout_rect().origin().to_vec2());
         let prev_size = self.state.size;
 
         let mut child_ctx = LayoutCtx {
@@ -1011,13 +1011,10 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                     }
                 }
                 InternalLifeCycle::ParentWindowOrigin => {
-                    let new_parent_window_origin = ctx.widget_state.window_origin();
-                    if new_parent_window_origin != self.state.parent_window_origin {
-                        self.state.parent_window_origin = new_parent_window_origin;
-                        true
-                    } else {
-                        false
-                    }
+                    let old_parent_window_origin = self.state.parent_window_origin;
+                    self.state.parent_window_origin = ctx.widget_state.window_origin();
+
+                    old_parent_window_origin != self.state.parent_window_origin || self.state.needs_window_origin
                 }
                 InternalLifeCycle::DebugRequestState { widget, state_cell } => {
                     if *widget == self.id() {
@@ -1304,7 +1301,7 @@ impl WidgetState {
             .layout_rect()
             .with_origin(Point::ORIGIN)
             .inset(self.paint_insets);
-        let offset = child_state.layout_rect().origin().to_vec2() - child_state.viewport_offset;
+        let offset = child_state.layout_rect().origin().to_vec2();
         for &r in child_state.invalid.rects() {
             let r = (r + offset).intersect(clip);
             if r.area() != 0.0 {

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -14,9 +14,9 @@
 
 //! The fundamental druid types.
 
+use druid::contexts::CommandCtx;
 use std::collections::VecDeque;
 use tracing::{trace, trace_span, warn};
-use druid::contexts::CommandCtx;
 
 use crate::bloom::Bloom;
 use crate::command::sys::{CLOSE_WINDOW, SUB_WINDOW_HOST_TO_PARENT, SUB_WINDOW_PARENT_TO_HOST};
@@ -273,7 +273,13 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
     /// [`LifeCycle::Size`]: enum.LifeCycle.html#variant.Size
     //TODO: we are using CommandCtx because it allows every context but paint, but it might be a
     // confusing name.
-    pub fn set_origin<'a>(&mut self, ctx: &mut impl CommandCtx<'a>, _data: &T, _env: &Env, origin: Point) {
+    pub fn set_origin<'a>(
+        &mut self,
+        ctx: &mut impl CommandCtx<'a>,
+        _data: &T,
+        _env: &Env,
+        origin: Point,
+    ) {
         //TODO: decide whether we should keep data and env for compatibility or do a breaking change
         self.state.is_expecting_set_origin_call = false;
 

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -284,13 +284,13 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
     /// [`Size`]: struct.Size.html
     /// [`LifeCycle::Size`]: enum.LifeCycle.html#variant.Size
     /// [`LifeCycle::ViewContextChanged`]: enum.LifeCycle.html#variant.ViewContextChanged
-    pub fn set_origin<'a>(&mut self, ctx: &mut impl ChangeCtx<'a>, origin: Point) {
+    pub fn set_origin(&mut self, ctx: &mut impl ChangeCtx, origin: Point) {
         self.state.is_expecting_set_origin_call = false;
 
         if origin != self.state.origin {
             self.state.origin = origin;
             self.state.view_context_changed = true;
-            // identical to calling merge up but faster!
+            // Instead of calling merge_up we directly propagate the flag we care about, to gain performance
             ctx.state().widget_state.children_view_context_changed = true;
         }
     }

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -271,8 +271,6 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
     /// [`Rect`]: struct.Rect.html
     /// [`Size`]: struct.Size.html
     /// [`LifeCycle::Size`]: enum.LifeCycle.html#variant.Size
-    //TODO: we are using CommandCtx because it allows every context but paint, but it might be a
-    // confusing name.
     pub fn set_origin<'a>(
         &mut self,
         ctx: &mut impl ChangeCtx<'a>,

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -14,7 +14,7 @@
 
 //! The fundamental druid types.
 
-use druid::contexts::CommandCtx;
+use druid::contexts::ChangeCtx;
 use std::collections::VecDeque;
 use tracing::{trace, trace_span, warn};
 
@@ -275,7 +275,7 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
     // confusing name.
     pub fn set_origin<'a>(
         &mut self,
-        ctx: &mut impl CommandCtx<'a>,
+        ctx: &mut impl ChangeCtx<'a>,
         _data: &T,
         _env: &Env,
         origin: Point,

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -365,10 +365,10 @@ pub enum InternalLifeCycle {
 }
 
 /// Information about the widgets surroundings.
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct ViewContext {
-    /// The origin of this widget relative to the window.
-    pub global_origin: Point,
+    /// The origin of this widget's parent relative to the window.
+    pub parent_window_origin: Point,
 
     /// The last position the cursor was on, relative to the widget.
     pub last_mouse_position: Option<Point>,
@@ -470,7 +470,7 @@ impl ViewContext {
     pub(crate) fn for_child_widget(&self, child_origin: Point) -> Self {
         let child_origin = child_origin.to_vec2();
         ViewContext {
-            global_origin: self.global_origin.add(child_origin),
+            parent_window_origin: self.parent_window_origin.add(child_origin),
             last_mouse_position: self.last_mouse_position.map(|pos|pos.sub(child_origin)),
             clip: self.clip.sub(child_origin)
         }
@@ -478,7 +478,6 @@ impl ViewContext {
 }
 
 pub(crate) use state_cell::{DebugStateCell, StateCell, StateCheckFn};
-use crate::image::flat::View;
 
 mod state_cell {
     use crate::core::WidgetState;

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -14,8 +14,8 @@
 
 //! Events.
 
+use crate::kurbo::{Rect, Size};
 use std::ops::{Add, Sub};
-use crate::kurbo::{Rect, Shape, Size, Vec2};
 
 use druid_shell::{Clipboard, KeyEvent, TimerToken};
 
@@ -438,7 +438,7 @@ impl LifeCycle {
             | LifeCycle::HotChanged(_)
             | LifeCycle::FocusChanged(_)
             | LifeCycle::BuildFocusChain
-            | LifeCycle::ViewContextChanged {..} => false,
+            | LifeCycle::ViewContextChanged { .. } => false,
         }
     }
 }
@@ -457,7 +457,7 @@ impl InternalLifeCycle {
             InternalLifeCycle::RouteWidgetAdded
             | InternalLifeCycle::RouteFocusChanged { .. }
             | InternalLifeCycle::RouteDisabledChanged => true,
-            InternalLifeCycle::RouteViewContextChanged {..} => false,
+            InternalLifeCycle::RouteViewContextChanged { .. } => false,
             InternalLifeCycle::DebugRequestState { .. }
             | InternalLifeCycle::DebugRequestDebugState { .. }
             | InternalLifeCycle::DebugInspectState(_) => true,
@@ -471,8 +471,8 @@ impl ViewContext {
         let child_origin = child_origin.to_vec2();
         ViewContext {
             parent_window_origin: self.parent_window_origin.add(child_origin),
-            last_mouse_position: self.last_mouse_position.map(|pos|pos.sub(child_origin)),
-            clip: self.clip.sub(child_origin)
+            last_mouse_position: self.last_mouse_position.map(|pos| pos.sub(child_origin)),
+            clip: self.clip.sub(child_origin),
         }
     }
 }

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -441,6 +441,30 @@ impl LifeCycle {
             | LifeCycle::ViewContextChanged { .. } => false,
         }
     }
+
+    /// Returns an event for a widget which maybe is overlapped by another widget.
+    ///
+    /// When ignore is set to `true` the widget will set its hot state to `false` even if the cursor
+    /// is inside its bounds.
+    pub fn ignore_hot(&self, ignore: bool) -> Self {
+        if ignore {
+            match self {
+                LifeCycle::ViewContextChanged(view_ctx) => {
+                    let mut view_ctx = view_ctx.to_owned();
+                    view_ctx.last_mouse_position = None;
+                    LifeCycle::ViewContextChanged(view_ctx)
+                },
+                LifeCycle::Internal(InternalLifeCycle::RouteViewContextChanged(view_ctx)) => {
+                    let mut view_ctx = view_ctx.to_owned();
+                    view_ctx.last_mouse_position = None;
+                    LifeCycle::Internal(InternalLifeCycle::RouteViewContextChanged(view_ctx))
+                },
+                _ => self.to_owned()
+            }
+        } else {
+            self.to_owned()
+        }
+    }
 }
 
 impl InternalLifeCycle {

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -362,53 +362,6 @@ pub enum InternalLifeCycle {
 }
 
 impl Event {
-    /// Transform the event for the contents of a scrolling container.
-    ///
-    /// the `force` flag is used to ensure an event is delivered even
-    /// if the cursor is out of the viewport, such as if the contents are active
-    /// or hot.
-    pub fn transform_scroll(&self, offset: Vec2, viewport: Rect, force: bool) -> Option<Event> {
-        match self {
-            Event::MouseDown(mouse_event) => {
-                if force || viewport.winding(mouse_event.pos) != 0 {
-                    let mut mouse_event = mouse_event.clone();
-                    mouse_event.pos += offset;
-                    Some(Event::MouseDown(mouse_event))
-                } else {
-                    None
-                }
-            }
-            Event::MouseUp(mouse_event) => {
-                if force || viewport.winding(mouse_event.pos) != 0 {
-                    let mut mouse_event = mouse_event.clone();
-                    mouse_event.pos += offset;
-                    Some(Event::MouseUp(mouse_event))
-                } else {
-                    None
-                }
-            }
-            Event::MouseMove(mouse_event) => {
-                if force || viewport.winding(mouse_event.pos) != 0 {
-                    let mut mouse_event = mouse_event.clone();
-                    mouse_event.pos += offset;
-                    Some(Event::MouseMove(mouse_event))
-                } else {
-                    None
-                }
-            }
-            Event::Wheel(mouse_event) => {
-                if force || viewport.winding(mouse_event.pos) != 0 {
-                    let mut mouse_event = mouse_event.clone();
-                    mouse_event.pos += offset;
-                    Some(Event::Wheel(mouse_event))
-                } else {
-                    None
-                }
-            }
-            _ => Some(self.clone()),
-        }
-    }
-
     /// Whether this event should be sent to widgets which are currently not visible and not
     /// accessible.
     ///

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -453,13 +453,13 @@ impl LifeCycle {
                     let mut view_ctx = view_ctx.to_owned();
                     view_ctx.last_mouse_position = None;
                     LifeCycle::ViewContextChanged(view_ctx)
-                },
+                }
                 LifeCycle::Internal(InternalLifeCycle::RouteViewContextChanged(view_ctx)) => {
                     let mut view_ctx = view_ctx.to_owned();
                     view_ctx.last_mouse_position = None;
                     LifeCycle::Internal(InternalLifeCycle::RouteViewContextChanged(view_ctx))
-                },
-                _ => self.to_owned()
+                }
+                _ => self.to_owned(),
             }
         } else {
             self.to_owned()

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -388,7 +388,7 @@ pub struct ViewContext {
 
     /// The visible area, this widget is contained in, relative to the widget.
     ///
-    /// The area may be larger than the widgets `paint_rect`.
+    /// The area may be larger than the widget's `paint_rect`.
     pub clip: Rect,
 }
 

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -211,7 +211,7 @@ pub use contexts::{EventCtx, LayoutCtx, LifeCycleCtx, PaintCtx, UpdateCtx};
 pub use data::Data;
 pub use dialog::FileDialogOptions;
 pub use env::{Env, Key, KeyOrValue, Value, ValueType, ValueTypeError};
-pub use event::{Event, InternalEvent, InternalLifeCycle, LifeCycle};
+pub use event::{Event, InternalEvent, InternalLifeCycle, LifeCycle, ViewContext};
 pub use ext_event::{ExtEventError, ExtEventSink};
 pub use lens::{Lens, LensExt};
 pub use localization::LocalizedString;

--- a/druid/src/sub_window.rs
+++ b/druid/src/sub_window.rs
@@ -161,8 +161,7 @@ impl<U: Data, W: Widget<U>> Widget<()> for SubWindowHost<U, W> {
     )]
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, _data: &(), _env: &Env) -> Size {
         let size = self.child.layout(ctx, bc, &self.data, &self.env);
-        self.child
-            .set_origin(ctx, &self.data, &self.env, Point::ORIGIN);
+        self.child.set_origin(ctx, Point::ORIGIN);
         size
     }
 

--- a/druid/src/text/input_component.rs
+++ b/druid/src/text/input_component.rs
@@ -372,7 +372,7 @@ impl<T: TextStorage + EditableText> Widget<T> for TextComponent<T> {
                 self.borrow_mut().layout.rebuild_if_needed(ctx.text(), env);
             }
             //FIXME: this should happen in the parent too?
-            LifeCycle::Internal(crate::InternalLifeCycle::ParentWindowOrigin)
+            LifeCycle::ViewContextChanged(_)
                 if self.can_write() =>
             {
                 if self.can_write() {

--- a/druid/src/text/input_component.rs
+++ b/druid/src/text/input_component.rs
@@ -372,9 +372,7 @@ impl<T: TextStorage + EditableText> Widget<T> for TextComponent<T> {
                 self.borrow_mut().layout.rebuild_if_needed(ctx.text(), env);
             }
             //FIXME: this should happen in the parent too?
-            LifeCycle::ViewContextChanged(_)
-                if self.can_write() =>
-            {
+            LifeCycle::ViewContextChanged(_) if self.can_write() => {
                 if self.can_write() {
                     let prev_origin = self.borrow().origin;
                     let new_origin = ctx.window_origin();

--- a/druid/src/widget/align.rs
+++ b/druid/src/widget/align.rs
@@ -125,7 +125,7 @@ impl<T: Data> Widget<T> for Align<T> {
             .align
             .resolve(Rect::new(0., 0., extra_width, extra_height))
             .expand();
-        self.child.set_origin(ctx, data, env, origin);
+        self.child.set_origin(ctx, origin);
 
         let my_insets = self.child.compute_parent_paint_insets(my_size);
         ctx.set_paint_insets(my_insets);

--- a/druid/src/widget/aspect_ratio_box.rs
+++ b/druid/src/widget/aspect_ratio_box.rs
@@ -144,7 +144,6 @@ impl<T: Data> Widget<T> for AspectRatioBox<T> {
 
             return self.child.layout(ctx, bc, data, env);
         }
-
         if bc.max().width == f64::INFINITY && bc.max().height == f64::INFINITY {
             warn!("Box constraints are INFINITE. Aspect ratio box won't be able to choose a size because the constraints given by the parent widget are INFINITE.");
 

--- a/druid/src/widget/clip_box.rs
+++ b/druid/src/widget/clip_box.rs
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 use crate::commands::SCROLL_TO_VIEW;
+use crate::contexts::CommandCtx;
 use crate::debug_state::DebugState;
 use crate::kurbo::{Point, Rect, Size, Vec2};
 use crate::widget::prelude::*;
 use crate::widget::Axis;
 use crate::{Data, InternalLifeCycle, WidgetPod};
 use tracing::{info, instrument, trace, warn};
-use crate::contexts::CommandCtx;
 
 /// Represents the size and position of a rectangular "viewport" into a larger area.
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
@@ -362,7 +362,13 @@ impl<T, W: Widget<T>> ClipBox<T, W> {
     /// Pans by `delta` units.
     ///
     /// Returns `true` if the scroll offset has changed.
-    pub fn pan_by<'a, C: CommandCtx<'a>>(&mut self, ctx: &mut C, data: &T, env: &Env, delta: Vec2) -> bool {
+    pub fn pan_by<'a, C: CommandCtx<'a>>(
+        &mut self,
+        ctx: &mut C,
+        data: &T,
+        env: &Env,
+        delta: Vec2,
+    ) -> bool {
         self.with_port(ctx, data, env, |_, port| {
             port.pan_by(delta);
         })
@@ -372,7 +378,13 @@ impl<T, W: Widget<T>> ClipBox<T, W> {
     ///
     /// If the target region is larger than the viewport, we will display the
     /// portion that fits, prioritizing the portion closest to the origin.
-    pub fn pan_to_visible<'a, C: CommandCtx<'a>>(&mut self, ctx: &mut C, data: &T, env: &Env, region: Rect) -> bool {
+    pub fn pan_to_visible<'a, C: CommandCtx<'a>>(
+        &mut self,
+        ctx: &mut C,
+        data: &T,
+        env: &Env,
+        region: Rect,
+    ) -> bool {
         self.with_port(ctx, data, env, |_, port| {
             port.pan_to_visible(region);
         })
@@ -381,7 +393,14 @@ impl<T, W: Widget<T>> ClipBox<T, W> {
     /// Pan to this position on a particular axis.
     ///
     /// Returns `true` if the scroll offset has changed.
-    pub fn pan_to_on_axis<'a, C: CommandCtx<'a>>(&mut self, ctx: &mut C, data: &T, env: &Env, axis: Axis, position: f64) -> bool {
+    pub fn pan_to_on_axis<'a, C: CommandCtx<'a>>(
+        &mut self,
+        ctx: &mut C,
+        data: &T,
+        env: &Env,
+        axis: Axis,
+        position: f64,
+    ) -> bool {
         self.with_port(ctx, data, env, |_, port| {
             port.pan_to_on_axis(axis, position);
         })
@@ -421,7 +440,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for ClipBox<T, W> {
                     // prevent unexpected behaviour, by clipping SCROLL_TO_VIEW notifications
                     // to this ClipBox's viewport.
                     ctx.set_handled();
-                    self.with_port(ctx, data, env,|ctx, port| {
+                    self.with_port(ctx, data, env, |ctx, port| {
                         port.fixed_scroll_to_view_handling(
                             ctx,
                             *global_highlight_rect,

--- a/druid/src/widget/clip_box.rs
+++ b/druid/src/widget/clip_box.rs
@@ -381,12 +381,7 @@ impl<T, W: Widget<T>> ClipBox<T, W> {
     /// Pan to this position on a particular axis.
     ///
     /// Returns `true` if the scroll offset has changed.
-    pub fn pan_to_on_axis<C: ChangeCtx>(
-        &mut self,
-        ctx: &mut C,
-        axis: Axis,
-        position: f64,
-    ) -> bool {
+    pub fn pan_to_on_axis<C: ChangeCtx>(&mut self, ctx: &mut C, axis: Axis, position: f64) -> bool {
         self.with_port(ctx, |_, port| {
             port.pan_to_on_axis(axis, position);
         })

--- a/druid/src/widget/clip_box.rs
+++ b/druid/src/widget/clip_box.rs
@@ -362,7 +362,7 @@ impl<T, W: Widget<T>> ClipBox<T, W> {
     /// Pans by `delta` units.
     ///
     /// Returns `true` if the scroll offset has changed.
-    pub fn pan_by<'a, C: ChangeCtx<'a>>(&mut self, ctx: &mut C, delta: Vec2) -> bool {
+    pub fn pan_by<C: ChangeCtx>(&mut self, ctx: &mut C, delta: Vec2) -> bool {
         self.with_port(ctx, |_, port| {
             port.pan_by(delta);
         })
@@ -372,7 +372,7 @@ impl<T, W: Widget<T>> ClipBox<T, W> {
     ///
     /// If the target region is larger than the viewport, we will display the
     /// portion that fits, prioritizing the portion closest to the origin.
-    pub fn pan_to_visible<'a, C: ChangeCtx<'a>>(&mut self, ctx: &mut C, region: Rect) -> bool {
+    pub fn pan_to_visible<C: ChangeCtx>(&mut self, ctx: &mut C, region: Rect) -> bool {
         self.with_port(ctx, |_, port| {
             port.pan_to_visible(region);
         })
@@ -381,7 +381,7 @@ impl<T, W: Widget<T>> ClipBox<T, W> {
     /// Pan to this position on a particular axis.
     ///
     /// Returns `true` if the scroll offset has changed.
-    pub fn pan_to_on_axis<'a, C: ChangeCtx<'a>>(
+    pub fn pan_to_on_axis<C: ChangeCtx>(
         &mut self,
         ctx: &mut C,
         axis: Axis,
@@ -396,7 +396,7 @@ impl<T, W: Widget<T>> ClipBox<T, W> {
     ///
     /// The provided callback function can modify its argument, and when it is
     /// done then this `ClipBox` will be modified to have the new viewport rectangle.
-    pub fn with_port<'a, C: ChangeCtx<'a>, F: FnOnce(&mut C, &mut Viewport)>(
+    pub fn with_port<C: ChangeCtx, F: FnOnce(&mut C, &mut Viewport)>(
         &mut self,
         ctx: &mut C,
         f: F,

--- a/druid/src/widget/clip_box.rs
+++ b/druid/src/widget/clip_box.rs
@@ -87,10 +87,10 @@ impl Viewport {
         }
     }
 
-    /// Sets the component selected by axis of viewport origin to `pos`, while trying to keep the
+    /// Sets the component selected by `axis` of viewport origin to `pos`, while trying to keep the
     /// view rectangle inside the content rectangle.
     ///
-    /// Returns true if the position changed. Note that the valid values for the viewport origin
+    /// Returns `true` if the position changed. Note that the valid values for the viewport origin
     /// are constrained by the size of the child, and so the origin might not get set to exactly
     /// `pos`.
     pub fn pan_to_on_axis(&mut self, axis: Axis, pos: f64) -> bool {
@@ -374,7 +374,7 @@ impl<T, W: Widget<T>> ClipBox<T, W> {
         })
     }
 
-    /// Pans the minimal distance to show the target rect.
+    /// Pans the minimal distance to show the `region`.
     ///
     /// If the target region is larger than the viewport, we will display the
     /// portion that fits, prioritizing the portion closest to the origin.

--- a/druid/src/widget/clip_box.rs
+++ b/druid/src/widget/clip_box.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::commands::SCROLL_TO_VIEW;
-use crate::contexts::CommandCtx;
+use crate::contexts::ChangeCtx;
 use crate::debug_state::DebugState;
 use crate::kurbo::{Point, Rect, Size, Vec2};
 use crate::widget::prelude::*;
@@ -362,7 +362,7 @@ impl<T, W: Widget<T>> ClipBox<T, W> {
     /// Pans by `delta` units.
     ///
     /// Returns `true` if the scroll offset has changed.
-    pub fn pan_by<'a, C: CommandCtx<'a>>(
+    pub fn pan_by<'a, C: ChangeCtx<'a>>(
         &mut self,
         ctx: &mut C,
         data: &T,
@@ -378,7 +378,7 @@ impl<T, W: Widget<T>> ClipBox<T, W> {
     ///
     /// If the target region is larger than the viewport, we will display the
     /// portion that fits, prioritizing the portion closest to the origin.
-    pub fn pan_to_visible<'a, C: CommandCtx<'a>>(
+    pub fn pan_to_visible<'a, C: ChangeCtx<'a>>(
         &mut self,
         ctx: &mut C,
         data: &T,
@@ -393,7 +393,7 @@ impl<T, W: Widget<T>> ClipBox<T, W> {
     /// Pan to this position on a particular axis.
     ///
     /// Returns `true` if the scroll offset has changed.
-    pub fn pan_to_on_axis<'a, C: CommandCtx<'a>>(
+    pub fn pan_to_on_axis<'a, C: ChangeCtx<'a>>(
         &mut self,
         ctx: &mut C,
         data: &T,
@@ -410,7 +410,7 @@ impl<T, W: Widget<T>> ClipBox<T, W> {
     ///
     /// The provided callback function can modify its argument, and when it is
     /// done then this `ClipBox` will be modified to have the new viewport rectangle.
-    pub fn with_port<'a, C: CommandCtx<'a>, F: FnOnce(&mut C, &mut Viewport)>(
+    pub fn with_port<'a, C: ChangeCtx<'a>, F: FnOnce(&mut C, &mut Viewport)>(
         &mut self,
         ctx: &mut C,
         data: &T,

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -190,7 +190,7 @@ impl<T: Data> Widget<T> for Container<T> {
         let child_bc = bc.shrink((2.0 * border_width, 2.0 * border_width));
         let size = self.child.layout(ctx, &child_bc, data, env);
         let origin = Point::new(border_width, border_width);
-        self.child.set_origin(ctx, data, env, origin);
+        self.child.set_origin(ctx, origin);
 
         let my_size = Size::new(
             size.width + 2.0 * border_width,

--- a/druid/src/widget/disable_if.rs
+++ b/druid/src/widget/disable_if.rs
@@ -61,7 +61,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for DisabledIf<T, W> {
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         let size = self.child.layout(ctx, bc, data, env);
-        self.child.set_origin(ctx, data, env, Point::ZERO);
+        self.child.set_origin(ctx, Point::ZERO);
         ctx.set_baseline_offset(self.child.baseline_offset());
         size
     }

--- a/druid/src/widget/either.rs
+++ b/druid/src/widget/either.rs
@@ -85,7 +85,7 @@ impl<T: Data> Widget<T> for Either<T> {
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         let current_widget = self.current_widget();
         let size = current_widget.layout(ctx, bc, data, env);
-        current_widget.set_origin(ctx, data, env, Point::ORIGIN);
+        current_widget.set_origin(ctx, Point::ORIGIN);
         ctx.set_paint_insets(current_widget.paint_insets());
         size
     }

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -94,7 +94,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for EnvScope<T, W> {
         (self.f)(&mut new_env, data);
 
         let size = self.child.layout(ctx, bc, data, &new_env);
-        self.child.set_origin(ctx, data, env, Point::ORIGIN);
+        self.child.set_origin(ctx, Point::ORIGIN);
         size
     }
 

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -850,7 +850,7 @@ impl<T: Data> Widget<T> for Flex<T> {
                     };
 
                     let child_pos: Point = self.direction.pack(major, child_minor_offset).into();
-                    widget.set_origin(ctx, data, env, child_pos);
+                    widget.set_origin(ctx, child_pos);
                     child_paint_rect = child_paint_rect.union(widget.paint_rect());
                     major += self.direction.major(child_size).expand();
                     major += spacing.next().unwrap_or(0.);

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -418,7 +418,7 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
             };
 
             let child_pos: Point = axis.pack(major_pos, 0.).into();
-            child.set_origin(ctx, child_data, env, child_pos);
+            child.set_origin(ctx, child_pos);
             paint_rect = paint_rect.union(child.paint_rect());
             minor = minor.max(axis.minor(child_size));
             major_pos += axis.major(child_size) + spacing;

--- a/druid/src/widget/maybe.rs
+++ b/druid/src/widget/maybe.rs
@@ -125,12 +125,12 @@ impl<T: Data> Widget<Option<T>> for Maybe<T> {
         match data.as_ref() {
             Some(d) => self.widget.with_some(|w| {
                 let size = w.layout(ctx, bc, d, env);
-                w.set_origin(ctx, d, env, Point::ORIGIN);
+                w.set_origin(ctx, Point::ORIGIN);
                 size
             }),
             None => self.widget.with_none(|w| {
                 let size = w.layout(ctx, bc, &(), env);
-                w.set_origin(ctx, &(), env, Point::ORIGIN);
+                w.set_origin(ctx, Point::ORIGIN);
                 size
             }),
         }

--- a/druid/src/widget/padding.rs
+++ b/druid/src/widget/padding.rs
@@ -101,7 +101,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Padding<T, W> {
         let child_bc = bc.shrink((hpad, vpad));
         let size = self.child.layout(ctx, &child_bc, data, env);
         let origin = Point::new(insets.x0, insets.y0);
-        self.child.set_origin(ctx, data, env, origin);
+        self.child.set_origin(ctx, origin);
 
         let my_size = Size::new(size.width + hpad, size.height + vpad);
         let my_insets = self.child.compute_parent_paint_insets(my_size);

--- a/druid/src/widget/scope.rs
+++ b/druid/src/widget/scope.rs
@@ -326,7 +326,7 @@ impl<SP: ScopePolicy, W: Widget<SP::State>> Widget<SP::In> for Scope<SP, W> {
     ) -> Size {
         self.with_state(data, |state, inner| {
             let size = inner.layout(ctx, bc, state, env);
-            inner.set_origin(ctx, state, env, Point::ORIGIN);
+            inner.set_origin(ctx, Point::ORIGIN);
             size
         })
     }

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -15,12 +15,12 @@
 //! A container that scrolls its contents.
 
 use crate::commands::SCROLL_TO_VIEW;
+use crate::contexts::CommandCtx;
 use crate::debug_state::DebugState;
 use crate::widget::prelude::*;
 use crate::widget::{Axis, ClipBox};
 use crate::{scroll_component::*, Data, Rect, Vec2};
 use tracing::{instrument, trace};
-use crate::contexts::CommandCtx;
 
 /// A container that scrolls its contents.
 ///
@@ -55,7 +55,13 @@ impl<T, W: Widget<T>> Scroll<T, W> {
     /// Scroll by `delta` units.
     ///
     /// Returns `true` if the scroll offset has changed.
-    pub fn scroll_by<'a, C: CommandCtx<'a>>(&mut self, ctx: &mut C, data: &T, env: &Env, delta: Vec2) -> bool {
+    pub fn scroll_by<'a, C: CommandCtx<'a>>(
+        &mut self,
+        ctx: &mut C,
+        data: &T,
+        env: &Env,
+        delta: Vec2,
+    ) -> bool {
         self.clip.pan_by(ctx, data, env, delta)
     }
 
@@ -63,14 +69,27 @@ impl<T, W: Widget<T>> Scroll<T, W> {
     ///
     /// If the target region is larger than the viewport, we will display the
     /// portion that fits, prioritizing the portion closest to the origin.
-    pub fn scroll_to<'a, C: CommandCtx<'a>>(&mut self, ctx: &mut C, data: &T, env: &Env, region: Rect) -> bool {
+    pub fn scroll_to<'a, C: CommandCtx<'a>>(
+        &mut self,
+        ctx: &mut C,
+        data: &T,
+        env: &Env,
+        region: Rect,
+    ) -> bool {
         self.clip.pan_to_visible(ctx, data, env, region)
     }
 
     /// Scroll to this position on a particular axis.
     ///
     /// Returns `true` if the scroll offset has changed.
-    pub fn scroll_to_on_axis<'a, C: CommandCtx<'a>>(&mut self, ctx: &mut C, data: &T, env: &Env, axis: Axis, position: f64) -> bool {
+    pub fn scroll_to_on_axis<'a, C: CommandCtx<'a>>(
+        &mut self,
+        ctx: &mut C,
+        data: &T,
+        env: &Env,
+        axis: Axis,
+        position: f64,
+    ) -> bool {
         self.clip.pan_to_on_axis(ctx, data, env, axis, position)
     }
 }

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -55,7 +55,7 @@ impl<T, W: Widget<T>> Scroll<T, W> {
     /// Scroll by `delta` units.
     ///
     /// Returns `true` if the scroll offset has changed.
-    pub fn scroll_by<'a, C: ChangeCtx<'a>>(&mut self, ctx: &mut C, delta: Vec2) -> bool {
+    pub fn scroll_by<C: ChangeCtx>(&mut self, ctx: &mut C, delta: Vec2) -> bool {
         self.clip.pan_by(ctx, delta)
     }
 
@@ -63,14 +63,14 @@ impl<T, W: Widget<T>> Scroll<T, W> {
     ///
     /// If the target region is larger than the viewport, we will display the
     /// portion that fits, prioritizing the portion closest to the origin.
-    pub fn scroll_to<'a, C: ChangeCtx<'a>>(&mut self, ctx: &mut C, region: Rect) -> bool {
+    pub fn scroll_to<C: ChangeCtx>(&mut self, ctx: &mut C, region: Rect) -> bool {
         self.clip.pan_to_visible(ctx, region)
     }
 
     /// Scroll to this position on a particular axis.
     ///
     /// Returns `true` if the scroll offset has changed.
-    pub fn scroll_to_on_axis<'a, C: ChangeCtx<'a>>(
+    pub fn scroll_to_on_axis<C: ChangeCtx>(
         &mut self,
         ctx: &mut C,
         axis: Axis,

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -65,7 +65,7 @@ impl<T, W: Widget<T>> Scroll<T, W> {
         self.clip.pan_by(ctx, data, env, delta)
     }
 
-    /// Scroll the minimal distance to show the target rect.
+    /// Scroll the minimal distance to show the target `region`.
     ///
     /// If the target region is larger than the viewport, we will display the
     /// portion that fits, prioritizing the portion closest to the origin.

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -55,28 +55,16 @@ impl<T, W: Widget<T>> Scroll<T, W> {
     /// Scroll by `delta` units.
     ///
     /// Returns `true` if the scroll offset has changed.
-    pub fn scroll_by<'a, C: ChangeCtx<'a>>(
-        &mut self,
-        ctx: &mut C,
-        data: &T,
-        env: &Env,
-        delta: Vec2,
-    ) -> bool {
-        self.clip.pan_by(ctx, data, env, delta)
+    pub fn scroll_by<'a, C: ChangeCtx<'a>>(&mut self, ctx: &mut C, delta: Vec2) -> bool {
+        self.clip.pan_by(ctx, delta)
     }
 
     /// Scroll the minimal distance to show the target `region`.
     ///
     /// If the target region is larger than the viewport, we will display the
     /// portion that fits, prioritizing the portion closest to the origin.
-    pub fn scroll_to<'a, C: ChangeCtx<'a>>(
-        &mut self,
-        ctx: &mut C,
-        data: &T,
-        env: &Env,
-        region: Rect,
-    ) -> bool {
-        self.clip.pan_to_visible(ctx, data, env, region)
+    pub fn scroll_to<'a, C: ChangeCtx<'a>>(&mut self, ctx: &mut C, region: Rect) -> bool {
+        self.clip.pan_to_visible(ctx, region)
     }
 
     /// Scroll to this position on a particular axis.
@@ -85,12 +73,10 @@ impl<T, W: Widget<T>> Scroll<T, W> {
     pub fn scroll_to_on_axis<'a, C: ChangeCtx<'a>>(
         &mut self,
         ctx: &mut C,
-        data: &T,
-        env: &Env,
         axis: Axis,
         position: f64,
     ) -> bool {
-        self.clip.pan_to_on_axis(ctx, data, env, axis, position)
+        self.clip.pan_to_on_axis(ctx, axis, position)
     }
 }
 
@@ -198,7 +184,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
     #[instrument(name = "Scroll", level = "trace", skip(self, ctx, event, data, env))]
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         let scroll_component = &mut self.scroll_component;
-        self.clip.with_port(ctx, data, env, |ctx, port| {
+        self.clip.with_port(ctx, |ctx, port| {
             scroll_component.event(port, ctx, event, env);
         });
         if !ctx.is_handled() {
@@ -207,7 +193,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
 
         // Handle scroll after the inner widget processed the events, to prefer inner widgets while
         // scrolling.
-        self.clip.with_port(ctx, data, env, |ctx, port| {
+        self.clip.with_port(ctx, |ctx, port| {
             scroll_component.handle_scroll(port, ctx, event, env);
 
             if !scroll_component.are_bars_held() {

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -15,7 +15,7 @@
 //! A container that scrolls its contents.
 
 use crate::commands::SCROLL_TO_VIEW;
-use crate::contexts::CommandCtx;
+use crate::contexts::ChangeCtx;
 use crate::debug_state::DebugState;
 use crate::widget::prelude::*;
 use crate::widget::{Axis, ClipBox};
@@ -55,7 +55,7 @@ impl<T, W: Widget<T>> Scroll<T, W> {
     /// Scroll by `delta` units.
     ///
     /// Returns `true` if the scroll offset has changed.
-    pub fn scroll_by<'a, C: CommandCtx<'a>>(
+    pub fn scroll_by<'a, C: ChangeCtx<'a>>(
         &mut self,
         ctx: &mut C,
         data: &T,
@@ -69,7 +69,7 @@ impl<T, W: Widget<T>> Scroll<T, W> {
     ///
     /// If the target region is larger than the viewport, we will display the
     /// portion that fits, prioritizing the portion closest to the origin.
-    pub fn scroll_to<'a, C: CommandCtx<'a>>(
+    pub fn scroll_to<'a, C: ChangeCtx<'a>>(
         &mut self,
         ctx: &mut C,
         data: &T,
@@ -82,7 +82,7 @@ impl<T, W: Widget<T>> Scroll<T, W> {
     /// Scroll to this position on a particular axis.
     ///
     /// Returns `true` if the scroll offset has changed.
-    pub fn scroll_to_on_axis<'a, C: CommandCtx<'a>>(
+    pub fn scroll_to_on_axis<'a, C: ChangeCtx<'a>>(
         &mut self,
         ctx: &mut C,
         data: &T,

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -524,14 +524,14 @@ impl<T: Data, W: Widget<T>> Widget<T> for Annotated<T, W> {
                 let child_bc = bc.shrink((label_size.width, 0.0));
                 let child_size = self.inner.layout(ctx, &child_bc, data, env);
                 self.inner
-                    .set_origin(ctx, data, env, Point::new(label_size.width, 0.0));
+                    .set_origin(ctx, Point::new(label_size.width, 0.0));
 
                 Size::new(child_size.width + label_size.width, child_size.height)
             }
             Axis::Horizontal => {
                 let child_bc = bc.shrink((0.0, label_size.height));
                 let child_size = self.inner.layout(ctx, &child_bc, data, env);
-                self.inner.set_origin(ctx, data, env, Point::ZERO);
+                self.inner.set_origin(ctx, Point::ZERO);
 
                 ctx.set_baseline_offset(self.inner.baseline_offset() + label_size.height);
                 Size::new(child_size.width, child_size.height + label_size.height)

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -496,8 +496,8 @@ impl<T: Data> Widget<T> for Split<T> {
                 Point::new(0.0, child1_size.height + bar_area)
             }
         };
-        self.child1.set_origin(ctx, data, env, child1_pos);
-        self.child2.set_origin(ctx, data, env, child2_pos);
+        self.child1.set_origin(ctx, child1_pos);
+        self.child2.set_origin(ctx, child2_pos);
 
         let paint_rect = self.child1.paint_rect().union(self.child2.paint_rect());
         let insets = paint_rect - my_size.to_rect();

--- a/druid/src/widget/tabs.rs
+++ b/druid/src/widget/tabs.rs
@@ -414,7 +414,7 @@ impl<TP: TabsPolicy> Widget<TabsState<TP>> for TabBar<TP> {
         let mut minor: f64 = 0.;
         for (_, tab) in self.tabs.iter_mut() {
             let size = tab.layout(ctx, bc, data, env);
-            tab.set_origin(ctx, data, env, self.axis.pack(major, 0.).into());
+            tab.set_origin(ctx, self.axis.pack(major, 0.).into());
             major += self.axis.major(size);
             minor = minor.max(self.axis.minor(size));
         }
@@ -692,7 +692,7 @@ impl<TP: TabsPolicy> Widget<TabsState<TP>> for TabsBody<TP> {
         // Laying out all children so events can be delivered to them.
         for child in self.child_pods() {
             child.layout(ctx, bc, inner, env);
-            child.set_origin(ctx, inner, env, Point::ORIGIN);
+            child.set_origin(ctx, Point::ORIGIN);
         }
 
         bc.max()
@@ -1059,7 +1059,7 @@ impl<TP: TabsPolicy> Widget<TP::Input> for Tabs<TP> {
     ) -> Size {
         if let TabsContent::Running { scope } = &mut self.content {
             let size = scope.layout(ctx, bc, data, env);
-            scope.set_origin(ctx, data, env, Point::ORIGIN);
+            scope.set_origin(ctx, Point::ORIGIN);
             size
         } else {
             bc.min()

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -17,7 +17,7 @@
 use std::time::Duration;
 use tracing::{instrument, trace};
 
-use crate::contexts::CommandCtx;
+use crate::contexts::ChangeCtx;
 use crate::debug_state::DebugState;
 use crate::kurbo::Insets;
 use crate::piet::TextLayout as _;
@@ -338,7 +338,7 @@ impl<T: TextStorage + EditableText> TextBox<T> {
         Rect::new(x, y0, x, y1)
     }
 
-    fn scroll_to_selection_end<'a, C: CommandCtx<'a>>(&mut self, ctx: &mut C, data: &T, env: &Env) {
+    fn scroll_to_selection_end<'a, C: ChangeCtx<'a>>(&mut self, ctx: &mut C, data: &T, env: &Env) {
         let rect = self.rect_for_selection_end();
         let view_rect = self.inner.viewport_rect();
         let is_visible =

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -17,6 +17,7 @@
 use std::time::Duration;
 use tracing::{instrument, trace};
 
+use crate::contexts::CommandCtx;
 use crate::debug_state::DebugState;
 use crate::kurbo::Insets;
 use crate::piet::TextLayout as _;
@@ -29,7 +30,6 @@ use crate::{
     theme, ArcStr, Color, Command, FontDescriptor, HotKey, KeyEvent, KeyOrValue, Point, Rect,
     SysMods, TextAlignment, TimerToken, Vec2,
 };
-use crate::contexts::CommandCtx;
 
 use super::LabelText;
 
@@ -344,7 +344,8 @@ impl<T: TextStorage + EditableText> TextBox<T> {
         let is_visible =
             view_rect.contains(rect.origin()) && view_rect.contains(Point::new(rect.x1, rect.y1));
         if !is_visible {
-            self.inner.scroll_to(ctx, data, env, rect + SCROLL_TO_INSETS);
+            self.inner
+                .scroll_to(ctx, data, env, rect + SCROLL_TO_INSETS);
         }
     }
 

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -338,14 +338,13 @@ impl<T: TextStorage + EditableText> TextBox<T> {
         Rect::new(x, y0, x, y1)
     }
 
-    fn scroll_to_selection_end<'a, C: ChangeCtx<'a>>(&mut self, ctx: &mut C, data: &T, env: &Env) {
+    fn scroll_to_selection_end<'a, C: ChangeCtx<'a>>(&mut self, ctx: &mut C) {
         let rect = self.rect_for_selection_end();
         let view_rect = self.inner.viewport_rect();
         let is_visible =
             view_rect.contains(rect.origin()) && view_rect.contains(Point::new(rect.x1, rect.y1));
         if !is_visible {
-            self.inner
-                .scroll_to(ctx, data, env, rect + SCROLL_TO_INSETS);
+            self.inner.scroll_to(ctx, rect + SCROLL_TO_INSETS);
         }
     }
 
@@ -390,7 +389,7 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
                         ctx.request_layout();
                         self.scroll_to_selection_after_layout = true;
                     } else {
-                        self.scroll_to_selection_end(ctx, data, env);
+                        self.scroll_to_selection_end(ctx);
                     }
                     ctx.set_handled();
                     ctx.request_paint();
@@ -530,7 +529,7 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
                 }
                 self.text_mut().has_focus = false;
                 if !self.multiline {
-                    self.inner.scroll_to(ctx, data, env, Rect::ZERO);
+                    self.inner.scroll_to(ctx, Rect::ZERO);
                 }
                 self.cursor_timer = TimerToken::INVALID;
                 self.was_focused_from_click = false;
@@ -589,7 +588,7 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
             + textbox_insets.y1;
         ctx.set_baseline_offset(baseline_off);
         if self.scroll_to_selection_after_layout {
-            self.scroll_to_selection_end(ctx, data, env);
+            self.scroll_to_selection_end(ctx);
             self.scroll_to_selection_after_layout = false;
         }
 

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -338,7 +338,7 @@ impl<T: TextStorage + EditableText> TextBox<T> {
         Rect::new(x, y0, x, y1)
     }
 
-    fn scroll_to_selection_end<'a, C: ChangeCtx<'a>>(&mut self, ctx: &mut C) {
+    fn scroll_to_selection_end<C: ChangeCtx>(&mut self, ctx: &mut C) {
         let rect = self.rect_for_selection_end();
         let view_rect = self.inner.viewport_rect();
         let is_visible =

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -337,13 +337,13 @@ impl<T: TextStorage + EditableText> TextBox<T> {
         Rect::new(x, y0, x, y1)
     }
 
-    fn scroll_to_selection_end(&mut self) {
+    fn scroll_to_selection_end(&mut self, ctx: &mut EventCtx) {
         let rect = self.rect_for_selection_end();
         let view_rect = self.inner.viewport_rect();
         let is_visible =
             view_rect.contains(rect.origin()) && view_rect.contains(Point::new(rect.x1, rect.y1));
         if !is_visible {
-            self.inner.scroll_to(rect + SCROLL_TO_INSETS);
+            self.inner.scroll_to(ctx, rect + SCROLL_TO_INSETS);
         }
     }
 
@@ -388,7 +388,7 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
                         ctx.request_layout();
                         self.scroll_to_selection_after_layout = true;
                     } else {
-                        self.scroll_to_selection_end();
+                        self.scroll_to_selection_end(ctx);
                     }
                     ctx.set_handled();
                     ctx.request_paint();
@@ -528,7 +528,8 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
                 }
                 self.text_mut().has_focus = false;
                 if !self.multiline {
-                    self.inner.scroll_to(Rect::ZERO);
+                    //TODO: scroll outside of event
+                    //self.inner.scroll_to(Rect::ZERO);
                 }
                 self.cursor_timer = TimerToken::INVALID;
                 self.was_focused_from_click = false;
@@ -587,7 +588,8 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
             + textbox_insets.y1;
         ctx.set_baseline_offset(baseline_off);
         if self.scroll_to_selection_after_layout {
-            self.scroll_to_selection_end();
+            //TODO: scroll during layout
+            //self.scroll_to_selection_end();
             self.scroll_to_selection_after_layout = false;
         }
 

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -29,6 +29,7 @@ use crate::{
     theme, ArcStr, Color, Command, FontDescriptor, HotKey, KeyEvent, KeyOrValue, Point, Rect,
     SysMods, TextAlignment, TimerToken, Vec2,
 };
+use crate::contexts::CommandCtx;
 
 use super::LabelText;
 
@@ -337,13 +338,13 @@ impl<T: TextStorage + EditableText> TextBox<T> {
         Rect::new(x, y0, x, y1)
     }
 
-    fn scroll_to_selection_end(&mut self, ctx: &mut EventCtx) {
+    fn scroll_to_selection_end<'a, C: CommandCtx<'a>>(&mut self, ctx: &mut C, data: &T, env: &Env) {
         let rect = self.rect_for_selection_end();
         let view_rect = self.inner.viewport_rect();
         let is_visible =
             view_rect.contains(rect.origin()) && view_rect.contains(Point::new(rect.x1, rect.y1));
         if !is_visible {
-            self.inner.scroll_to(ctx, rect + SCROLL_TO_INSETS);
+            self.inner.scroll_to(ctx, data, env, rect + SCROLL_TO_INSETS);
         }
     }
 
@@ -388,7 +389,7 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
                         ctx.request_layout();
                         self.scroll_to_selection_after_layout = true;
                     } else {
-                        self.scroll_to_selection_end(ctx);
+                        self.scroll_to_selection_end(ctx, data, env);
                     }
                     ctx.set_handled();
                     ctx.request_paint();
@@ -528,8 +529,7 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
                 }
                 self.text_mut().has_focus = false;
                 if !self.multiline {
-                    //TODO: scroll outside of event
-                    //self.inner.scroll_to(Rect::ZERO);
+                    self.inner.scroll_to(ctx, data, env, Rect::ZERO);
                 }
                 self.cursor_timer = TimerToken::INVALID;
                 self.was_focused_from_click = false;
@@ -588,8 +588,7 @@ impl<T: TextStorage + EditableText> Widget<T> for TextBox<T> {
             + textbox_insets.y1;
         ctx.set_baseline_offset(baseline_off);
         if self.scroll_to_selection_after_layout {
-            //TODO: scroll during layout
-            //self.scroll_to_selection_end();
+            self.scroll_to_selection_end(ctx, data, env);
             self.scroll_to_selection_after_layout = false;
         }
 

--- a/druid/src/widget/view_switcher.rs
+++ b/druid/src/widget/view_switcher.rs
@@ -128,7 +128,7 @@ impl<T: Data, U: Data> Widget<T> for ViewSwitcher<T, U> {
         match self.active_child {
             Some(ref mut child) => {
                 let size = child.layout(ctx, bc, data, env);
-                child.set_origin(ctx, data, env, Point::ORIGIN);
+                child.set_origin(ctx, Point::ORIGIN);
                 size
             }
             None => bc.max(),

--- a/druid/src/widget/z_stack.rs
+++ b/druid/src/widget/z_stack.rs
@@ -140,7 +140,6 @@ impl<T: Data> Widget<T> for ZStack<T> {
         }
 
         //Set origin for all Layers and calculate paint insets
-        let mut previous_child_hot = false;
         let mut paint_rect = Rect::ZERO;
 
         for layer in self.layers.iter_mut() {
@@ -149,7 +148,6 @@ impl<T: Data> Widget<T> for ZStack<T> {
             layer.child.set_origin(ctx, data, env, origin);
 
             paint_rect = paint_rect.union(layer.child.paint_rect());
-            previous_child_hot |= layer.child.is_hot();
         }
 
         ctx.set_paint_insets(paint_rect - base_size.to_rect());

--- a/druid/src/widget/z_stack.rs
+++ b/druid/src/widget/z_stack.rs
@@ -145,7 +145,7 @@ impl<T: Data> Widget<T> for ZStack<T> {
         for layer in self.layers.iter_mut() {
             let remaining = base_size - layer.child.layout_rect().size();
             let origin = layer.resolve_point(remaining);
-            layer.child.set_origin(ctx, data, env, origin);
+            layer.child.set_origin(ctx, origin);
 
             paint_rect = paint_rect.union(layer.child.paint_rect());
         }

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -512,7 +512,7 @@ impl<T: Data> Window<T> {
         data: &T,
         env: &Env,
     ) {
-        let widget_state = WidgetState::new(self.root.id(), Some(self.size));
+        let mut widget_state = WidgetState::new(self.root.id(), Some(self.size));
         let mut state = ContextState::new::<T>(
             queue,
             &self.ext_handle,
@@ -525,7 +525,7 @@ impl<T: Data> Window<T> {
         let mut ctx = PaintCtx {
             render_ctx: piet,
             state: &mut state,
-            widget_state: &widget_state,
+            widget_state: &mut widget_state,
             z_ops: Vec::new(),
             region: invalid.clone(),
             depth: 0,

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -32,7 +32,11 @@ use crate::menu::{MenuItemId, MenuManager};
 use crate::text::TextFieldRegistration;
 use crate::widget::LabelText;
 use crate::win_handler::RUN_COMMANDS_TOKEN;
-use crate::{BoxConstraints, Data, Env, Event, EventCtx, ExtEventSink, Handled, InternalEvent, InternalLifeCycle, LayoutCtx, LifeCycle, LifeCycleCtx, Menu, PaintCtx, Point, Size, TimerToken, UpdateCtx, ViewContext, Widget, WidgetId, WidgetPod};
+use crate::{
+    BoxConstraints, Data, Env, Event, EventCtx, ExtEventSink, Handled, InternalEvent,
+    InternalLifeCycle, LayoutCtx, LifeCycle, LifeCycleCtx, Menu, PaintCtx, Point, Size, TimerToken,
+    UpdateCtx, ViewContext, Widget, WidgetId, WidgetPod,
+};
 
 pub type ImeUpdateFn = dyn FnOnce(crate::shell::text::Event);
 
@@ -179,11 +183,12 @@ impl<T: Data> Window<T> {
         }
 
         if self.root.state().children_view_context_changed && !self.root.state().needs_layout {
-            let event = LifeCycle::Internal(InternalLifeCycle::RouteViewContextChanged(ViewContext {
-                parent_window_origin: Point::ORIGIN,
-                last_mouse_position: self.last_mouse_pos,
-                clip: self.size.to_rect(),
-            }));
+            let event =
+                LifeCycle::Internal(InternalLifeCycle::RouteViewContextChanged(ViewContext {
+                    parent_window_origin: Point::ORIGIN,
+                    last_mouse_position: self.last_mouse_pos,
+                    clip: self.size.to_rect(),
+                }));
             self.lifecycle(queue, &event, data, env, false);
         }
 

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -180,7 +180,7 @@ impl<T: Data> Window<T> {
 
         if self.root.state().children_view_context_changed && !self.root.state().needs_layout {
             let event = LifeCycle::Internal(InternalLifeCycle::RouteViewContextChanged(ViewContext {
-                global_origin: Point::ORIGIN,
+                parent_window_origin: Point::ORIGIN,
                 last_mouse_position: self.last_mouse_pos,
                 clip: self.size.to_rect(),
             }));
@@ -489,13 +489,7 @@ impl<T: Data> Window<T> {
         }
         self.root
             .set_origin(&mut layout_ctx, data, env, Point::ORIGIN);
-        self.lifecycle(
-            queue,
-            &LifeCycle::Internal(InternalLifeCycle::ParentWindowOrigin),
-            data,
-            env,
-            false,
-        );
+
         self.post_event_processing(&mut widget_state, queue, data, env, true);
     }
 

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -185,7 +185,7 @@ impl<T: Data> Window<T> {
         if self.root.state().children_view_context_changed && !self.root.state().needs_layout {
             let event =
                 LifeCycle::Internal(InternalLifeCycle::RouteViewContextChanged(ViewContext {
-                    parent_window_origin: Point::ORIGIN,
+                    window_origin: Point::ORIGIN,
                     last_mouse_position: self.last_mouse_pos,
                     clip: self.size.to_rect(),
                 }));

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -182,7 +182,7 @@ impl<T: Data> Window<T> {
             );
         }
 
-        if self.root.state().children_view_context_changed && !self.root.state().needs_layout {
+        if widget_state.children_view_context_changed && !widget_state.needs_layout {
             let event =
                 LifeCycle::Internal(InternalLifeCycle::RouteViewContextChanged(ViewContext {
                     window_origin: Point::ORIGIN,
@@ -194,14 +194,14 @@ impl<T: Data> Window<T> {
 
         // Update the disabled state if necessary
         // Always do this before updating the focus-chain
-        if self.root.state().tree_disabled_changed() {
+        if widget_state.tree_disabled_changed() {
             let event = LifeCycle::Internal(InternalLifeCycle::RouteDisabledChanged);
             self.lifecycle(queue, &event, data, env, false);
         }
 
         // Update the focus-chain if necessary
         // Always do this before sending focus change, since this event updates the focus chain.
-        if self.root.state().update_focus_chain {
+        if widget_state.update_focus_chain {
             let event = LifeCycle::BuildFocusChain;
             self.lifecycle(queue, &event, data, env, false);
         }
@@ -524,7 +524,7 @@ impl<T: Data> Window<T> {
         let mut ctx = PaintCtx {
             render_ctx: piet,
             state: &mut state,
-            widget_state: &mut widget_state,
+            widget_state: &widget_state,
             z_ops: Vec::new(),
             region: invalid.clone(),
             depth: 0,

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -185,7 +185,7 @@ impl<T: Data> Window<T> {
         if widget_state.children_view_context_changed && !widget_state.needs_layout {
             let event =
                 LifeCycle::Internal(InternalLifeCycle::RouteViewContextChanged(ViewContext {
-                    window_origin: Point::ORIGIN,
+                    window_origin: Point::ORIGIN, // not the same as the root widget's origin
                     last_mouse_position: self.last_mouse_pos,
                     clip: self.size.to_rect(),
                 }));

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -511,7 +511,7 @@ impl<T: Data> Window<T> {
         data: &T,
         env: &Env,
     ) {
-        let mut widget_state = WidgetState::new(self.root.id(), Some(self.size));
+        let widget_state = WidgetState::new(self.root.id(), Some(self.size));
         let mut state = ContextState::new::<T>(
             queue,
             &self.ext_handle,

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -492,8 +492,7 @@ impl<T: Data> Window<T> {
                 self.handle.set_size(full_size)
             }
         }
-        self.root
-            .set_origin(&mut layout_ctx, data, env, Point::ORIGIN);
+        self.root.set_origin(&mut layout_ctx, Point::ORIGIN);
 
         self.post_event_processing(&mut widget_state, queue, data, env, true);
     }


### PR DESCRIPTION
This PR removes the `viewport_offset` property of `WidgetPod` and changes the `ClipBox` implementation to use `WidgetPod::set_origin` instead. This will fix incorrect hot state when scrolling.


TODOs:
- [x] find a way to merge `WidgetPod::set_origin` and `WidgetPod::set_origin_dyn`
- [x] decide when hot state should change. I think the current implementation, which is doing it during layout is wrong, since we don't know the new origin in layout.
- [x] change TextBox implementation to use `scroll_to_view` and `LifeCycle::ViewContextChanged` instead of manually managing its `Scroll` widget