### PR TITLE
Adjust README code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,15 @@ use druid::widget::{Button, Flex, Label};
 use druid::{AppLauncher, LocalizedString, PlatformError, Widget, WidgetExt, WindowDesc};
 
 fn main() -> Result<(), PlatformError> {
-    let main_window = WindowDesc::new(ui_builder());
+    let main_window = WindowDesc::new(|| ui_builder());
     let data = 0_u32;
     AppLauncher::with_window(main_window)
-        .log_to_console()
         .launch(data)
 }
 
 fn ui_builder() -> impl Widget<u32> {
     // The label text will be computed dynamically based on the current locale and count
-    let text =
-        LocalizedString::new("hello-counter").with_arg("count", |data: &u32, _env| (*data).into());
+    let text = LocalizedString::new("hello-counter").with_arg("count", |data: &u32, _env| (*data).into());
     let label = Label::new(text).padding(5.0).center();
     let button = Button::new("increment")
         .on_click(|_ctx, data, _env| *data += 1)


### PR DESCRIPTION
Looking into the example, the README code snippet contains compilation errors and cannot be run. This PR contains minimal changes to make the example runnable and usable. 