### PR TITLE
[macos] Fix issue with missing default menu

### DIFF
--- a/druid/src/menu/mod.rs
+++ b/druid/src/menu/mod.rs
@@ -168,7 +168,7 @@ impl<T: Data> MenuManager<T> {
     #[allow(unreachable_code)]
     pub fn platform_default() -> Option<MenuManager<T>> {
         #[cfg(target_os = "macos")]
-        return Some(MenuManager::new(|_, _, _| sys::mac::application::default()));
+        return Some(MenuManager::new(|_, _, _| sys::mac::menu_bar()));
 
         #[cfg(any(target_os = "windows", target_os = "linux", target_os = "openbsd"))]
         return None;


### PR DESCRIPTION
This has been an issue since the menu refactor, apparently, but i hadn't
bothered to track it down until now. I think it might have also been surfaced
by an OS release?

With this fix, macos windows will have a standard looking menu, which
will provide functionality like cmd-Q to quit. This likely closes a
number of open issues.

- closes #2008
- references #1711 (which this may fix?)