### PR TITLE
Windows: fix the raw-win-handle feature

### DIFF
--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -48,7 +48,7 @@ use winapi::Interface;
 use wio::com::ComPtr;
 
 #[cfg(feature = "raw-win-handle")]
-use raw_window_handle::{windows::WindowsHandle, HasRawWindowHandle, RawWindowHandle};
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle, Win32Handle};
 
 use piet_common::d2d::{D2DFactory, DeviceContext};
 use piet_common::dwrite::DwriteFactory;
@@ -185,18 +185,18 @@ impl Eq for WindowHandle {}
 unsafe impl HasRawWindowHandle for WindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle {
         if let Some(hwnd) = self.get_hwnd() {
-            let handle = WindowsHandle {
-                hwnd: hwnd as *mut core::ffi::c_void,
-                hinstance: unsafe {
-                    winapi::um::libloaderapi::GetModuleHandleW(0 as winapi::um::winnt::LPCWSTR)
-                        as *mut core::ffi::c_void
-                },
-                ..WindowsHandle::empty()
+            // Using empty + set fields instead Win32Handle{...} to shut up a unexplainable compiler error
+            // "cannot create non-exhaustive struct using struct expression"
+            let mut handle = Win32Handle::empty();
+            handle.hwnd = hwnd as *mut core::ffi::c_void;
+            handle.hinstance = unsafe {
+                winapi::um::libloaderapi::GetModuleHandleW(0 as winapi::um::winnt::LPCWSTR)
+                    as *mut core::ffi::c_void
             };
-            RawWindowHandle::Windows(handle)
+            RawWindowHandle::Win32(handle)
         } else {
             error!("Cannot retrieved HWND for window.");
-            RawWindowHandle::Windows(WindowsHandle::empty())
+            RawWindowHandle::Win32(Win32Handle::empty())
         }
     }
 }

--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -185,8 +185,8 @@ impl Eq for WindowHandle {}
 unsafe impl HasRawWindowHandle for WindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle {
         if let Some(hwnd) = self.get_hwnd() {
-            // Using empty + set fields instead Win32Handle{...} to shut up a unexplainable compiler error
-            // "cannot create non-exhaustive struct using struct expression"
+            // Using empty + set fields instead Win32Handle{...}
+            // because Win32Handle is marked as #[non_exhaustive]
             let mut handle = Win32Handle::empty();
             handle.hwnd = hwnd as *mut core::ffi::c_void;
             handle.hinstance = unsafe {


### PR DESCRIPTION
The raw-win-handle feature is currently broken on windows because it was not properly updated to `raw-window-handle` 0.4 when that dependency was bumped.