### PR TITLE
Add dark mode support for Windows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - `WidgetPod::requested_layout` ([#2145] by [@xarvic])
 - Make `Parse` work better with floats and similar types ([#2148] by [@superfell])
 - Added `compute_max_intrinsic` method to the `Widget` trait, which determines the maximum useful dimension of the widget ([#2172] by [@sjoshid])
+- Windows: Dark mode support for the title bar ([#2196] by [@dristic])
 
 ### Changed
 
@@ -554,6 +555,7 @@ Last release without a changelog :(
 [@superfell]: https://github.com/superfell
 [@GoldsteinE]: https://github.com/GoldsteinE
 [@twitchyliquid64]: https://github.com/twitchyliquid64
+[@dristic]: https://github.com/dristic
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611
@@ -847,6 +849,7 @@ Last release without a changelog :(
 [#2157]: https://github.com/linebender/druid/pull/2157
 [#2158]: https://github.com/linebender/druid/pull/2158
 [#2172]: https://github.com/linebender/druid/pull/2172
+[#2196]: https://github.com/linebender/druid/pull/2196
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -35,7 +35,7 @@ use winapi::shared::minwindef::*;
 use winapi::shared::windef::*;
 use winapi::shared::winerror::*;
 use winapi::um::dcomp::{IDCompositionDevice, IDCompositionTarget, IDCompositionVisual};
-use winapi::um::dwmapi::DwmExtendFrameIntoClientArea;
+use winapi::um::dwmapi::{DwmExtendFrameIntoClientArea, DwmSetWindowAttribute};
 use winapi::um::errhandlingapi::GetLastError;
 use winapi::um::shellscalingapi::MDT_EFFECTIVE_DPI;
 use winapi::um::unknwnbase::*;
@@ -1515,6 +1515,18 @@ impl WindowBuilder {
                     };
                 }
             }
+
+            // Dark mode support
+            // https://docs.microsoft.com/en-us/windows/apps/desktop/modernize/apply-windows-themes
+            const DWMWA_USE_IMMERSIVE_DARK_MODE: u32 = 20;
+            let value: BOOL = 1;
+            let value_ptr = &value as *const _ as *const c_void;
+            DwmSetWindowAttribute(
+                hwnd,
+                DWMWA_USE_IMMERSIVE_DARK_MODE,
+                value_ptr,
+                std::mem::size_of::<BOOL>() as u32,
+            );
 
             self.app.add_window(hwnd);
 


### PR DESCRIPTION
Small edit to let Windows theme the title bar with dark mode support. I followed the instructions at the bottom of this page: https://docs.microsoft.com/en-us/windows/apps/desktop/modernize/apply-windows-themes

Here is how it looks:
![DarkMode](https://user-images.githubusercontent.com/1205755/172019322-d454d758-3ca7-40d1-87da-3e92e5fa4c93.png)

First time contributing so let me know if I missed anything. Thanks!