### PR TITLE
Update raw window handle and fix raw-win-handle feature

### DIFF
--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -76,7 +76,7 @@ keyboard-types = { version = "0.6.2", default_features = false }
 
 # Optional dependencies
 image = { version = "0.23.12", optional = true, default_features = false }
-raw-window-handle = { version = "0.4.2", optional = true, default_features = false }
+raw-window-handle = { version = "0.5.0", optional = true, default_features = false }
 
 [target.'cfg(target_os="windows")'.dependencies]
 scopeguard = "1.1.0"

--- a/druid-shell/src/backend/gtk/window.rs
+++ b/druid-shell/src/backend/gtk/window.rs
@@ -44,7 +44,7 @@ use instant::Duration;
 use tracing::{error, warn};
 
 #[cfg(feature = "raw-win-handle")]
-use raw_window_handle::{unix::XcbHandle, HasRawWindowHandle, RawWindowHandle};
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle, XcbWindowHandle};
 
 use crate::kurbo::{Insets, Point, Rect, Size, Vec2};
 use crate::piet::{Piet, PietText, RenderContext};
@@ -126,7 +126,7 @@ unsafe impl HasRawWindowHandle for WindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle {
         error!("HasRawWindowHandle trait not implemented for gtk.");
         // GTK is not a platform, and there's no empty generic handle. Pick XCB randomly as fallback.
-        RawWindowHandle::Xcb(XcbHandle::empty())
+        RawWindowHandle::Xcb(XcbWindowHandle::empty())
     }
 }
 

--- a/druid-shell/src/backend/mac/window.rs
+++ b/druid-shell/src/backend/mac/window.rs
@@ -40,7 +40,7 @@ use objc::{class, msg_send, sel, sel_impl};
 use tracing::{debug, error, info};
 
 #[cfg(feature = "raw-win-handle")]
-use raw_window_handle::{AppKitHandle, HasRawWindowHandle, RawWindowHandle};
+use raw_window_handle::{AppKitWindowHandle, HasRawWindowHandle, RawWindowHandle};
 
 use crate::kurbo::{Insets, Point, Rect, Size, Vec2};
 use crate::piet::{Piet, PietText, RenderContext};
@@ -1417,7 +1417,7 @@ impl WindowHandle {
 unsafe impl HasRawWindowHandle for WindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle {
         let nsv = self.nsview.load();
-        let mut handle = AppKitHandle::empty();
+        let mut handle = AppKitWindowHandle::empty();
         handle.ns_view = *nsv as *mut _;
         RawWindowHandle::AppKit(handle)
     }

--- a/druid-shell/src/backend/wayland/window.rs
+++ b/druid-shell/src/backend/wayland/window.rs
@@ -18,6 +18,9 @@ use wayland_protocols::xdg_shell::client::xdg_popup;
 use wayland_protocols::xdg_shell::client::xdg_positioner;
 use wayland_protocols::xdg_shell::client::xdg_surface;
 
+#[cfg(feature = "raw-win-handle")]
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle, WaylandWindowHandle};
+
 use super::application::{self, Timer};
 use super::{error::Error, menu::Menu, outputs, surfaces};
 
@@ -302,6 +305,14 @@ impl std::default::Default for WindowHandle {
                 appdata: std::sync::Weak::new(),
             }),
         }
+    }
+}
+
+#[cfg(feature = "raw-win-handle")]
+unsafe impl HasRawWindowHandle for WindowHandle {
+    fn raw_window_handle(&self) -> RawWindowHandle {
+        tracing::error!("HasRawWindowHandle trait not implemented for wasm.");
+        RawWindowHandle::Wayland(WaylandWindowHandle::empty())
     }
 }
 

--- a/druid-shell/src/backend/web/window.rs
+++ b/druid-shell/src/backend/web/window.rs
@@ -25,7 +25,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
 #[cfg(feature = "raw-win-handle")]
-use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle, WebWindowHandle};
 
 use crate::kurbo::{Insets, Point, Rect, Size, Vec2};
 
@@ -94,7 +94,7 @@ impl Eq for WindowHandle {}
 unsafe impl HasRawWindowHandle for WindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle {
         error!("HasRawWindowHandle trait not implemented for wasm.");
-        RawWindowHandle::Web(WebHandle::empty())
+        RawWindowHandle::Web(WebWindowHandle::empty())
     }
 }
 

