### PR TITLE
impl Sync for IdleHandle

### DIFF
--- a/druid-shell/src/backend/mac/window.rs
+++ b/druid-shell/src/backend/mac/window.rs
@@ -1424,6 +1424,7 @@ unsafe impl HasRawWindowHandle for WindowHandle {
 }
 
 unsafe impl Send for IdleHandle {}
+unsafe impl Sync for IdleHandle {}
 
 impl IdleHandle {
     fn add_idle(&self, idle: IdleKind) {

--- a/druid-shell/src/backend/web/window.rs
+++ b/druid-shell/src/backend/web/window.rs
@@ -688,6 +688,7 @@ impl WindowHandle {
 }
 
 unsafe impl Send for IdleHandle {}
+unsafe impl Sync for IdleHandle {}
 
 impl IdleHandle {
     /// Add an idle handler, which is called (once) when the main thread is idle.

--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -2236,6 +2236,7 @@ impl WindowHandle {
 
 // There is a tiny risk of things going wrong when hwnd is sent across threads.
 unsafe impl Send for IdleHandle {}
+unsafe impl Sync for IdleHandle {}
 
 impl IdleHandle {
     /// Add an idle handler, which is called (once) when the message loop

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -716,5 +716,5 @@ mod test {
     use static_assertions as sa;
 
     sa::assert_not_impl_any!(WindowHandle: Send, Sync);
-    sa::assert_impl_all!(IdleHandle: Send);
+    sa::assert_impl_all!(IdleHandle: Send, Sync);
 }


### PR DESCRIPTION
Make IdleHandle implement the Sync bound on all platforms. This is required to wrap IdleHandle in any Arc, motivated in particular by ArcWaker which is in turn motivated by async Xilem experiments (see #2184)