### PR TITLE
Fix build error on Mac when spin_no_std is enabled by dependents of lazy_static. (#2211)

### DIFF
--- a/druid-shell/src/backend/mac/application.rs
+++ b/druid-shell/src/backend/mac/application.rs
@@ -156,6 +156,7 @@ impl DelegateState {
 
 struct AppDelegate(*const Class);
 unsafe impl Sync for AppDelegate {}
+unsafe impl Send for AppDelegate {}
 
 lazy_static! {
     static ref APP_DELEGATE: AppDelegate = unsafe {

--- a/druid-shell/src/backend/mac/window.rs
+++ b/druid-shell/src/backend/mac/window.rs
@@ -335,6 +335,7 @@ impl WindowBuilder {
 // Wrap pointer because lazy_static requires Sync.
 struct ViewClass(*const Class);
 unsafe impl Sync for ViewClass {}
+unsafe impl Send for ViewClass {}
 
 lazy_static! {
     static ref VIEW_CLASS: ViewClass = unsafe {
@@ -583,6 +584,7 @@ fn make_view(handler: Box<dyn WinHandler>) -> (id, Weak<Mutex<Vec<IdleKind>>>) {
 
 struct WindowClass(*const Class);
 unsafe impl Sync for WindowClass {}
+unsafe impl Send for WindowClass {}
 
 lazy_static! {
     static ref WINDOW_CLASS: WindowClass = unsafe {


### PR DESCRIPTION
Fix build error on Mac when spin_no_std is enabled by dependents of lazy_static. (#2211)