### PR TITLE
Rough implementation of selected menu items for gtk backend

### DIFF
--- a/druid-shell/examples/quit.rs
+++ b/druid-shell/examples/quit.rs
@@ -75,8 +75,8 @@ fn main() {
         0x100,
         "E&xit",
         Some(&HotKey::new(SysMods::Cmd, "q")),
+        None,
         true,
-        false,
     );
 
     let mut menubar = Menu::new();

--- a/druid-shell/examples/shello.rs
+++ b/druid-shell/examples/shello.rs
@@ -140,22 +140,22 @@ fn main() {
         0x100,
         "E&xit",
         Some(&HotKey::new(SysMods::Cmd, "q")),
+        None,
         true,
-        false,
     );
     file_menu.add_item(
         0x101,
         "O&pen",
         Some(&HotKey::new(SysMods::Cmd, "o")),
+        None,
         true,
-        false,
     );
     file_menu.add_item(
         0x102,
         "S&ave",
         Some(&HotKey::new(SysMods::Cmd, "s")),
+        None,
         true,
-        false,
     );
     let mut menubar = Menu::new();
     menubar.add_dropdown(Menu::new(), "Application", true);

--- a/druid-shell/src/backend/mac/menu.rs
+++ b/druid-shell/src/backend/mac/menu.rs
@@ -90,8 +90,8 @@ impl Menu {
         id: u32,
         text: &str,
         key: Option<&HotKey>,
+        selected: Option<bool>,
         enabled: bool,
-        selected: bool,
     ) {
         let menu_item = make_menu_item(id, text, key, enabled, selected);
         unsafe {

--- a/druid-shell/src/backend/mac/menu.rs
+++ b/druid-shell/src/backend/mac/menu.rs
@@ -28,7 +28,13 @@ pub struct Menu {
     pub menu: id,
 }
 
-fn make_menu_item(id: u32, text: &str, key: Option<&HotKey>, enabled: bool, selected: bool) -> id {
+fn make_menu_item(
+    id: u32,
+    text: &str,
+    key: Option<&HotKey>,
+    selected: Option<bool>,
+    enabled: bool,
+) -> id {
     let key_equivalent = key.map(HotKey::key_equivalent).unwrap_or("");
     let stripped_text = strip_access_key(text);
     unsafe {
@@ -49,7 +55,7 @@ fn make_menu_item(id: u32, text: &str, key: Option<&HotKey>, enabled: bool, sele
             let () = msg_send![item, setEnabled: NO];
         }
 
-        if selected {
+        if let Some(true) = selected {
             let () = msg_send![item, setState: 1_isize];
         }
         item
@@ -93,7 +99,7 @@ impl Menu {
         selected: Option<bool>,
         enabled: bool,
     ) {
-        let menu_item = make_menu_item(id, text, key, enabled, selected);
+        let menu_item = make_menu_item(id, text, key, selected, enabled);
         unsafe {
             self.menu.addItem_(menu_item);
         }

--- a/druid-shell/src/backend/wayland/menu.rs
+++ b/druid-shell/src/backend/wayland/menu.rs
@@ -33,17 +33,22 @@ impl Menu {
         Menu
     }
 
-    pub fn add_dropdown(&mut self, menu: Menu, text: &str, _enabled: bool) {}
+    pub fn add_dropdown(&mut self, menu: Menu, text: &str, _enabled: bool) {
+        tracing::warn!("unimplemented");
+    }
 
     pub fn add_item(
         &mut self,
-        id: u32,
-        text: &str,
-        key: Option<&HotKey>,
-        enabled: bool,
-        _selected: bool,
+        _id: u32,
+        _text: &str,
+        _key: Option<&HotKey>,
+        _selected: Option<bool>,
+        _enabled: bool,
     ) {
+        tracing::warn!("unimplemented");
     }
 
-    pub fn add_separator(&mut self) {}
+    pub fn add_separator(&mut self) {
+        tracing::warn!("unimplemented");
+    }
 }

--- a/druid-shell/src/backend/web/menu.rs
+++ b/druid-shell/src/backend/web/menu.rs
@@ -44,8 +44,8 @@ impl Menu {
         _id: u32,
         _text: &str,
         _key: Option<&HotKey>,
+        _selected: Option<bool>,
         _enabled: bool,
-        _selected: bool,
     ) {
         tracing::warn!("unimplemented");
     }

--- a/druid-shell/src/backend/windows/menu.rs
+++ b/druid-shell/src/backend/windows/menu.rs
@@ -112,7 +112,7 @@ impl Menu {
             if !enabled {
                 flags |= MF_GRAYED;
             }
-            if selected {
+            if let Some(true) = selected {
                 flags |= MF_CHECKED;
             }
             AppendMenuW(

--- a/druid-shell/src/backend/windows/menu.rs
+++ b/druid-shell/src/backend/windows/menu.rs
@@ -99,8 +99,8 @@ impl Menu {
         id: u32,
         text: &str,
         key: Option<&HotKey>,
+        selected: Option<bool>,
         enabled: bool,
-        selected: bool,
     ) {
         let mut anno_text = text.to_string();
         if let Some(key) = key {

--- a/druid-shell/src/backend/x11/menu.rs
+++ b/druid-shell/src/backend/x11/menu.rs
@@ -41,8 +41,8 @@ impl Menu {
         _id: u32,
         _text: &str,
         _key: Option<&HotKey>,
+        _selected: Option<bool>,
         _enabled: bool,
-        _selected: bool,
     ) {
         // TODO(x11/menus): implement Menu::add_item (currently a no-op)
         tracing::warn!("Menu::add_item is currently unimplemented for X11 backend.");

--- a/druid-shell/src/menu.rs
+++ b/druid-shell/src/menu.rs
@@ -71,10 +71,10 @@ impl Menu {
         id: u32,
         text: &str,
         key: Option<&HotKey>,
+        selected: Option<bool>,
         enabled: bool,
-        selected: bool,
     ) {
-        self.0.add_item(id, text, key, enabled, selected)
+        self.0.add_item(id, text, key, selected, enabled)
     }
 
     /// Add a separator to the menu.

--- a/druid/src/menu/mod.rs
+++ b/druid/src/menu/mod.rs
@@ -285,10 +285,10 @@ impl MenuBuildCtx {
         id: u32,
         text: &str,
         key: Option<&HotKey>,
+        selected: Option<bool>,
         enabled: bool,
-        selected: bool,
     ) {
-        self.current.add_item(id, text, key, enabled, selected);
+        self.current.add_item(id, text, key, selected, enabled);
     }
 
     fn add_separator(&mut self) {
@@ -700,11 +700,7 @@ impl<T: Data> MenuItem<T> {
         let new_state = MenuItemState {
             title: self.title.display_text(),
             hotkey: self.hotkey.as_mut().and_then(|h| h(data, env)),
-            selected: self
-                .selected
-                .as_mut()
-                .map(|s| s(data, env))
-                .unwrap_or(false),
+            selected: self.selected.as_mut().map(|s| s(data, env)),
             enabled: self.enabled.as_mut().map(|e| e(data, env)).unwrap_or(true),
         };
         let ret = self.old_state.as_ref() != Some(&new_state);
@@ -798,8 +794,8 @@ impl<T: Data> MenuVisitor<T> for MenuItem<T> {
             self.id.0.map(|x| x.get()).unwrap_or(0),
             &state.title,
             state.hotkey.as_ref(),
-            state.enabled,
             state.selected,
+            state.enabled,
         );
     }
 }
@@ -820,7 +816,7 @@ impl<T: Data> MenuVisitor<T> for Separator {
 struct MenuItemState {
     title: ArcStr,
     hotkey: Option<HotKey>,
-    selected: bool,
+    selected: Option<bool>,
     enabled: bool,
 }
 


### PR DESCRIPTION
If there's a way to make a `gtk::prelude::IsA<gtk::MenuItem> + gtk::prelude::IsA<gtk::Widget>` trait object then this could be a lot shorter, but I couldn't get that to work.

Technically checkbox menu entries should have a distinct unchecked state (at least in GTK), but I didn't see a distinction in druid's MenuItem which would allow for that so these do not.