### PR TITLE
fix: update `calc` example to version `0.7.0`

### DIFF
--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -246,7 +246,7 @@ fn build_calc() -> impl Widget<CalcState> {
 }
 
 pub fn main() {
-    let window = WindowDesc::new(build_calc())
+    let window = WindowDesc::new(build_calc)
         .window_size((223., 300.))
         .resizable(false)
         .title(
@@ -259,7 +259,7 @@ pub fn main() {
         in_num: false,
     };
     AppLauncher::with_window(window)
-        .log_to_console()
+        .use_simple_logger()
         .launch(calc_state)
         .expect("launch failed");
 }


### PR DESCRIPTION
Replaces `log_to_console` with `use_simple_logger` and also updates
function expected as parameter for `WindowDesc::new`.

Refer: https://github.com/linebender/druid/issues/2120