### PR TITLE
Fixed window creation position at high-dpi screen

### DIFF
--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -737,7 +737,7 @@ impl WndProc for MyWndProc {
                     state.hwnd.set(hwnd);
                 }
                 
-                let origin_pos = self.handle.borrow().get_position());
+                let origin_pos = self.handle.borrow().get_position();
                 self.set_scale(scale);
                 self.handle_deferred(DeferredOp::SetPosition(origin_pos));
                 

--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -736,11 +736,11 @@ impl WndProc for MyWndProc {
                 if let Some(state) = self.handle.borrow().state.upgrade() {
                     state.hwnd.set(hwnd);
                 }
-                
+
                 let origin_pos = self.handle.borrow().get_position();
                 self.set_scale(scale);
                 self.handle_deferred(DeferredOp::SetPosition(origin_pos));
-                
+
                 if let Some(state) = self.state.borrow_mut().as_mut() {
                     let dxgi_state = unsafe {
                         create_dxgi_state(self.present_strategy, hwnd, self.is_transparent())

--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -732,11 +732,15 @@ impl WndProc for MyWndProc {
                     1.0
                 };
                 let scale = Scale::new(scale_factor, scale_factor);
-                self.set_scale(scale);
 
                 if let Some(state) = self.handle.borrow().state.upgrade() {
                     state.hwnd.set(hwnd);
                 }
+                
+                let origin_pos = self.handle.borrow().get_position());
+                self.set_scale(scale);
+                self.handle_deferred(DeferredOp::SetPosition(origin_pos));
+                
                 if let Some(state) = self.state.borrow_mut().as_mut() {
                     let dxgi_state = unsafe {
                         create_dxgi_state(self.present_strategy, hwnd, self.is_transparent())


### PR DESCRIPTION
Fixed windows position at high-dpi screen when creating window.

Because I've just noticed that when I need to make window center on high-dpi screen the window will shift to the upper left corner. I've just checked the code for a while and tried to simply fix it.