### PR TITLE
feat(druid-shell): added `window` mode on wasm target

### DIFF
--- a/druid-shell/src/backend/web/window.rs
+++ b/druid-shell/src/backend/web/window.rs
@@ -171,7 +171,7 @@ impl WindowState {
         let dpr = w.device_pixel_ratio();
 
         match self.canvas_size {
-            Some(Size {width, height}) => (width, height, dpr),
+            Some(Size { width, height }) => (width, height, dpr),
             _ => {
                 let width = w.inner_width().unwrap().as_f64().unwrap();
                 let height = w.inner_height().unwrap().as_f64().unwrap();
@@ -423,14 +423,15 @@ impl WindowBuilder {
             .map_err(|_| Error::JsCast)?;
 
         let cnv_attr = |attr| {
-            canvas.get_attribute(attr)
+            canvas
+                .get_attribute(attr)
                 .map(|value| value.parse().ok())
                 .flatten()
         };
 
         let canvas_size = match (cnv_attr("width"), cnv_attr("height")) {
             (Some(width), Some(height)) => Some(Size::new(width, height)),
-            _ => None
+            _ => None,
         };
 
         let context = canvas

--- a/druid-shell/src/backend/web/window.rs
+++ b/druid-shell/src/backend/web/window.rs
@@ -118,6 +118,7 @@ struct WindowState {
     handler: RefCell<Box<dyn WinHandler>>,
     window: web_sys::Window,
     canvas: web_sys::HtmlCanvasElement,
+    canvas_size: Option<Size>,
     context: web_sys::CanvasRenderingContext2d,
     invalid: RefCell<Region>,
     click_counter: ClickCounter,
@@ -167,10 +168,16 @@ impl WindowState {
     /// Returns the window size in css units
     fn get_window_size_and_dpr(&self) -> (f64, f64, f64) {
         let w = &self.window;
-        let width = w.inner_width().unwrap().as_f64().unwrap();
-        let height = w.inner_height().unwrap().as_f64().unwrap();
         let dpr = w.device_pixel_ratio();
-        (width, height, dpr)
+
+        match self.canvas_size {
+            Some(Size {width, height}) => (width, height, dpr),
+            _ => {
+                let width = w.inner_width().unwrap().as_f64().unwrap();
+                let height = w.inner_height().unwrap().as_f64().unwrap();
+                (width, height, dpr)
+            }
+        }
     }
 
     /// Updates the canvas size and scale factor and returns `Scale` and `ScaledArea`.
@@ -414,6 +421,18 @@ impl WindowBuilder {
             .ok_or_else(|| Error::NoElementById("canvas".to_string()))?
             .dyn_into::<web_sys::HtmlCanvasElement>()
             .map_err(|_| Error::JsCast)?;
+
+        let cnv_attr = |attr| {
+            canvas.get_attribute(attr)
+                .map(|value| value.parse().ok())
+                .flatten()
+        };
+
+        let canvas_size = match (cnv_attr("width"), cnv_attr("height")) {
+            (Some(width), Some(height)) => Some(Size::new(width, height)),
+            _ => None
+        };
+
         let context = canvas
             .get_context("2d")?
             .ok_or(Error::NoContext)?
@@ -446,6 +465,7 @@ impl WindowBuilder {
             handler: RefCell::new(handler),
             window,
             canvas,
+            canvas_size,
             context,
             invalid: RefCell::new(Region::EMPTY),
             click_counter: ClickCounter::default(),

--- a/druid-shell/src/backend/web/window.rs
+++ b/druid-shell/src/backend/web/window.rs
@@ -425,8 +425,7 @@ impl WindowBuilder {
         let cnv_attr = |attr| {
             canvas
                 .get_attribute(attr)
-                .map(|value| value.parse().ok())
-                .flatten()
+                .and_then(|value| value.parse().ok())
         };
 
         let canvas_size = match (cnv_attr("width"), cnv_attr("height")) {

--- a/druid/examples/hello_web/index.html
+++ b/druid/examples/hello_web/index.html
@@ -16,9 +16,15 @@
         </style>
     </head>
     <body>
-        <noscript>This page contains WebAssembly and JavaScript content, please enable JavaScript in your
-            browser.</noscript>
-        <canvas id="canvas"></canvas>
+        <noscript>This page contains WebAssembly and JavaScript content, please enable JavaScript in your browser.</noscript>
+        <div style="text-align: center; margin: 0px; padding: 0px;">
+            <!-- Windowed mode: canvas MUST has a set both `width` AND `height` attributes -->
+            <!-- <canvas id="canvas" style="width: 300px; height: 300px;" width="300" height="300"></canvas> -->
+
+            <!-- Fullscreen mode: unset `height` OR\AND `width` attribute -->
+            <canvas id="canvas"></canvas>
+        </div>
+
         <script type="module" src="./index.js" type="application/javascript"></script>
     </body>
 </html>


### PR DESCRIPTION
A `window` mode has been added: restricted area by canvas size will be
use to draw an application on a web page. The mode will be enabled if
`canvas` element has both attributes: `height` and `width`.

A `fullscreen` mode will be on by default (`height` or\and `width`
attrs are missed)

![изображение](https://user-images.githubusercontent.com/3790195/173639495-840da222-bce4-422a-89c3-7cfb031c7510.png)

