### PR TITLE
Separation of Concern by separating presentation from event handling widgets

### DIFF
--- a/xilem/examples/counter.rs
+++ b/xilem/examples/counter.rs
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 use xilem::{button, v_stack, Adapt, App, AppLauncher, LayoutObserver, Memoize, View};
+use xilem::interactive::{Interactive, ClickController, ClickEvents, InteractiveExt, LeftClick};
+use xilem::label::Label;
+use xilem::EventResult;
+
 
 #[derive(Default)]
 struct AppData {
@@ -25,6 +29,26 @@ fn count_button(count: u32) -> impl View<u32> {
 
 fn app_logic(data: &mut AppData) -> impl View<AppData> {
     v_stack((
+        Interactive::<ClickController>::new(
+            Label::new(format!("this is a clickable label: {}", data.count)),
+            |event, _controller, data: &mut AppData| {
+                data.count += 1;
+                match event {
+                    ClickEvents::LeftClick => println!("LeftClick"),
+                    ClickEvents::MiddleClick => println!("MiddleClick"),
+                    ClickEvents::RightClick => println!("RightClick"),
+                };
+                EventResult::Nop
+            }
+        ),
+
+        format!("this is another clickable label: {}", data.count)
+            .handle_event::<LeftClick, _>(|data: &mut AppData| {
+                data.count += 1;
+                println!("simple click handler");
+                EventResult::Nop
+            }),
+
         format!("count: {}", data.count),
         button("reset", |data: &mut AppData| data.count = 0),
         Memoize::new(data.count, |count| {

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -35,3 +35,7 @@ pub use view::vstack::v_stack;
 pub use view::View;
 pub use widget::align::{AlignmentAxis, AlignmentProxy, HorizAlignment, VertAlignment};
 pub use widget::Widget;
+
+pub use view::interactive;
+pub use event::EventResult;
+pub use view::label;

--- a/xilem/src/view.rs
+++ b/xilem/src/view.rs
@@ -20,6 +20,8 @@ pub mod memoize;
 pub mod text;
 pub mod use_state;
 pub mod vstack;
+pub mod interactive;
+pub mod label;
 
 use std::any::Any;
 

--- a/xilem/src/view/interactive.rs
+++ b/xilem/src/view/interactive.rs
@@ -1,0 +1,151 @@
+use crate::{Widget, widget::RawEvent};
+use std::{any::Any, marker::PhantomData};
+
+use crate::{
+    id::{Id},
+};
+
+pub trait MaybeFrom<T>: Sized {
+    fn maybe_from(value: &T) -> Option<Self>;
+}
+
+pub trait Controller: Default {
+    type Event: MaybeFrom<RawEvent>;
+}
+pub struct Interactive<C: Controller>{
+    phantom: PhantomData<C>,
+}
+
+impl<C: Controller> Interactive<C> {
+    pub fn new<T, A, V: View<T, A>>(child: V, handler: impl Fn(&C::Event, &mut C, &mut T) -> crate::event::EventResult<A> + 'static) -> InteractiveView<C, C::Event, T, A, V> {
+        InteractiveView::new(child, handler)
+    }
+}
+
+pub struct InteractiveView<C, E, T, A, V: View<T, A>> {
+    child: V,
+    // phantom: PhantomData<(T, A)>,
+    handler: Box<dyn Fn(&E, &mut C, &mut T) -> crate::event::EventResult<A>>,
+}
+
+impl<C, E, T, A, V: View<T, A>> InteractiveView<C, E, T, A, V>  {
+    pub fn new(child: V, handler: impl Fn(&E, &mut C, &mut T) -> crate::event::EventResult<A> + 'static) -> Self {
+        InteractiveView { child, handler: Box::new(handler) }
+    }
+}
+
+use super::View;
+
+impl<C: Default, E: 'static + MaybeFrom<RawEvent>, T, A, V: View<T, A>> View<T,A> for InteractiveView<C, E, T, A, V> 
+where
+    V::Element: Widget,
+{
+    type State = (C, V::State);
+
+    type Element = crate::widget::interactive::Interactive<V::Element, E>;
+
+    
+    fn build(&self, cx: &mut super::Cx) -> (Id, Self::State, Self::Element) {
+        let (id, (state, interactive)) = cx.with_new_id(|cx| {
+            let (innerId, state, element) = self.child.build(cx);
+            let interactive = crate::widget::interactive::Interactive::new(cx.id_path(), element);
+
+            ((Default::default(), state), interactive)
+        });
+        
+        (id, state, interactive)
+    }
+
+
+    fn rebuild(
+        &self,
+        cx: &mut super::Cx,
+        prev: &Self,
+        id: &mut Id,
+        state: &mut Self::State,
+        element: &mut Self::Element,
+    ) -> bool {
+        cx.with_id(*id, |cx| {
+            self.child
+            .rebuild(cx, &prev.child, id, &mut state.1, element.child_mut())
+        })
+    }
+
+    fn event(
+            &self,
+            id_path: &[Id],
+            state: &mut Self::State,
+            event: Box<dyn Any>,
+            app_state: &mut T,
+        ) -> crate::event::EventResult<A> {
+        (self.handler)(&event.downcast::<E>().expect("THERE SHOULD BE AN E IN HERE"), &mut state.0, app_state)
+    }
+}
+
+pub trait InteractiveExt<T, A, V: View<T, A>> {
+    fn handle_events_with_controller<C: Controller>(self, handler: impl Fn(&C::Event, &mut C, &mut T) -> crate::event::EventResult<A> + 'static) -> InteractiveView<C, C::Event, T, A, V>;
+
+    fn handle_events<E>(self, handler: impl Fn(&E, &mut T) -> crate::event::EventResult<A> + 'static) -> InteractiveView<(), E, T, A, V>;
+
+    fn handle_event<E, H: Fn(&mut T) -> crate::event::EventResult<A> + 'static>(self, handler: H ) -> InteractiveView<(), E, T, A, V>;
+}
+
+impl<T, A, V: View<T, A>> InteractiveExt<T, A, V> for V {
+    fn handle_events_with_controller<C: Controller>(self, handler: impl Fn(&C::Event, &mut C, &mut T) -> crate::event::EventResult<A> + 'static) -> InteractiveView<C, C::Event, T, A, V> {
+        InteractiveView::new(self, handler)
+    }
+
+    fn handle_events<E>(self, handler: impl Fn(&E, &mut T) -> crate::event::EventResult<A> + 'static) -> InteractiveView<(), E, T, A, V> {
+        InteractiveView::new(self, move |event, _, data| {
+            handler(event, data)
+        })
+    }
+
+    fn handle_event<E, H : Fn(&mut T) -> crate::event::EventResult<A> + 'static>(self, handler: H ) -> InteractiveView<(), E, T, A, V>{
+        InteractiveView::new(self, move |_, _, data| {
+            handler(data)
+        })
+    }
+}
+
+pub enum ClickEvents {
+    LeftClick,
+    MiddleClick,
+    RightClick
+}
+
+impl MaybeFrom<RawEvent> for ClickEvents {
+    fn maybe_from(value: &RawEvent) -> Option<Self> {
+        match value {
+            RawEvent::MouseUp(event) => if event.button.is_left() {
+                Some(ClickEvents::LeftClick)
+            } else {
+                None
+            }
+            _ => None
+        }
+        
+    }
+}
+
+#[derive(Default)]
+pub struct ClickController {}
+
+impl Controller for ClickController {
+    type Event = ClickEvents;
+}
+
+pub struct LeftClick {}
+
+impl MaybeFrom<RawEvent> for LeftClick {
+    fn maybe_from(value: &RawEvent) -> Option<Self> {
+        match value {
+            RawEvent::MouseUp(event) => if event.button.is_left() {
+                Some(LeftClick{})
+            } else {
+                None
+            }
+            _ => None
+        }
+    }
+}

--- a/xilem/src/view/label.rs
+++ b/xilem/src/view/label.rs
@@ -1,0 +1,69 @@
+// Copyright 2022 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{any::Any};
+
+use crate::{event::EventResult, id::Id};
+
+use super::{Cx, View};
+
+pub struct Label {
+    label: String,
+}
+
+impl Label {
+    pub fn new(label: impl Into<String>) -> Self {
+        Label {
+            label: label.into(),
+        }
+    }
+}
+
+impl<T> View<T, ()> for Label {
+    type State = ();
+
+    type Element = crate::widget::label::Label;
+
+    fn build(&self, cx: &mut Cx) -> (Id, Self::State, Self::Element) {
+        let (id, element) = cx
+            .with_new_id(|cx| crate::widget::label::Label::new(self.label.clone()));
+        (id, (), element)
+    }
+
+    fn rebuild(
+            &self,
+            cx: &mut super::Cx,
+            prev: &Self,
+            id: &mut Id,
+            state: &mut Self::State,
+            element: &mut Self::Element,
+        ) -> bool {
+        if prev.label != self.label {
+            element.set_label(self.label.clone());
+            true
+        } else {
+            false
+        }
+    }
+
+    fn event(
+            &self,
+            id_path: &[crate::id::Id],
+            state: &mut Self::State,
+            event: Box<dyn Any>,
+            app_state: &mut T,
+        ) -> crate::event::EventResult<()> {
+        EventResult::Nop
+    }
+}

--- a/xilem/src/widget.rs
+++ b/xilem/src/widget.rs
@@ -20,6 +20,8 @@ pub mod layout_observer;
 mod raw_event;
 pub mod text;
 pub mod vstack;
+pub mod interactive;
+pub mod label;
 
 use std::any::Any;
 use std::ops::{Deref, DerefMut};

--- a/xilem/src/widget/interactive.rs
+++ b/xilem/src/widget/interactive.rs
@@ -1,0 +1,79 @@
+// Copyright 2022 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::marker::PhantomData;
+
+use druid_shell::{
+    kurbo::{Point, Size},
+    piet::{Piet},
+};
+
+use crate::{event::Event, id::IdPath, view::interactive::MaybeFrom};
+use super::{Widget};
+
+
+#[derive(Default)]
+
+pub struct Interactive<W: Widget, E> {
+    id_path: IdPath,
+    child: W,
+    phanton: PhantomData<E>
+}
+
+impl<W: Widget, E> Interactive<W, E> {
+    pub fn new(id_path: &IdPath, child: W) -> Self {
+        Interactive {
+            id_path: id_path.clone(),
+            child,
+            phanton: Default::default()
+        }
+    }
+    
+    pub fn child_mut(&mut self) -> &mut W {
+        &mut self.child
+    }
+}
+
+impl<'a, W: Widget, E: 'static + MaybeFrom<super::RawEvent>> Widget for Interactive<W, E> {
+    fn event(&mut self, cx: &mut super::EventCx, event: &super::RawEvent) {
+        match E::maybe_from(event) {
+            Some(e) => {
+                cx.add_event(Event::new(self.id_path.clone(), e))
+            },
+            _ => {
+                // not an event we are interested in
+            }
+        }
+    }
+
+    fn layout(&mut self, cx: &mut super::LayoutCx, proposed_size: Size) -> Size {
+        self.child.layout(cx, proposed_size)
+    }
+    
+    fn paint(&mut self, cx: &mut super::PaintCx) {
+        self.child.paint(cx)
+    }
+
+    fn lifecycle(&mut self, cx: &mut super::contexts::LifeCycleCx, event: &super::LifeCycle) {
+        self.child.lifecycle(cx, event)
+    }
+
+    fn update(&mut self, cx: &mut super::UpdateCx) {
+        self.child.update(cx)
+    }
+
+    fn prelayout(&mut self, cx: &mut super::LayoutCx) -> (Size, Size) {
+        self.child.prelayout(cx)
+    }
+}

--- a/xilem/src/widget/label.rs
+++ b/xilem/src/widget/label.rs
@@ -1,0 +1,99 @@
+// Copyright 2022 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use druid_shell::{
+    kurbo::{Insets, Size},
+    piet::{
+        Color, LinearGradient, PietTextLayout, RenderContext, Text, TextLayout, TextLayoutBuilder,
+        UnitPoint,
+    },
+};
+
+use crate::{event::Event, id::IdPath, VertAlignment};
+
+use super::{
+    align::{FirstBaseline, LastBaseline, SingleAlignment},
+    contexts::LifeCycleCx,
+    AlignCx, EventCx, LayoutCx, LifeCycle, PaintCx, RawEvent, UpdateCx, Widget,
+};
+
+#[derive(Default)]
+
+pub struct Label {
+    // id_path: IdPath,
+    label: String,
+    layout: Option<PietTextLayout>,
+}
+
+impl Label {
+    // pub fn new(id_path: &IdPath, label: String) -> Label {
+    pub fn new(label: String) -> Label {
+        Label {
+            // id_path: id_path.clone(),
+            label,
+            layout: None
+        }
+    }
+
+    pub fn set_label(&mut self, label: String) {
+        self.label = label;
+    }
+}
+
+impl Widget for Label {
+    fn update(&mut self, cx: &mut UpdateCx) {
+        cx.request_layout()
+    }
+
+    fn event(&mut self, cx: &mut EventCx, event: &RawEvent) {}
+
+    fn lifecycle(&mut self, cx: &mut LifeCycleCx, event: &LifeCycle) {
+        match event {
+            LifeCycle::HotChanged(_) => cx.request_paint(),
+            _ => (),
+        }
+    }
+
+    fn prelayout(&mut self, cx: &mut LayoutCx) -> (Size, Size) {
+        let min_height = 24.0;
+        let layout = cx
+            .text()
+            .new_text_layout(self.label.clone())
+            .text_color(Color::WHITE)
+            .build()
+            .unwrap();
+        let size = Size::new(
+            layout.size().width,
+            (layout.size().height).max(min_height),
+        );
+        self.layout = Some(layout);
+        (Size::new(10.0, min_height), size)
+    }
+
+    fn layout(&mut self, cx: &mut LayoutCx, proposed_size: Size) -> Size {
+        let size = Size::new(
+            proposed_size
+                .width
+                .clamp(cx.min_size().width, cx.max_size().width),
+            cx.max_size().height,
+        );
+        size
+    }
+
+    fn paint(&mut self, cx: &mut PaintCx) {
+        let layout = self.layout.as_ref().unwrap();
+        let offset = (cx.size().to_vec2() - layout.size().to_vec2()) * 0.5;
+        cx.draw_text(layout, offset.to_point());
+    }
+}


### PR DESCRIPTION
# Preface

after reading #2159 and #2160 i felt compelled to share some of the ideas gathered in my own GUI experiments

# The Idea

is basically separation of concern. Instead of having a `Button` widget which handels presentation *and* logic this PR proposes a way to attach specific behaviors to  "purely presentation" widgets, thereby allowing for customizability of appearance and interaction.

The issue presented in #2159 would thus be solved with the proposed architecture as follows:

```rust
Row::new((
    Icon::new(Symbol::PlusOnes),
    Label::new("increment"),
))
.handle_event::<LeftClick, _>(|data| {
    *data += 1;
})
```

similarly a OpenUI-like dropdown would wrap widgets handling presentation of the dropdown button, the suggestion list etc in ` Interactive::<ClickController>::new(...)`, ` Interactive::<ScrollController>::new()` and the like.

# Future direction

another idea which emerged from my experiments is to further separate the visual layer by providing a `impl Theme` as a type parameter to the Widgets, where the `Theme` would be responsible for the actual visual presentation, thus superseding current `env` based way. The base `trait Theme` would then provide a default `impl` of a basic, minimally styled widget presentations. (c.f. [Iced per widget `render` traits](https://github.com/iced-rs/iced/blob/0.3/native/src/widget/button.rs#L253-L278))

```rust
Column::new((
    Label::<FancyTheme>::new("i am fancy"),
    Label::<SeriousTheme>::new("i am serious"),
))
```

I am very much looking for feedback on these ideas.

P.S.

i apologise for this PR not being formatted properly, it was not clear to me how PRs for research branches are to be prepared.