### PR TITLE
Implement RadioGroup::{row,column,for_axis} to allow layout customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - Dont warn about unhandled `Notification`s which have `known_target` set to false ([#2141] by [@xarvic])
 - `ClipBox`, `Flex`, `List` and `Split` only call layout on children which need it ([#2145] by [@xarvic]) 
 - `SizedBox` now supports using `Key<f64>` for specifying  size ([#2151] by [@GoldsteinE])
+- `RadioGroup` widgets are now constructed with new `row()`, `column()`, and `for_axis()` methods ([#2157] by [@twitchyliquid64])
 
 ### Deprecated
 
@@ -550,6 +551,7 @@ Last release without a changelog :(
 [@maurerdietmar]: https://github.com/maurerdietmar
 [@superfell]: https://github.com/superfell
 [@GoldsteinE]: https://github.com/GoldsteinE
+[@twitchyliquid64]: https://github.com/twitchyliquid64
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611
@@ -840,6 +842,7 @@ Last release without a changelog :(
 [#2145]: https://github.com/linebender/druid/pull/2145
 [#2148]: https://github.com/linebender/druid/pull/2148
 [#2151]: https://github.com/linebender/druid/pull/2151
+[#2157]: https://github.com/linebender/druid/pull/2157
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid/examples/flex.rs
+++ b/druid/examples/flex.rs
@@ -158,7 +158,7 @@ fn make_control_row() -> impl Widget<AppState> {
                 .cross_axis_alignment(CrossAxisAlignment::Start)
                 .with_child(Label::new("Type:"))
                 .with_default_spacer()
-                .with_child(RadioGroup::new(FLEX_TYPE_OPTIONS.to_vec()).lens(Params::axis)),
+                .with_child(RadioGroup::column(FLEX_TYPE_OPTIONS.to_vec()).lens(Params::axis)),
         )
         .with_default_spacer()
         .with_child(
@@ -167,7 +167,7 @@ fn make_control_row() -> impl Widget<AppState> {
                 .with_child(Label::new("CrossAxis:"))
                 .with_default_spacer()
                 .with_child(
-                    RadioGroup::new(CROSS_AXIS_ALIGNMENT_OPTIONS.to_vec())
+                    RadioGroup::column(CROSS_AXIS_ALIGNMENT_OPTIONS.to_vec())
                         .lens(Params::cross_alignment),
                 ),
         )
@@ -178,7 +178,7 @@ fn make_control_row() -> impl Widget<AppState> {
                 .with_child(Label::new("MainAxis:"))
                 .with_default_spacer()
                 .with_child(
-                    RadioGroup::new(MAIN_AXIS_ALIGNMENT_OPTIONS.to_vec())
+                    RadioGroup::column(MAIN_AXIS_ALIGNMENT_OPTIONS.to_vec())
                         .lens(Params::main_alignment),
                 ),
         )
@@ -209,7 +209,7 @@ fn make_spacer_select() -> impl Widget<Params> {
         .cross_axis_alignment(CrossAxisAlignment::Start)
         .with_child(Label::new("Insert Spacers:"))
         .with_default_spacer()
-        .with_child(RadioGroup::new(SPACER_OPTIONS.to_vec()).lens(Params::spacers))
+        .with_child(RadioGroup::column(SPACER_OPTIONS.to_vec()).lens(Params::spacers))
         .with_default_spacer()
         .with_child(
             Flex::row()

--- a/druid/examples/image.rs
+++ b/druid/examples/image.rs
@@ -116,7 +116,7 @@ fn make_control_row() -> impl Widget<AppState> {
                 .with_child(Label::new("FillStrat:"))
                 .with_default_spacer()
                 .with_child(
-                    RadioGroup::new(FILL_STRAT_OPTIONS.to_vec()).lens(AppState::fill_strat),
+                    RadioGroup::column(FILL_STRAT_OPTIONS.to_vec()).lens(AppState::fill_strat),
                 ),
         )
         .with_default_spacer()
@@ -126,7 +126,7 @@ fn make_control_row() -> impl Widget<AppState> {
                 .with_child(Label::new("interpolation mode:"))
                 .with_default_spacer()
                 .with_child(
-                    RadioGroup::new(INTERPOLATION_MODE_OPTIONS.to_vec())
+                    RadioGroup::column(INTERPOLATION_MODE_OPTIONS.to_vec())
                         .lens(AppState::interpolation_mode),
                 ),
         )

--- a/druid/examples/tabs.rs
+++ b/druid/examples/tabs.rs
@@ -114,7 +114,7 @@ fn build_root_widget() -> impl Widget<AppState> {
 
     let axis_picker = group(
         "Tab bar axis",
-        RadioGroup::new(vec![
+        RadioGroup::column(vec![
             ("Horizontal", Axis::Horizontal),
             ("Vertical", Axis::Vertical),
         ])
@@ -123,7 +123,7 @@ fn build_root_widget() -> impl Widget<AppState> {
 
     let cross_picker = group(
         "Tab bar edge",
-        RadioGroup::new(vec![
+        RadioGroup::column(vec![
             ("Leading", TabsEdge::Leading),
             ("Trailing", TabsEdge::Trailing),
         ])
@@ -132,7 +132,7 @@ fn build_root_widget() -> impl Widget<AppState> {
 
     let transit_picker = group(
         "Transition",
-        RadioGroup::new(vec![
+        RadioGroup::column(vec![
             ("Instant", TabsTransition::Instant),
             (
                 "Slide",

--- a/druid/examples/text.rs
+++ b/druid/examples/text.rs
@@ -123,7 +123,7 @@ fn build_root_widget() -> impl Widget<AppState> {
     let line_break_chooser = Flex::column()
         .with_child(Label::new("Line break mode"))
         .with_spacer(SPACER_SIZE)
-        .with_child(RadioGroup::new(vec![
+        .with_child(RadioGroup::column(vec![
             ("Clip", LineBreaking::Clip),
             ("Wrap", LineBreaking::WordWrap),
             ("Overflow", LineBreaking::Overflow),
@@ -133,7 +133,7 @@ fn build_root_widget() -> impl Widget<AppState> {
     let alignment_picker = Flex::column()
         .with_child(Label::new("Justification"))
         .with_spacer(SPACER_SIZE)
-        .with_child(RadioGroup::new(vec![
+        .with_child(RadioGroup::column(vec![
             ("Start", TextAlignment::Start),
             ("End", TextAlignment::End),
             ("Center", TextAlignment::Center),

--- a/druid/examples/widget_gallery.rs
+++ b/druid/examples/widget_gallery.rs
@@ -145,7 +145,7 @@ fn ui_builder() -> impl Widget<AppData> {
                 "Painter",
             ))
             .with_child(label_widget(
-                RadioGroup::new(vec![
+                RadioGroup::column(vec![
                     ("radio gaga", MyRadio::GaGa),
                     ("radio gugu", MyRadio::GuGu),
                     ("radio baabaa", MyRadio::BaaBaa),

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -17,7 +17,7 @@
 use crate::debug_state::DebugState;
 use crate::kurbo::Circle;
 use crate::widget::prelude::*;
-use crate::widget::{CrossAxisAlignment, Flex, Label, LabelText};
+use crate::widget::{Axis, CrossAxisAlignment, Flex, Label, LabelText};
 use crate::{theme, Data, LinearGradient, UnitPoint};
 use tracing::{instrument, trace};
 
@@ -29,10 +29,28 @@ pub struct RadioGroup;
 
 impl RadioGroup {
     /// Given a vector of `(label_text, enum_variant)` tuples, create a group of Radio buttons
-    pub fn new<T: Data + PartialEq>(
+    /// along the vertical axis.
+    pub fn column<T: Data + PartialEq>(
         variants: impl IntoIterator<Item = (impl Into<LabelText<T>> + 'static, T)>,
     ) -> impl Widget<T> {
-        let mut col = Flex::column().cross_axis_alignment(CrossAxisAlignment::Start);
+        RadioGroup::for_axis(Axis::Vertical, variants)
+    }
+
+    /// Given a vector of `(label_text, enum_variant)` tuples, create a group of Radio buttons
+    /// along the horizontal axis.
+    pub fn row<T: Data + PartialEq>(
+        variants: impl IntoIterator<Item = (impl Into<LabelText<T>> + 'static, T)>,
+    ) -> impl Widget<T> {
+        RadioGroup::for_axis(Axis::Horizontal, variants)
+    }
+
+    /// Given a vector of `(label_text, enum_variant)` tuples, create a group of Radio buttons
+    /// along the specified axis.
+    pub fn for_axis<T: Data + PartialEq>(
+        axis: Axis,
+        variants: impl IntoIterator<Item = (impl Into<LabelText<T>> + 'static, T)>,
+    ) -> impl Widget<T> {
+        let mut col = Flex::for_axis(axis).cross_axis_alignment(CrossAxisAlignment::Start);
         let mut is_first = true;
         for (label, variant) in variants.into_iter() {
             if !is_first {


### PR DESCRIPTION
Trivial change to allow the user to set the Axis on which Radio's are laid out. Breaking change in that `RadioGroup::new` is now `RadioGroup::column`.

Builder methods `column()`, `row()`, `for_axis()` are consistent with the `Flex` widget.