### PR TITLE
Fix mouse enter/leave events on macos 13 fixes #2280

### DIFF
--- a/druid-shell/src/backend/mac/window.rs
+++ b/druid-shell/src/backend/mac/window.rs
@@ -290,6 +290,18 @@ impl WindowBuilder {
             let frame = NSView::frame(content_view);
             view.initWithFrame_(frame);
 
+            // The rect of the tracking area doesn't matter, because
+            // we use the InVisibleRect option where the OS syncs the size automatically.
+            let rect = NSRect::new(NSPoint::new(0., 0.), NSSize::new(0., 0.));
+            let opts = NSTrackingAreaOptions::MouseEnteredAndExited
+                | NSTrackingAreaOptions::MouseMoved
+                | NSTrackingAreaOptions::ActiveAlways
+                | NSTrackingAreaOptions::InVisibleRect;
+            let tracking_area = NSTrackingArea::alloc(nil)
+                .initWithRect_options_owner_userInfo(rect, opts, view, nil)
+                .autorelease();
+            view.addTrackingArea(tracking_area);
+
             let () = msg_send![window, setDelegate: view];
 
             if let Some(menu) = self.menu {
@@ -577,18 +589,6 @@ fn make_view(handler: Box<dyn WinHandler>) -> (id, Weak<Mutex<Vec<IdleKind>>>) {
         (*view).set_ivar("viewState", state_ptr as *mut c_void);
         let options: NSAutoresizingMaskOptions = NSViewWidthSizable | NSViewHeightSizable;
         view.setAutoresizingMask_(options);
-
-        // The rect of the tracking area doesn't matter, because
-        // we use the InVisibleRect option where the OS syncs the size automatically.
-        let rect = NSRect::new(NSPoint::new(0., 0.), NSSize::new(0., 0.));
-        let opts = NSTrackingAreaOptions::MouseEnteredAndExited
-            | NSTrackingAreaOptions::MouseMoved
-            | NSTrackingAreaOptions::ActiveAlways
-            | NSTrackingAreaOptions::InVisibleRect;
-        let tracking_area = NSTrackingArea::alloc(nil)
-            .initWithRect_options_owner_userInfo(rect, opts, view, nil)
-            .autorelease();
-        view.addTrackingArea(tracking_area);
 
         (view.autorelease(), queue_handle)
     }


### PR DESCRIPTION
macOS 13 introduces an issue that mouse events are not fired anymore. This is caused by `NSView.addTrackingArea` being called too soon and is fixed here to be done after `NSView.initWithFrame` has been called.

The docs at https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/EventOverview/TrackingAreaObjects/TrackingAreaObjects.html does say that you can create an `NSTrackingArea` instance and add it to a view at any point because successful creation does not depend on the view being added to a window. But it seems there are still some undocumented preconditions.