### PR TITLE
pop-up window without a parent use config position

### DIFF
--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -1401,18 +1401,20 @@ impl WindowBuilder {
                         dwStyle = WS_POPUP;
                         dwExStyle = WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW;
                         focusable = false;
-                        if let Some(point_in_window_coord) = self.position {
-                            let screen_point = parent_window_handle.get_position()
-                                + point_in_window_coord.to_vec2();
-                            let scaled_point = WindowBuilder::scale_sub_window_position(
-                                screen_point,
-                                parent_window_handle.get_scale(),
-                            );
-                            pos_x = scaled_point.x as i32;
-                            pos_y = scaled_point.y as i32;
-                        } else {
-                            warn!("No position provided for subwindow!");
-                        }
+
+                        match (parent_hwnd, self.position) {
+                            (Some(_), Some(point_in_window_coord)) => {
+                                let screen_point = parent_window_handle.get_position()
+                                    + point_in_window_coord.to_vec2();
+                                let scaled_point = WindowBuilder::scale_sub_window_position(
+                                    screen_point,
+                                    parent_window_handle.get_scale(),
+                                );
+                                pos_x = scaled_point.x as i32;
+                                pos_y = scaled_point.y as i32;
+                            }
+                            _ => warn!("No position or parent widnow provided for subwindow!"),
+                        };
                     }
                 }
             } else {


### PR DESCRIPTION
My app has only one pop-up window, but it always shows in top left corner of the screen.

The reason is that the parent window is not considered empty and the calculation of the relative position of the child window fails.


```
WindowDesc::new(app_ui())
    .window_size(size)
    .set_level(WindowLevel::Tooltip(WindowHandle::default()))
```