### PR TITLE
Upgrade bindgen from 0.58 to 0.61

### DIFF
--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -134,5 +134,5 @@ tracing-subscriber = { version = "0.3.2", features = ["env-filter"] }
 unicode-segmentation = "1.7.0"
 
 [build-dependencies]
-bindgen = {version = "0.58", optional = true}
+bindgen = { version = "0.61", optional = true }
 pkg-config = { version = "0.3", optional = true }


### PR DESCRIPTION
Removes the unmaintained `ansi_term` dependency from the dependency tree. The only breaking changes in 0.59 and 0.60 are MSRV bumps, according to their changelog.