### PR TITLE
Satisfy clippy 1.63.

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -3,3 +3,8 @@
 # it makes sense to optimize for 64-bit and accept the performance hits on 32-bit.
 # 16 bytes is the number of bytes that fits into two 64-bit CPU registers.
 trivial-copy-size-limit = 16
+
+# The default clippy value for this is 250, which causes warnings for rather simple types
+# like Box<dyn Fn(&mut Env, &T)>, which seems overly strict. The new value of 400 is
+# a simple guess. It might be worth lowering this, or using the default, in the future.
+type-complexity-threshold = 400

--- a/druid-derive/src/attr.rs
+++ b/druid-derive/src/attr.rs
@@ -68,7 +68,7 @@ pub struct Field<Attrs> {
     pub attrs: Attrs,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum DataAttr {
     Empty,
     Ignore,

--- a/druid-shell/src/backend/gtk/window.rs
+++ b/druid-shell/src/backend/gtk/window.rs
@@ -216,7 +216,7 @@ impl std::fmt::Debug for WindowState {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct CustomCursor(gtk::gdk::Cursor);
 
 impl WindowBuilder {

--- a/druid-shell/src/backend/mac/window.rs
+++ b/druid-shell/src/backend/mac/window.rs
@@ -180,7 +180,7 @@ struct ViewState {
     parent: Option<crate::WindowHandle>,
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 // TODO: support custom cursors
 pub struct CustomCursor;
 

--- a/druid-shell/src/backend/wayland/pointers.rs
+++ b/druid-shell/src/backend/wayland/pointers.rs
@@ -201,7 +201,7 @@ impl Pointer {
 
     fn get_cursor_buffer(&self, cursor: &mouse::Cursor) -> Option<CursorImageBuffer> {
         #[allow(deprecated)]
-        return match cursor {
+        match cursor {
             mouse::Cursor::Arrow => self.unpack_image_buffer("left_ptr"),
             mouse::Cursor::IBeam => self.unpack_image_buffer("xterm"),
             mouse::Cursor::Crosshair => self.unpack_image_buffer("cross"),
@@ -214,7 +214,7 @@ impl Pointer {
                 tracing::warn!("custom cursors not implemented");
                 self.unpack_image_buffer("left_ptr")
             }
-        };
+        }
     }
 
     // Just use the first image, people using animated cursors have already made bad life

--- a/druid-shell/src/backend/wayland/surfaces/buffers.rs
+++ b/druid-shell/src/backend/wayland/surfaces/buffers.rs
@@ -526,7 +526,7 @@ impl Drop for Mmap {
         }
     }
 }
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct RawSize {
     pub width: i32,
     pub height: i32,

--- a/druid-shell/src/backend/wayland/window.rs
+++ b/druid-shell/src/backend/wayland/window.rs
@@ -318,7 +318,7 @@ unsafe impl HasRawWindowHandle for WindowHandle {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct CustomCursor;
 
 /// Builder abstraction for creating new windows

--- a/druid-shell/src/backend/wayland/window.rs
+++ b/druid-shell/src/backend/wayland/window.rs
@@ -293,6 +293,8 @@ impl std::cmp::PartialEq for WindowHandle {
     }
 }
 
+impl Eq for WindowHandle {}
+
 impl std::default::Default for WindowHandle {
     fn default() -> WindowHandle {
         WindowHandle {

--- a/druid-shell/src/backend/web/window.rs
+++ b/druid-shell/src/backend/web/window.rs
@@ -127,7 +127,7 @@ struct WindowState {
 }
 
 // TODO: support custom cursors
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct CustomCursor;
 
 impl WindowState {

--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -302,10 +302,10 @@ struct DxgiState {
     composition_visual: Option<ComPtr<IDCompositionVisual>>,
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct CustomCursor(Arc<HCursor>);
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 struct HCursor(HCURSOR);
 
 impl Drop for HCursor {

--- a/druid-shell/src/backend/x11/window.rs
+++ b/druid-shell/src/backend/x11/window.rs
@@ -397,7 +397,7 @@ impl WindowBuilder {
             let mut wm_class = Vec::with_capacity(2 * (name.len() + 1));
             wm_class.extend(name.as_bytes());
             wm_class.push(0);
-            if let Some(&first) = wm_class.get(0) {
+            if let Some(&first) = wm_class.first() {
                 wm_class.push(first.to_ascii_uppercase());
                 wm_class.extend(&name.as_bytes()[1..]);
             }

--- a/druid-shell/src/backend/x11/window.rs
+++ b/druid-shell/src/backend/x11/window.rs
@@ -662,7 +662,7 @@ struct PresentData {
     last_ust: Option<u64>,
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct CustomCursor(xproto::Cursor);
 
 impl Window {

--- a/druid-shell/src/dialog.rs
+++ b/druid-shell/src/dialog.rs
@@ -41,7 +41,7 @@ pub struct FileInfo {
     all(feature = "x11", any(target_os = "linux", target_os = "openbsd")),
     feature = "wayland"
 )))]
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum FileDialogType {
     /// File open dialog.
     Open,
@@ -164,7 +164,7 @@ pub struct FileDialogOptions {
 ///
 /// [`COMDLG_FILTERSPEC`]: https://docs.microsoft.com/en-ca/windows/win32/api/shtypes/ns-shtypes-comdlg_filterspec
 /// [packages]: struct.FileDialogOptions.html#packages
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FileSpec {
     /// A human readable name, describing this filetype.
     ///

--- a/druid-shell/src/hotkey.rs
+++ b/druid-shell/src/hotkey.rs
@@ -55,7 +55,7 @@ use crate::{IntoKey, KbKey, KeyEvent, Modifiers};
 /// ```
 ///
 /// [`SysMods`]: enum.SysMods.html
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HotKey {
     pub(crate) mods: RawMods,
     pub(crate) key: KbKey,
@@ -140,7 +140,7 @@ pub enum SysMods {
 /// A representation of the active modifier keys.
 ///
 /// This is intended to be clearer than `Modifiers`, when describing hotkeys.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RawMods {
     None,
     Alt,

--- a/druid-shell/src/mouse.rs
+++ b/druid-shell/src/mouse.rs
@@ -248,7 +248,7 @@ impl std::fmt::Debug for MouseButtons {
 //NOTE: this currently only contains cursors that are included by default on
 //both Windows and macOS. We may want to provide polyfills for various additional cursors.
 /// Mouse cursors.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum Cursor {
     /// The default arrow cursor.
     Arrow,

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -148,7 +148,7 @@ impl FileDialogToken {
 /// Levels in the window system - Z order for display purposes.
 /// Describes the purpose of a window and should be mapped appropriately to match platform
 /// conventions.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum WindowLevel {
     /// A top level app window.
     AppWindow,
@@ -161,7 +161,7 @@ pub enum WindowLevel {
 }
 
 /// Contains the different states a Window can be in.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WindowState {
     Maximized,
     Minimized,
@@ -169,7 +169,7 @@ pub enum WindowState {
 }
 
 /// A handle to a platform window object.
-#[derive(Clone, Default, PartialEq)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct WindowHandle(pub(crate) backend::WindowHandle);
 
 impl WindowHandle {

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -40,7 +40,7 @@ pub struct AppLauncher<T> {
 }
 
 /// Defines how a windows size should be determined
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum WindowSizePolicy {
     /// Use the content of the window to determine the size.
     ///

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -138,7 +138,7 @@ pub struct SingleUse<T>(Mutex<Option<T>>);
 /// The target of a [`Command`].
 ///
 /// [`Command`]: struct.Command.html
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Target {
     /// The target is the top-level application.
     ///

--- a/druid/src/env.rs
+++ b/druid/src/env.rs
@@ -87,7 +87,7 @@ struct EnvImpl {
 ///
 /// [`ValueType`]: trait.ValueType.html
 /// [`Env`]: struct.Env.html
-#[derive(Clone, Debug, PartialEq, Data)]
+#[derive(Clone, Debug, PartialEq, Eq, Data)]
 pub struct Key<T> {
     key: &'static str,
     value_type: PhantomData<T>,
@@ -120,7 +120,7 @@ pub enum Value {
 ///
 /// [`Key<T>`]: struct.Key.html
 /// [`Env`]: struct.Env.html
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum KeyOrValue<T> {
     /// A concrete [`Value`] of type `T`.
     ///

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -133,6 +133,7 @@
 )]
 #![warn(missing_docs)]
 #![allow(clippy::new_ret_no_self, clippy::needless_doctest_main)]
+#![allow(clippy::duplicate_mod)] // TODO: Remove this after the text/mod.rs format_priv hack has been removed (0.8.0+)
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/linebender/druid/screenshots/images/doc_logo.png"

--- a/druid/src/widget/common.rs
+++ b/druid/src/widget/common.rs
@@ -16,7 +16,7 @@ use crate::{Affine, Data, Size};
 
 // These are based on https://api.flutter.dev/flutter/painting/BoxFit-class.html
 /// Strategies for inscribing a rectangle inside another rectangle.
-#[derive(Clone, Data, Copy, PartialEq)]
+#[derive(Clone, Data, Copy, PartialEq, Eq)]
 pub enum FillStrat {
     /// As large as possible without changing aspect ratio of image and all of image shown
     Contain,

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -189,7 +189,7 @@ pub struct FlexParams {
 /// Most often used by widgets to describe
 /// the direction in which they grow as their number of children increases.
 /// Has some methods for manipulating geometry with respect to the axis.
-#[derive(Data, Debug, Clone, Copy, PartialEq)]
+#[derive(Data, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Axis {
     /// The x axis
     Horizontal,
@@ -291,7 +291,7 @@ impl Axis {
 ///
 /// If a widget is smaller than the container on the minor axis, this determines
 /// where it is positioned.
-#[derive(Debug, Clone, Copy, PartialEq, Data)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Data)]
 pub enum CrossAxisAlignment {
     /// Top or leading.
     ///
@@ -323,7 +323,7 @@ pub enum CrossAxisAlignment {
 ///
 /// If there is surplus space on the main axis after laying out children, this
 /// enum represents how children are laid out in this space.
-#[derive(Debug, Clone, Copy, PartialEq, Data)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Data)]
 pub enum MainAxisAlignment {
     /// Top or leading.
     ///

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -103,7 +103,7 @@ pub struct RawLabel<T> {
 }
 
 /// Options for handling lines that are too wide for the label.
-#[derive(Debug, Clone, Copy, PartialEq, Data)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Data)]
 pub enum LineBreaking {
     /// Lines are broken at word boundaries.
     WordWrap,

--- a/druid/src/widget/tabs.rs
+++ b/druid/src/widget/tabs.rs
@@ -754,7 +754,7 @@ impl<TP: TabsPolicy> ScopePolicy for TabsScopePolicy<TP> {
 }
 
 /// Determines whether the tabs will have a transition animation when a new tab is selected.
-#[derive(Data, Copy, Clone, Debug, PartialOrd, PartialEq)]
+#[derive(Data, Copy, Clone, Debug, PartialOrd, PartialEq, Eq)]
 pub enum TabsTransition {
     /// Change tabs instantly with no animation
     Instant,
@@ -778,7 +778,7 @@ impl TabsTransition {
 }
 
 /// Determines where the tab bar should be placed relative to the cross axis
-#[derive(Debug, Copy, Clone, PartialEq, Data)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Data)]
 pub enum TabsEdge {
     /// For horizontal tabs, top. For vertical tabs, left.
     Leading,


### PR DESCRIPTION
This PR addresses the following clippy lints:
* [`derive_partial_eq_without_eq`](https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq) - It seems somewhat slippery in general, because we might want to expand a type with floats or such in the future. However in the specific cases here I think it's fine. The most questionable one is `CustomCursor` in `druid-shell` I guess, but for now it works.
* [`type-complexity`](https://rust-lang.github.io/rust-clippy/master/index.html#type-complexity) - This lint got a lot more aggressive. The lint may get tweaked, pending conclusion of [rust-clippy#9299](https://github.com/rust-lang/rust-clippy/issues/9299). Until then I just increased our complexity tolerance threshold.
* [`duplicate_mod`](https://rust-lang.github.io/rust-clippy/master/index.html#duplicate_mod) - Apparently we have a delibrate hack of duplicate mod import, so I just disabled this lint until we can remove the hack.
* [`needless_return`](https://rust-lang.github.io/rust-clippy/master/index.html#needless_return)
* [`get_first`](https://rust-lang.github.io/rust-clippy/master/index.html#get_first)