### PR TITLE
Use custom application icon on Windows, if present.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,7 @@ values and their textual representations. ([#1377])
 - All Image formats are now optional, reducing compile time and binary size by default ([#1340] by [@JAicewizard])
 - The `Cursor` API has changed to a stateful one ([#1433] by [@jneem])
 - Part of the `SAVE_FILE` command is now `SAVE_FILE_AS` ([#1463] by [@jneem])
+- Windows: Use custom application icon, if present ([#2274] by [@tay64])
 
 ### Deprecated
 - Parse widget (replaced with `Formatter` trait) ([#1377] by [@cmyr])
@@ -862,6 +863,7 @@ Last release without a changelog :(
 [#2203]: https://github.com/linebender/druid/pull/2203
 [#2235]: https://github.com/linebender/druid/pull/2235
 [#2247]: https://github.com/linebender/druid/pull/2247
+[#2274]: https://github.com/linebender/druid/pull/2274
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/linebender/druid/compare/v0.5.0...v0.6.0

--- a/druid-shell/src/backend/windows/application.rs
+++ b/druid-shell/src/backend/windows/application.rs
@@ -26,13 +26,14 @@ use winapi::shared::ntdef::LPCWSTR;
 use winapi::shared::windef::{DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, HCURSOR, HWND};
 use winapi::shared::winerror::HRESULT_FROM_WIN32;
 use winapi::um::errhandlingapi::GetLastError;
+use winapi::um::libloaderapi::GetModuleHandleW;
 use winapi::um::shellscalingapi::PROCESS_PER_MONITOR_DPI_AWARE;
 use winapi::um::winnls::GetUserDefaultLocaleName;
 use winapi::um::winnt::LOCALE_NAME_MAX_LENGTH;
 use winapi::um::winuser::{
     DispatchMessageW, GetAncestor, GetMessageW, LoadIconW, PeekMessageW, PostMessageW,
     PostQuitMessage, RegisterClassW, TranslateAcceleratorW, TranslateMessage, GA_ROOT,
-    IDI_APPLICATION, MSG, PM_NOREMOVE, WM_TIMER, WNDCLASSW,
+    MAKEINTRESOURCEW, MSG, PM_NOREMOVE, WM_TIMER, WNDCLASSW,
 };
 
 use piet_common::D2DLoadedFonts;
@@ -90,7 +91,7 @@ impl Application {
             .is_ok()
         {
             let class_name = CLASS_NAME.to_wide();
-            let icon = unsafe { LoadIconW(0 as HINSTANCE, IDI_APPLICATION) };
+            let icon = unsafe { LoadIconW(GetModuleHandleW(0 as LPCWSTR), MAKEINTRESOURCEW(1)) };
             let wnd = WNDCLASSW {
                 style: 0,
                 lpfnWndProc: Some(window::win_proc_dispatch),


### PR DESCRIPTION
On Windows, if the executable contains an icon resource with id 1, this icon will be used in the Taskbar and in the titlebar of Druid windows. If there is no such icon resource, the default application icon IDI_APPLICATION will be used (as before this change).

Adding a custom icon: one way is to use the [winres] crate and follow the guide in its README; `winres::WindowsResource::set_icon()` adds an icon with id 1.

Non-Windows back-ends are not modified.

-----

This is a very small change that improves on status-quo a little; it is not an attempt in adding proper support for icons. The new behavior is a strict superset of the previous behavior and should have no negative effects. The users that do not take special steps to embed a Windows icon won't be affected.

### What happens if there is no icon resource #⁠1?

It will fall back to use the standard icon `IDI_APPLICATION`, matching the original behavior without this PR.

1. `LoadIconW` will [return][LoadIconW] `NULL`:
    _If the function fails, the return value is NULL_.
2. `WNDCLASSW::hIcon`, being `NULL`, [causes][WNDCLASSW] Windows to use a default icon:
    _If this member is NULL, the system provides a default icon._

I was unable to find any document that explicitly says that the default icon is `IDI_APPLICATION`, but in practice it has been this way since Windows 3.1.

### Why use the hard-coded icon id #⁠1?

The icon used by Windows for the executable file (in Explorer etc) is the first icon resource in the resource section. It does not have to be specifically #⁠1, but it is a common practice to use #⁠1 for the application icon, because the Resource Compiler orders icons by id and using 1 guarantees it to be the first one.

Also, one of the convenient methods of adding an icon to a Rust binary, the [winres] crate, uses the id #⁠1 by default.

I think this justifies the use of a hard-coded id in this case. This PR is intended as a very small change and any additional complexity wouldn't be welcome. Also, this will be superseded by a proper support for window icons, if and when it arrives in Druid (something like `WindowDesc::set_icon`).


[LoadIconW]: https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-loadiconw#return-value
[WNDCLASSW]: https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-wndclassw
[winres]: https://crates.io/crates/winres
