### PR TITLE
Satisfy clippy 1.62

### DIFF
--- a/druid-shell/src/backend/gtk/window.rs
+++ b/druid-shell/src/backend/gtk/window.rs
@@ -76,11 +76,11 @@ const SCALE_TARGET_DPI: f64 = 96.0;
 /// Taken from <https://gtk-rs.org/docs-src/tutorial/closures>
 /// It is used to reduce the boilerplate of setting up gtk callbacks
 /// Example:
-/// ```
+/// ```ignore
 /// button.connect_clicked(clone!(handle => move |_| { ... }))
 /// ```
 /// is equivalent to:
-/// ```
+/// ```ignore
 /// {
 ///     let handle = handle.clone();
 ///     button.connect_clicked(move |_| { ... })

--- a/druid-shell/src/backend/wayland/pointers.rs
+++ b/druid-shell/src/backend/wayland/pointers.rs
@@ -333,7 +333,7 @@ impl Pointer {
                             ))
                         }
                         ButtonState::Released => {
-                            let mut updated = self.buttons.borrow_mut().remove(button);
+                            self.buttons.borrow_mut().remove(button);
                             self.clickevent.borrow_mut().debounce(MouseEvtKind::Up(
                                 mouse::MouseEvent {
                                     pos: self.pos.get(),

--- a/druid-shell/src/backend/windows/menu.rs
+++ b/druid-shell/src/backend/windows/menu.rs
@@ -15,6 +15,7 @@
 //! Safe wrapper for menus.
 
 use std::collections::HashMap;
+use std::fmt::Write as _;
 use std::mem;
 use std::ptr::null;
 
@@ -219,6 +220,7 @@ fn format_hotkey(key: &HotKey, s: &mut String) {
         KbKey::ArrowRight => s.push_str("Right"),
         KbKey::ArrowUp => s.push_str("Up"),
         KbKey::ArrowDown => s.push_str("Down"),
-        _ => s.push_str(&format!("{:?}", key.key)),
+        _ => write!(s, "{}", key.key)
+            .unwrap_or_else(|err| tracing::warn!("Failed to convert hotkey to string: {}", err)),
     }
 }


### PR DESCRIPTION
Lints addressed:
* [`format_push_string`](https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string)
* [`let_unit_value`](https://rust-lang.github.io/rust-clippy/master/index.html#let_unit_value)