### PR TITLE
Update to latest x11rb

### DIFF
--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -109,7 +109,7 @@ gtk-rs = { version = "0.14.0", features = ["v3_22"], package = "gtk", optional =
 glib-sys = { version = "0.14.0", optional = true }
 gtk-sys = { version = "0.14.0", optional = true }
 nix = { version = "0.24.0", optional = true }
-x11rb = { version = "0.8.0", features = ["allow-unsafe-code", "present", "render", "randr", "xfixes", "xkb", "resource_manager", "cursor"], optional = true }
+x11rb = { version = "0.9.0", features = ["allow-unsafe-code", "present", "render", "randr", "xfixes", "xkb", "resource_manager", "cursor"], optional = true }
 wayland-client = { version = "0.29", optional = true }
 wayland-protocols = { version = "0.29", optional = true }
 wayland-cursor = { version = "0.29", optional = true }

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -109,7 +109,7 @@ gtk-rs = { version = "0.14.0", features = ["v3_22"], package = "gtk", optional =
 glib-sys = { version = "0.14.0", optional = true }
 gtk-sys = { version = "0.14.0", optional = true }
 nix = { version = "0.24.0", optional = true }
-x11rb = { version = "0.9.0", features = ["allow-unsafe-code", "present", "render", "randr", "xfixes", "xkb", "resource_manager", "cursor"], optional = true }
+x11rb = { version = "0.10", features = ["allow-unsafe-code", "present", "render", "randr", "xfixes", "xkb", "resource_manager", "cursor"], optional = true }
 wayland-client = { version = "0.29", optional = true }
 wayland-protocols = { version = "0.29", optional = true }
 wayland-cursor = { version = "0.29", optional = true }

--- a/druid-shell/src/backend/x11/application.rs
+++ b/druid-shell/src/backend/x11/application.rs
@@ -30,7 +30,9 @@ use x11rb::protocol::xproto::{
     self, ConnectionExt, CreateWindowAux, EventMask, Timestamp, Visualtype, WindowClass,
 };
 use x11rb::protocol::Event;
-use x11rb::resource_manager::Database as ResourceDb;
+use x11rb::resource_manager::{
+    new_from_default as new_resource_db_from_default, Database as ResourceDb,
+};
 use x11rb::xcb_ffi::XCBConnection;
 
 use crate::application::AppHandler;
@@ -210,7 +212,7 @@ impl Application {
         //
         // https://github.com/linebender/druid/pull/1025#discussion_r442777892
         let (conn, screen_num) = XCBConnection::connect(None)?;
-        let rdb = Rc::new(ResourceDb::new_from_default(&conn)?);
+        let rdb = Rc::new(new_resource_db_from_default(&conn)?);
         let xkb_context = xkb::Context::new();
         xkb_context.set_log_level(tracing::Level::DEBUG);
         use x11rb::protocol::xkb::ConnectionExt;

--- a/druid-shell/src/backend/x11/application.rs
+++ b/druid-shell/src/backend/x11/application.rs
@@ -684,9 +684,9 @@ impl Application {
             }
             Event::Error(e) => {
                 // TODO: if an error is caused by the present extension, disable it and fall back
-                // to copying pixels. This is blocked on
-                // https://github.com/psychon/x11rb/issues/503
-                return Err(x11rb::errors::ReplyError::from(*e).into());
+                // to copying pixels. This was blocked on
+                // https://github.com/psychon/x11rb/issues/503 but no longer is
+                return Err(x11rb::errors::ReplyError::from(e.clone()).into());
             }
             _ => {}
         }


### PR DESCRIPTION
This PR updates to the latest version of x11rb, getting rid of one old version of nix in the dependency tree.

While doing this, I noticed a comment referring to an x11rb issue that was already fixed two years ago and released in v0.7.0. Thus, the x11rb version you are using should already provide everything that is needed. CC @jneem FYI