### PR TITLE
Wayland protocol objects versioning & XDG Shell initial size

### DIFF
--- a/druid-shell/src/backend/wayland/application.rs
+++ b/druid-shell/src/backend/wayland/application.rs
@@ -171,11 +171,15 @@ impl Application {
                         let id = *id;
                         let version = *version;
 
-                        if !(interface.as_str() == "wl_seat" && version >= 7) {
+                        if interface.as_str() != "wl_seat" {
                             return;
                         }
+
                         tracing::debug!("seat detected {:?} {:?} {:?}", interface, id, version);
-                        let new_seat = registry.bind::<WlSeat>(7, id);
+
+                        // 7 is the max version supported by wayland-rs 0.29.5
+                        let version = version.min(7);
+                        let new_seat = registry.bind::<WlSeat>(version, id);
                         let prev_seat = weak_seats
                             .upgrade()
                             .unwrap()
@@ -185,6 +189,10 @@ impl Application {
                             prev_seat.is_none(),
                             "internal: wayland should always use new IDs"
                         );
+
+                        // TODO: This code handles only app startup, but seats can come and go on the fly,
+                        // so we have to handle that in the future
+
                         // Defer setting up the pointer/keyboard event handling until we've
                         // finished constructing the `Application`. That way we can pass it as a
                         // parameter.
@@ -290,8 +298,14 @@ impl Application {
                             });
                             seat.pointer = Some(pointer);
                         }
