### PR TITLE
pass build_ui function object to WindowDesc::new

### DIFF
--- a/docs/src/get_started.md
+++ b/docs/src/get_started.md
@@ -26,7 +26,7 @@ fn build_ui() -> impl Widget<()> {
 }
 
 fn main() -> Result<(), PlatformError> {
-    AppLauncher::with_window(WindowDesc::new(build_ui())).launch(())?;
+    AppLauncher::with_window(WindowDesc::new(build_ui)).launch(())?;
     Ok(())
 }
 ```


### PR DESCRIPTION
`WindowDesc::new` expects a function object as its argument, not the value of the called object. If `build_ui()` is passed, we get the following compiler error:

```
expected a `std::ops::FnOnce<()>` closure, found `impl druid::Widget<()>`

expected an `FnOnce<()>` closure, found `impl druid::Widget<()>`
```

Passing `build_ui` (no parentheses) to `WindowDesc::new` fixes the error.