### PR TITLE
X11 dialogs, take 2.

### DIFF
--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -24,7 +24,6 @@ x11 = [
     "nix",
     "pkg-config",
     "x11rb",
-    "zbus",
 ]
 wayland = [
     "wayland-client",
@@ -118,7 +117,6 @@ rand = { version = "0.8.0", optional = true }
 calloop = { version = "0.7.1", optional = true }
 log = { version = "0.4.14", optional = true }
 im = { version = "15.0.0", optional = true }
-zbus = { version = "2.1.1", optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 wasm-bindgen = "0.2.67"

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -16,7 +16,17 @@ default-target = "x86_64-pc-windows-msvc"
 [features]
 default = ["gtk"]
 gtk = ["gdk-sys", "glib-sys", "gtk-sys", "gtk-rs"]
-x11 = ["x11rb", "nix", "cairo-sys-rs", "bindgen", "pkg-config"]
+x11 = [
+    "ashpd",
+    "bindgen",
+    "cairo-sys-rs",
+    "futures",
+    "nix",
+    "pkg-config",
+    "raw-window-handle",
+    "x11rb",
+    "zbus",
+]
 wayland = [
     "wayland-client",
     "wayland-protocols/client",
@@ -68,7 +78,7 @@ keyboard-types = { version = "0.6.2", default_features = false }
 
 # Optional dependencies
 image = { version = "0.23.12", optional = true, default_features = false }
-raw-window-handle = { version = "0.3.3", optional = true, default_features = false }
+raw-window-handle = { version = "0.4.2", optional = true, default_features = false }
 
 [target.'cfg(target_os="windows")'.dependencies]
 scopeguard = "1.1.0"
@@ -91,8 +101,10 @@ bitflags = "1.2.1"
 
 [target.'cfg(any(target_os="linux", target_os="openbsd"))'.dependencies]
 # TODO(x11/dependencies): only use feature "xcb" if using X11
+ashpd = { version = "0.2.6", optional = true , features = ["raw_handle"]}
 cairo-rs = { version = "0.14.0", default_features = false, features = ["xcb"] }
 cairo-sys-rs = { version = "0.14.0", default_features = false, optional = true }
+futures = { version = "0.3.21", optional = true, features = ["executor"]}
 gdk-sys = { version = "0.14.0", optional = true }
 # `gtk` gets renamed to `gtk-rs` so that we can use `gtk` as the feature name.
 gtk-rs = { version = "0.14.0", features = ["v3_22"], package = "gtk", optional = true }
@@ -107,6 +119,7 @@ rand = { version = "0.8.0", optional = true }
 calloop = { version = "0.7.1", optional = true }
 log = { version = "0.4.14", optional = true }
 im = { version = "15.0.0", optional = true }
+zbus = { version = "2.1.1", optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 wasm-bindgen = "0.2.67"

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -23,7 +23,6 @@ x11 = [
     "futures",
     "nix",
     "pkg-config",
-    "raw-window-handle",
     "x11rb",
     "zbus",
 ]
@@ -100,8 +99,8 @@ foreign-types = "0.3.2"
 bitflags = "1.2.1"
 
 [target.'cfg(any(target_os="linux", target_os="openbsd"))'.dependencies]
+ashpd = { version = "0.2.6", optional = true }
 # TODO(x11/dependencies): only use feature "xcb" if using X11
-ashpd = { version = "0.2.6", optional = true , features = ["raw_handle"]}
 cairo-rs = { version = "0.14.0", default_features = false, features = ["xcb"] }
 cairo-sys-rs = { version = "0.14.0", default_features = false, optional = true }
 futures = { version = "0.3.21", optional = true, features = ["executor"]}

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -98,7 +98,7 @@ foreign-types = "0.3.2"
 bitflags = "1.2.1"
 
 [target.'cfg(any(target_os="linux", target_os="openbsd"))'.dependencies]
-ashpd = { version = "0.2.6", optional = true }
+ashpd = { version = "0.3.0", optional = true }
 # TODO(x11/dependencies): only use feature "xcb" if using X11
 cairo-rs = { version = "0.14.0", default_features = false, features = ["xcb"] }
 cairo-sys-rs = { version = "0.14.0", default_features = false, optional = true }

--- a/druid-shell/src/backend/x11/dialog.rs
+++ b/druid-shell/src/backend/x11/dialog.rs
@@ -1,0 +1,169 @@
+//! This module contains functions for opening file dialogs using DBus.
+
+use ashpd::desktop::file_chooser;
+use ashpd::WindowIdentifier;
+use futures::executor::block_on;
+use raw_window_handle::{RawWindowHandle, XcbHandle};
+use tracing::warn;
+
+use crate::{FileDialogOptions, FileDialogToken, FileInfo};
+
+use super::window::IdleHandle;
+
+pub(crate) fn open_file(
+    window: u32,
+    idle: IdleHandle,
+    options: FileDialogOptions,
+) -> FileDialogToken {
+    dialog(window, idle, options, true)
+}
+
+pub(crate) fn save_file(
+    window: u32,
+    idle: IdleHandle,
+    options: FileDialogOptions,
+) -> FileDialogToken {
+    dialog(window, idle, options, false)
+}
+
+fn dialog(
+    window: u32,
+    idle: IdleHandle,
+    mut options: FileDialogOptions,
+    open: bool,
+) -> FileDialogToken {
+    let tok = FileDialogToken::next();
+
+    std::thread::spawn(move || {
+        if let Err(e) = block_on(async {
+            let mut handle = XcbHandle::empty();
+            handle.window = window;
+
+            let conn = zbus::Connection::session().await?;
+            let proxy = file_chooser::FileChooserProxy::new(&conn).await?;
+            let id = WindowIdentifier::from_raw_handle(&RawWindowHandle::Xcb(handle));
+            let multi = options.multi_selection;
+
+            let title_owned = options.title.take();
+            let title = match (open, options.select_directories) {
+                (true, true) => "Open Folder",
+                (true, false) => "Open File",
+                (false, _) => "Save File",
+            };
+            let title = title_owned.as_deref().unwrap_or(title);
+
+            let callback = move |uris: &[String]| {
+                let mut paths = uris.iter().filter_map(|s| {
+                    s.strip_prefix("file://").or_else(|| {
+                        warn!("expected path '{}' to start with 'file://'", s);
+                        None
+                    })
+                });
+                if multi && open {
+                    let infos = paths
+                        .map(|p| FileInfo {
+                            path: p.into(),
+                            format: None,
+                        })
+                        .collect();
+                    idle.add_idle_callback(move |handler| handler.open_files(tok, infos));
+                } else if !multi {
+                    if uris.len() > 2 {
+                        warn!(
+                            "expected one path (got {}), returning only the first",
+                            uris.len()
+                        );
+                    }
+                    let info = paths.next().map(|p| FileInfo {
+                        path: p.into(),
+                        format: None,
+                    });
+                    if open {
+                        idle.add_idle_callback(move |handler| handler.open_file(tok, info));
+                    } else {
+                        idle.add_idle_callback(move |handler| handler.save_as(tok, info));
+                    }
+                } else {
+                    warn!("cannot save multiple paths");
+                }
+            };
+
+            if open {
+                callback(proxy.open_file(&id, title, options.into()).await?.uris());
+            } else {
+                callback(proxy.save_file(&id, title, options.into()).await?.uris());
+            };
+
+            Ok(()) as ashpd::Result<()>
+        }) {
+            warn!("error while opening file dialog: {}", e);
+        }
+    });
+
+    tok
+}
+
+impl From<crate::FileSpec> for file_chooser::FileFilter {
+    fn from(spec: crate::FileSpec) -> file_chooser::FileFilter {
+        let mut filter = file_chooser::FileFilter::new(spec.name);
+        for ext in spec.extensions {
+            filter = filter.glob(&format!("*.{}", ext));
+        }
+        filter
+    }
+}
+
+impl From<crate::FileDialogOptions> for file_chooser::OpenFileOptions {
+    fn from(opts: crate::FileDialogOptions) -> file_chooser::OpenFileOptions {
+        let mut fc = file_chooser::OpenFileOptions::default()
+            .modal(true)
+            .multiple(opts.multi_selection)
+            .directory(opts.select_directories);
+
+        if let Some(label) = &opts.button_text {
+            fc = fc.accept_label(label);
+        }
+
+        if let Some(filters) = opts.allowed_types {
+            for f in filters {
+                fc = fc.add_filter(f.into());
+            }
+        }
+
+        if let Some(filter) = opts.default_type {
+            fc = fc.current_filter(filter.into());
+        }
+
+        fc
+    }
+}
+
+impl From<crate::FileDialogOptions> for file_chooser::SaveFileOptions {
+    fn from(opts: crate::FileDialogOptions) -> file_chooser::SaveFileOptions {
+        let mut fc = file_chooser::SaveFileOptions::default().modal(true);
+
+        if let Some(name) = &opts.default_name {
+            fc = fc.current_name(name);
+        }
+
+        if let Some(label) = &opts.button_text {
+            fc = fc.accept_label(label);
+        }
+
+        if let Some(filters) = opts.allowed_types {
+            for f in filters {
+                fc = fc.add_filter(f.into());
+            }
+        }
+
+        if let Some(filter) = opts.default_type {
+            fc = fc.current_filter(filter.into());
+        }
+
+        if let Some(dir) = &opts.starting_directory {
+            fc = fc.current_folder(dir);
+        }
+
+        fc
+    }
+}

--- a/druid-shell/src/backend/x11/dialog.rs
+++ b/druid-shell/src/backend/x11/dialog.rs
@@ -1,7 +1,7 @@
 //! This module contains functions for opening file dialogs using DBus.
 
 use ashpd::desktop::file_chooser;
-use ashpd::WindowIdentifier;
+use ashpd::{zbus, WindowIdentifier};
 use futures::executor::block_on;
 use tracing::warn;
 

--- a/druid-shell/src/backend/x11/dialog.rs
+++ b/druid-shell/src/backend/x11/dialog.rs
@@ -26,7 +26,7 @@ pub(crate) fn save_file(
 }
 
 fn dialog(
-    _window: u32,
+    window: u32,
     idle: IdleHandle,
     mut options: FileDialogOptions,
     open: bool,
@@ -37,8 +37,7 @@ fn dialog(
         if let Err(e) = block_on(async {
             let conn = zbus::Connection::session().await?;
             let proxy = file_chooser::FileChooserProxy::new(&conn).await?;
-            // TODO: use the window id. This requires changes in ashpd.
-            let id = WindowIdentifier::default();
+            let id = WindowIdentifier::from_xid(window as u64);
             let multi = options.multi_selection;
 
             let title_owned = options.title.take();

--- a/druid-shell/src/backend/x11/dialog.rs
+++ b/druid-shell/src/backend/x11/dialog.rs
@@ -3,7 +3,6 @@
 use ashpd::desktop::file_chooser;
 use ashpd::WindowIdentifier;
 use futures::executor::block_on;
-use raw_window_handle::{RawWindowHandle, XcbHandle};
 use tracing::warn;
 
 use crate::{FileDialogOptions, FileDialogToken, FileInfo};
@@ -27,7 +26,7 @@ pub(crate) fn save_file(
 }
 
 fn dialog(
-    window: u32,
+    _window: u32,
     idle: IdleHandle,
     mut options: FileDialogOptions,
     open: bool,
@@ -36,12 +35,10 @@ fn dialog(
 
     std::thread::spawn(move || {
         if let Err(e) = block_on(async {
-            let mut handle = XcbHandle::empty();
-            handle.window = window;
-
             let conn = zbus::Connection::session().await?;
             let proxy = file_chooser::FileChooserProxy::new(&conn).await?;
-            let id = WindowIdentifier::from_raw_handle(&RawWindowHandle::Xcb(handle));
+            // TODO: use the window id. This requires changes in ashpd.
+            let id = WindowIdentifier::default();
             let multi = options.multi_selection;
 
             let title_owned = options.title.take();

--- a/druid-shell/src/backend/x11/mod.rs
+++ b/druid-shell/src/backend/x11/mod.rs
@@ -35,6 +35,7 @@ mod util;
 
 pub mod application;
 pub mod clipboard;
+pub mod dialog;
 pub mod error;
 pub mod menu;
 pub mod screen;


### PR DESCRIPTION
This supersedes #1774 (which I'll close). It has the same [bug](https://github.com/linebender/druid/pull/1774#issuecomment-846762795), which doesn't seem solvable without some acknowledgement from `xdg-desktop-portal`. I'm still not thrilled about this situation, but I don't see another viable path forward to native file dialogs on x11 (and wayland). Therefore I'm inclined to just merge this despite the issue.