### PR TITLE
always_on_top for WindowBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ You can find its changes [documented below](#070---2021-01-01).
 
 ## Unreleased
 
+- Always on top setting for WindowBuilder ([#2265] by [@mgalos999])
+
 ### Highlights
 
 - International text input support (IME) on macOS.

--- a/druid-shell/src/backend/gtk/window.rs
+++ b/druid-shell/src/backend/gtk/window.rs
@@ -261,6 +261,10 @@ impl WindowBuilder {
         self.transparent = transparent;
     }
 
+    pub fn set_always_on_top(&mut self, _always_on_top: bool) {
+        tracing::warn!("set_always_on_top unimplemented for gtk");
+    }
+
     pub fn set_position(&mut self, position: Point) {
         self.position = Some(position);
     }

--- a/druid-shell/src/backend/mac/window.rs
+++ b/druid-shell/src/backend/mac/window.rs
@@ -225,6 +225,10 @@ impl WindowBuilder {
         self.transparent = transparent;
     }
 
+    pub fn set_always_on_top(&mut self, _always_on_top: bool) {
+        tracing::warn!("set_always_on_top unimplemented for mac");
+    }
+
     pub fn set_level(&mut self, level: WindowLevel) {
         self.level = Some(level);
     }

--- a/druid-shell/src/backend/wayland/window.rs
+++ b/druid-shell/src/backend/wayland/window.rs
@@ -380,6 +380,12 @@ impl WindowBuilder {
         );
     }
 
+    pub fn set_always_on_top(&mut self, _always_on_top: bool) {
+        tracing::warn!(
+            "set_always_on_top unimplemented for wayland"
+        );
+    }
+
     pub fn set_position(&mut self, position: Point) {
         self.position = Some(position);
     }

--- a/druid-shell/src/backend/web/window.rs
+++ b/druid-shell/src/backend/web/window.rs
@@ -392,6 +392,10 @@ impl WindowBuilder {
         // Ignored
     }
 
+    pub fn set_always_on_top(&mut self, _always_on_top: bool) {
+        // Ignored
+    }
+
     pub fn set_position(&mut self, _position: Point) {
         // Ignored
     }

--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -96,6 +96,7 @@ pub(crate) struct WindowBuilder {
     show_titlebar: bool,
     size: Option<Size>,
     transparent: bool,
+    always_on_top: bool,
     min_size: Option<Size>,
     position: Option<Point>,
     level: Option<WindowLevel>,
@@ -1281,6 +1282,7 @@ impl WindowBuilder {
             resizable: true,
             show_titlebar: true,
             transparent: false,
+            always_on_top: false,
             present_strategy: Default::default(),
             size: None,
             min_size: None,
@@ -1322,6 +1324,10 @@ impl WindowBuilder {
                 tracing::warn!("Transparency requires Windows 8 or newer");
             }
         }
+    }
+
+    pub fn set_always_on_top(&mut self, always_on_top: bool) {
+        self.always_on_top = always_on_top;
     }
 
     pub fn set_title<S: Into<String>>(&mut self, title: S) {
@@ -1468,6 +1474,10 @@ impl WindowBuilder {
 
             if self.present_strategy == PresentStrategy::Flip {
                 dwExStyle |= WS_EX_NOREDIRECTIONBITMAP;
+            }
+
+            if self.always_on_top {
+                dwExStyle |= WS_EX_TOPMOST;
             }
 
             match self.state {

--- a/druid-shell/src/backend/x11/window.rs
+++ b/druid-shell/src/backend/x11/window.rs
@@ -169,6 +169,10 @@ impl WindowBuilder {
         self.transparent = transparent;
     }
 
+    pub fn set_always_on_top(&mut self, _always_on_top: bool) {
+        warn!("WindowBuilder::set_always_on_top is currently unimplemented for X11 backend.");
+    }
+
     pub fn set_position(&mut self, position: Point) {
         self.position = Some(position);
     }

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -484,6 +484,11 @@ impl WindowBuilder {
         self.0.set_transparent(transparent)
     }
 
+    /// Set whether the window is always on top
+    pub fn set_always_on_top(&mut self, always_on_top: bool) {
+        self.0.set_always_on_top(always_on_top)
+    }
+
     /// Sets the initial window position in display points.
     /// For windows with a parent, the position is relative to the parent.
     /// For windows without a parent, it is relative to the origin of the virtual screen.


### PR DESCRIPTION
WindowBuilder now has a `.always_on_top(bool)` setting.
Currently I have only implemented this for windows and just have warnings for other backends.