### PR TITLE
Creating lens from closures

### DIFF
--- a/druid/src/lens/lens.rs
+++ b/druid/src/lens/lens.rs
@@ -279,6 +279,42 @@ where
     }
 }
 
+struct LensAdapter<GETTER, SETTER>
+{
+    pub getter: GETTER,
+    pub setter: SETTER,
+}
+
+impl<U, T, GETTER, SETTER> Lens<U, T> for LensAdapter<GETTER, SETTER>
+    where GETTER: Fn(&U) -> T,
+          SETTER: Fn(&mut U, T)
+{
+    fn with<V, F: FnOnce(&T) -> V>(&self, data: &U, f: F) -> V {
+        let value = (self.getter)(data);
+        f(&value)
+    }
+
+    fn with_mut<V, F: FnOnce(&mut T) -> V>(&self, data: &mut U, f: F) -> V {
+        let mut value = (self.getter)(data);
+        let result = f(&mut value);
+        (self.setter)(data, value);
+        result
+    }
+}
+
+pub fn lens_of<U, T, GETTER, SETTER>(
+    getter: GETTER,
+    setter: SETTER,
+) -> impl Lens<U, T>
+    where GETTER: Fn(&U) -> T,
+          SETTER: Fn(&mut U, T)
+{
+    LensAdapter {
+        getter,
+        setter,
+    }
+}
+
 /// Construct a lens accessing a type's field
 ///
 /// This is a convenience macro for constructing `Field` lenses for fields or indexable elements.


### PR DESCRIPTION
Hi! (Rust newbie here)

I find it easier in my project to create Lenses from closures. Here's my attempt to simplify things. I have either:
- Came up with a good idea.
- Have got Lenses totally wrong :smile:

Please review and advise. Thanks!

PS: the reason I need closures for my lenses, are that the state struct contains fields, whose types are structs from other traits. And the actual state for a widget is deeply nested in those fields. 