--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -185,7 +185,7 @@ impl Eq for WindowHandle {}
 unsafe impl HasRawWindowHandle for WindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle {
         if let Some(hwnd) = self.get_hwnd() {
-            let handle = Win32WindowHandle::empty();
+            let mut handle = Win32WindowHandle::empty();
             handle.hwnd = hwnd as *mut core::ffi::c_void;
             handle.hinstance = unsafe {
                 winapi::um::libloaderapi::GetModuleHandleW(0 as winapi::um::winnt::LPCWSTR)

--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -48,7 +48,7 @@ use winapi::Interface;
 use wio::com::ComPtr;
 
 #[cfg(feature = "raw-win-handle")]
-use raw_window_handle::{windows::WindowsHandle, HasRawWindowHandle, RawWindowHandle};
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle, Win32WindowHandle};
 
 use piet_common::d2d::{D2DFactory, DeviceContext};
 use piet_common::dwrite::DwriteFactory;
@@ -185,18 +185,16 @@ impl Eq for WindowHandle {}
 unsafe impl HasRawWindowHandle for WindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle {
         if let Some(hwnd) = self.get_hwnd() {
-            let handle = WindowsHandle {
-                hwnd: hwnd as *mut core::ffi::c_void,
-                hinstance: unsafe {
-                    winapi::um::libloaderapi::GetModuleHandleW(0 as winapi::um::winnt::LPCWSTR)
-                        as *mut core::ffi::c_void
-                },
-                ..WindowsHandle::empty()
+            let handle = Win32WindowHandle::empty();
+            handle.hwnd = hwnd as *mut core::ffi::c_void;
+            handle.hinstance = unsafe {
+                winapi::um::libloaderapi::GetModuleHandleW(0 as winapi::um::winnt::LPCWSTR)
+                    as *mut core::ffi::c_void
             };
-            RawWindowHandle::Windows(handle)
+            RawWindowHandle::Win32(handle)
         } else {
             error!("Cannot retrieved HWND for window.");
-            RawWindowHandle::Windows(WindowsHandle::empty())
+            RawWindowHandle::Win32(Win32WindowHandle::empty())
         }
     }
 }

--- a/druid-shell/src/backend/x11/window.rs
+++ b/druid-shell/src/backend/x11/window.rs
@@ -1581,6 +1581,7 @@ impl IdleHandle {
 #[derive(Clone, Default)]
 pub(crate) struct WindowHandle {
     id: u32,
+    #[allow(dead_code)] // Only used with the raw-win-handle feature
     visual_id: u32,
     window: Weak<Window>,
 }

--- a/druid-shell/src/backend/x11/window.rs
+++ b/druid-shell/src/backend/x11/window.rs
@@ -42,7 +42,7 @@ use x11rb::wrapper::ConnectionExt as _;
 use x11rb::xcb_ffi::XCBConnection;
 
 #[cfg(feature = "raw-win-handle")]
-use raw_window_handle::{unix::XcbHandle, HasRawWindowHandle, RawWindowHandle};
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle, XcbWindowHandle};
 
 use crate::backend::shared::Timer;
 use crate::common_util::IdleCallback;
@@ -494,7 +494,7 @@ impl WindowBuilder {
             window.set_position(pos);
         }
 
-        let handle = WindowHandle::new(id, Rc::downgrade(&window));
+        let handle = WindowHandle::new(id, visual_type.visual_id, Rc::downgrade(&window));
         window.connect(handle.clone())?;
 
         self.app.add_window(id, window)?;
@@ -1581,6 +1581,7 @@ impl IdleHandle {
 #[derive(Clone, Default)]
 pub(crate) struct WindowHandle {
     id: u32,
+    visual_id: u32,
     window: Weak<Window>,
 }
 impl PartialEq for WindowHandle {
@@ -1591,8 +1592,12 @@ impl PartialEq for WindowHandle {
 impl Eq for WindowHandle {}
 
 impl WindowHandle {
-    fn new(id: u32, window: Weak<Window>) -> WindowHandle {
-        WindowHandle { id, window }
+    fn new(id: u32, visual_id: u32, window: Weak<Window>) -> WindowHandle {
+        WindowHandle {
+            id,
+            visual_id,
+            window,
+        }
     }
 
     pub fn show(&self) {
@@ -1846,19 +1851,9 @@ impl WindowHandle {
 #[cfg(feature = "raw-win-handle")]
 unsafe impl HasRawWindowHandle for WindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle {
-        let mut handle = XcbHandle {
-            window: self.id,
-            ..XcbHandle::empty()
-        };
-
-        if let Some(window) = self.window.upgrade() {
-            handle.connection = window.app.connection().get_raw_xcb_connection();
-        } else {
-            // Documentation for HasRawWindowHandle encourages filling in all fields possible,
-            // leaving those empty that cannot be derived.
-            error!("Failed to get XCBConnection, returning incomplete handle");
-        }
-
+        let mut handle = XcbWindowHandle::empty();
+        handle.window = self.id;
+        handle.visual_id = self.visual_id;
         RawWindowHandle::Xcb(handle)
     }
 }


### PR DESCRIPTION
Fixes https://github.com/linebender/druid/issues/2237, resolves https://github.com/linebender/druid/issues/2225

Updates raw-window-handle from 0.4.2 to 0.5.0 and fixes the feature which is currently broken on all platforms.

I tested it on all platforms except macOS.

Small note: for the `x11` backend, the xcb connection was previously stored in the `RawWindowHandle`, but since 0.5.0 decoupled the `WindowHandle`s and `DisplayHandles`, it is no longer present. It was not used anywhere by druid however.