### PR TITLE
Minor wayland fixes.

### DIFF
--- a/druid-shell/src/backend/wayland/pointers.rs
+++ b/druid-shell/src/backend/wayland/pointers.rs
@@ -191,8 +191,9 @@ impl Pointer {
             Some(b) => b,
         };
 
+        let (hot_x, hot_y) = buffer.hotspot();
         self.current_cursor.replace(cursor);
-        wl_pointer.set_cursor(0, Some(&self.cursor_surface), 0, 0);
+        wl_pointer.set_cursor(0, Some(&self.cursor_surface), hot_x as i32, hot_y as i32);
         self.cursor_surface.attach(Some(&*buffer), 0, 0);
         self.cursor_surface.damage_buffer(0, 0, i32::MAX, i32::MAX);
         self.cursor_surface.commit();

--- a/druid-shell/src/backend/wayland/surfaces/buffers.rs
+++ b/druid-shell/src/backend/wayland/surfaces/buffers.rs
@@ -624,6 +624,7 @@ impl RawRect {
 impl From<Rect> for RawRect {
     fn from(r: Rect) -> Self {
         let max = i32::MAX as f64;
+        let r = r.expand();
         assert!(r.x0.abs() < max && r.y0.abs() < max && r.x1.abs() < max && r.y1.abs() < max);
         RawRect {
             x0: r.x0 as i32,


### PR DESCRIPTION
- use the correct cursor hotspot
- expand the invalidated rect