-                        // Dont worry if they go away - we will just stop receiving events. If the
-                        // capability comes back we will start getting events again.
+
+                        // TODO: We should react to capability removal, 
+                        // "if a seat regains the pointer capability 
+                        // and a client has a previously obtained wl_pointer object 
+                        // of version 4 or less, that object may start sending pointer events again. 
+                        // This behavior is considered a misinterpretation of the intended behavior 
+                        // and must not be relied upon by the client", 
+                        // versions 5 up guarantee that events will not be sent for sure
                     }
                     wl_seat::Event::Name { name } => {
                         seat.name = name;

--- a/druid-shell/src/backend/wayland/application.rs
+++ b/druid-shell/src/backend/wayland/application.rs
@@ -220,8 +220,8 @@ impl Application {
 
         let wl_compositor = env
             .registry
-            .instantiate_exact::<WlCompositor>(4)
-            .map_err(|e| Error::global("wl_compositor", 4, e))?;
+            .instantiate_range::<WlCompositor>(1, 5)
+            .map_err(|e| Error::global("wl_compositor", 1, e))?;
         let wl_shm = env
             .registry
             .instantiate_exact::<WlShm>(1)

--- a/druid-shell/src/backend/wayland/display.rs
+++ b/druid-shell/src/backend/wayland/display.rs
@@ -134,9 +134,10 @@ pub(super) fn new(dispatcher: Dispatcher) -> Result<Environment, error::Error> {
         .sync_roundtrip(&mut (), |_, _, _| unreachable!())
         .map_err(error::Error::fatal)?;
 
+    // 3 is the max version supported by wayland-rs 0.29.5
     let xdg_base = registry
-        .instantiate_exact::<xdg_wm_base::XdgWmBase>(2)
-        .map_err(|e| error::Error::global("xdg_wm_base", 2, e))?;
+        .instantiate_range::<xdg_wm_base::XdgWmBase>(1, 3)
+        .map_err(|e| error::Error::global("xdg_wm_base", 1, e))?;
 
     // We do this to make sure wayland knows we're still responsive.
     //

--- a/druid-shell/src/backend/wayland/outputs/output.rs
+++ b/druid-shell/src/backend/wayland/outputs/output.rs
@@ -30,11 +30,14 @@ pub fn detect(
                         return;
                     }
 
-                    if !(interface.as_str() == "wl_output" && version >= 3) {
+                    // We rely on wl_output::done() event so version 2 is our minimum,
+                    // it is also 9 years old so we can assume that any non-abandonware compositor uses it.
+                    if !(interface.as_str() == "wl_output" && version >= 2) {
                         return;
                     }
 
-                    let output = registry.bind::<wl_output::WlOutput>(3, id);
+                    let version = version.min(3);
+                    let output = registry.bind::<wl_output::WlOutput>(version, id);
                     let xdgm = (*xdg_output_manager_id.borrow()).map(|xdgm_id| {
                         registry.bind::<zxdg_output_manager_v1::ZxdgOutputManagerV1>(3, xdgm_id)
                     });

--- a/druid-shell/src/backend/wayland/pointers.rs
+++ b/druid-shell/src/backend/wayland/pointers.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 use wayland_client::protocol::wl_pointer;
-use wayland_client::protocol::wl_surface::WlSurface;
+use wayland_client::protocol::wl_surface::{self, WlSurface};
 use wayland_client::{self as wl};
 use wayland_cursor::CursorImageBuffer;
 use wayland_cursor::CursorTheme;
@@ -195,7 +195,13 @@ impl Pointer {
         self.current_cursor.replace(cursor);
         wl_pointer.set_cursor(0, Some(&self.cursor_surface), hot_x as i32, hot_y as i32);
         self.cursor_surface.attach(Some(&*buffer), 0, 0);
-        self.cursor_surface.damage_buffer(0, 0, i32::MAX, i32::MAX);
+
+        if self.cursor_surface.as_ref().version() >= wl_surface::REQ_DAMAGE_BUFFER_SINCE {
+            self.cursor_surface.damage_buffer(0, 0, i32::MAX, i32::MAX);
+        } else {
+            self.cursor_surface.damage(0, 0, i32::MAX, i32::MAX);
+        }
+
         self.cursor_surface.commit();
     }
 

--- a/druid-shell/src/backend/wayland/surfaces/surface.rs
+++ b/druid-shell/src/backend/wayland/surfaces/surface.rs
@@ -130,15 +130,18 @@ impl Surface {
             _ => tracing::warn!("unhandled wayland surface event {:?}", event),
         }
 
-        let new_scale = current.recompute_scale();
-        if current.set_scale(new_scale).is_changed() {
-            current.wl_surface.borrow().set_buffer_scale(new_scale);
-            // We also need to change the physical size to match the new scale
-            current
-                .buffers
-                .set_size(buffers::RawSize::from(current.logical_size.get()).scale(new_scale));
-            // always repaint, because the scale changed.
-            current.schedule_deferred_task(DeferredTask::Paint);
+        if current.wl_surface.borrow().as_ref().version() >= wl_surface::REQ_SET_BUFFER_SCALE_SINCE
+        {
+            let new_scale = current.recompute_scale();
+            if current.set_scale(new_scale).is_changed() {
+                current.wl_surface.borrow().set_buffer_scale(new_scale);
+                // We also need to change the physical size to match the new scale
+                current
+                    .buffers
+                    .set_size(buffers::RawSize::from(current.logical_size.get()).scale(new_scale));
+                // always repaint, because the scale changed.
+                current.schedule_deferred_task(DeferredTask::Paint);
+            }
         }
     }
 }
@@ -376,12 +379,22 @@ impl Data {
             for rect in damaged_region.rects() {
                 // Convert it to physical coordinate space.
                 let rect = buffers::RawRect::from(*rect).scale(self.scale.get());
-                self.wl_surface.borrow().damage_buffer(
-                    rect.x0,
-                    rect.y0,
-                    rect.x1 - rect.x0,
-                    rect.y1 - rect.y0,
-                );
+
+                if self.wl_surface.borrow().as_ref().version()
+                    >= wl_surface::REQ_DAMAGE_BUFFER_SINCE
+                {
+                    self.wl_surface.borrow().damage_buffer(
+                        rect.x0,
+                        rect.y0,
+                        rect.x1 - rect.x0,
+                        rect.y1 - rect.y0,
+                    );
+                } else {
+                    // We don't care about obscure pre version 4 compositors
+                    // and just damage the whole surface instead of
+                    // translating from buffer coordinates to surface coordinates
+                    self.wl_surface.borrow().damage(0, 0, i32::MAX, i32::MAX);
+                }
             }
             if damaged_region.is_empty() {
                 // Nothing to draw, so we can finish here!

--- a/druid-shell/src/backend/wayland/surfaces/toplevel.rs
+++ b/druid-shell/src/backend/wayland/surfaces/toplevel.rs
@@ -85,10 +85,8 @@ impl Surface {
                         (width as f64, height as f64)
                     };
 
-                    let dim = kurbo::Size::new(
-                        width.max(min_size.width),
-                        height.max(min_size.height),
-                    );
+                    let dim =
+                        kurbo::Size::new(width.max(min_size.width), height.max(min_size.height));
 
                     wl_surface.update_dimensions(dim);
                 }

--- a/druid-shell/src/backend/wayland/surfaces/toplevel.rs
+++ b/druid-shell/src/backend/wayland/surfaces/toplevel.rs
@@ -35,6 +35,7 @@ impl Surface {
     pub fn new(
         c: impl Into<CompositorHandle>,
         handler: Box<dyn window::WinHandler>,
+        size: kurbo::Size,
         min_size: Option<kurbo::Size>,
     ) -> Self {
         let min_size = min_size.unwrap_or_else(|| kurbo::Size::from((1.0, 1.0)));
@@ -61,7 +62,6 @@ impl Surface {
 
         xdg_toplevel.quick_assign({
             let wl_surface = wl_surface.clone();
-            let dim = min_size;
             move |_xdg_toplevel, event, a3| match event {
                 xdg_toplevel::Event::Configure {
                     width,
@@ -76,9 +76,18 @@ impl Surface {
                         a3
                     );
 
+                    // If the width or height arguments are zero, it means the client should decide its own window dimension.
+                    // This may happen when the compositor needs to configure the state of the surface
+                    // but doesn't have any information about any previous or expected dimension.
+                    let (width, height) = if width == 0 || height == 0 {
+                        (size.width, size.height)
+                    } else {
+                        (width as f64, height as f64)
+                    };
+
                     let dim = kurbo::Size::new(
-                        (width as f64).max(dim.width),
-                        (height as f64).max(dim.height),
+                        width.max(min_size.width),
+                        height.max(min_size.height),
                     );
 
                     wl_surface.update_dimensions(dim);

--- a/druid-shell/src/backend/wayland/window.rs
+++ b/druid-shell/src/backend/wayland/window.rs
@@ -422,7 +422,8 @@ impl WindowBuilder {
 
         let handler = self.handler.expect("must set a window handler");
 
-        let surface = surfaces::toplevel::Surface::new(appdata.clone(), handler, self.min_size);
+        let surface =
+            surfaces::toplevel::Surface::new(appdata.clone(), handler, self.size, self.min_size);
 
         (&surface as &dyn surfaces::Decor).set_title(self.title);
 


### PR DESCRIPTION
This PR introduces support for running on a wide variety of versions of core protocols.
Druid can now run on both Weston and Mutter.

While at it, I also fixed the initial size of top levels, they are no longer 1px x 1px, they now use the size provided by the user. 