### PR TITLE
[mac] Don't forward DoCommandBySelector: to parent

### DIFF
--- a/druid-shell/src/backend/mac/text_input.rs
+++ b/druid-shell/src/backend/mac/text_input.rs
@@ -262,14 +262,7 @@ pub extern "C" fn first_rect_for_character_range(
 }
 
 pub extern "C" fn do_command_by_selector(this: &mut Object, _: Sel, cmd: Sel) {
-    if with_edit_lock_from_window(this, true, |lock| do_command_by_selector_impl(lock, cmd))
-        .is_none()
-    {
-        // this is not a text field, so forward command to parent
-        if let Some(superclass) = this.class().superclass() {
-            unsafe { msg_send![superclass, doCommandBySelector: cmd] }
-        }
-    }
+    with_edit_lock_from_window(this, true, |lock| do_command_by_selector_impl(lock, cmd));
 }
 
 fn do_command_by_selector_impl(mut edit_lock: Box<dyn InputHandler>, cmd: Sel) {


### PR DESCRIPTION
This method does not exist on NSView, only on implementors of
NSTextInputClient. As such there is no reason to be invoking it on super
when there is no active text input session.

It is possible that we shouldn't even be responding to this selector if
we do not have an active text session, but I'm not sure if that matters
or not, so we can leave it as is for now.

- fixes #2197 