### PR TITLE
Fix double-release bug in macOS save dialog.

### DIFF
--- a/druid-shell/src/backend/mac/dialog.rs
+++ b/druid-shell/src/backend/mac/dialog.rs
@@ -20,9 +20,7 @@ use std::ffi::OsString;
 
 use cocoa::appkit::NSView;
 use cocoa::base::{id, nil, NO, YES};
-use cocoa::foundation::{
-    NSArray, NSAutoreleasePool, NSInteger, NSPoint, NSRect, NSSize, NSString, NSURL,
-};
+use cocoa::foundation::{NSArray, NSAutoreleasePool, NSInteger, NSPoint, NSRect, NSSize, NSURL};
 use objc::{class, msg_send, sel, sel_impl};
 
 use super::util::{from_nsstring, make_nsstring};
@@ -222,9 +220,7 @@ unsafe fn file_format_popup_button(allowed_types: &[crate::FileSpec], popup_fram
     let popup_button: id = msg_send![class!(NSPopUpButton), alloc];
     let _: () = msg_send![popup_button, initWithFrame:popup_frame pullsDown:false];
     for allowed_type in allowed_types {
-        let title = NSString::alloc(nil)
-            .init_str(allowed_type.name)
-            .autorelease();
+        let title = make_nsstring(allowed_type.name);
         msg_send![popup_button, addItemWithTitle: title]
     }
     let _: () = msg_send![popup_button, setTag: FileFormatPopoverTag];
@@ -237,7 +233,7 @@ unsafe fn file_format_label() -> (id, NSSize) {
     let _: () = msg_send![label, setDrawsBackground:false];
     // FIXME: As we have to roll our own view hierachy, we're not getting a translated
     // title here. So we ought to find a way to translate this.
-    let title = NSString::alloc(nil).init_str("File Format:").autorelease();
+    let title = make_nsstring("File Format:");
     let _: () = msg_send![label, setStringValue: title];
     let _: () = msg_send![label, sizeToFit];
     (label.autorelease(), label.frame().size)
@@ -275,5 +271,5 @@ unsafe fn rewritten_path(
         path,
         stringByAppendingPathExtension: make_nsstring(extension)
     ];
-    (path.autorelease(), Some(file_spec))
+    (path, Some(file_spec))
 }


### PR DESCRIPTION
This PR fixes a double-release bug in `druid-shell` in the macOS file save dialog code path.

It's not completely clear to me when an object needs manual releasing. The problematic object in question here is a string returned by [`stringByAppendingPathExtension`](https://developer.apple.com/documentation/foundation/nsstring/1412501-stringbyappendingpathextension) and the Apple documentation for that mentions nothing.

The best I found was an [old comment on StackOverflow](https://stackoverflow.com/a/4354184/138826) which claims that *The convention is that a method should autorelease any object it returns. The only exception (AFAIK) is for constructors*. Looking at our existing macOS code, both `alloc` and `new` seem to require releasing. Are there others? Would be nice to know for future code reviews.

Right now though, it seems clear that `stringByAppendingPathExtension` sets up `autorelease` by itself, so we don't need to do it.

Before the change in this PR, on macOS 10.15.4, I get `objc[484]: NSPathStore2 object 0x7f852fb2ed50 overreleased while already deallocating; break on objc_overrelease_during_dealloc_error to debug`. After this change, the warning disappears.

I am going to assume, based on the stack trace provided, that this will also resolve the segfault reported in #2209. @SamuelMarks could you please test if this resolves the segfault you're seeing?

Fixes #2209.

PS. This PR also contains a pre-emptive robustification by replacing a few `NSString` allocations/releasings with the util function we already have for that.