### PR TITLE
ZStack fix

### DIFF
--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -666,11 +666,11 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         }
 
         // TODO: factor as much logic as possible into monomorphic functions.
-        if ctx.is_handled
-            && !matches!(
-                event,
-                Event::MouseDown(_) | Event::MouseUp(_) | Event::MouseMove(_) | Event::Wheel(_)
-            )
+        // a follow_up event should reach the widget which handled the first event.
+        // in this case we dont discard events when ctx.is_handled is set but just dont set our hot
+        // state to true
+        let follow_up_event = event.is_pointer_event() && self.state.has_active;
+        if ctx.is_handled && !follow_up_event
         {
             // This function is called by containers to propagate an event from
             // containers to children. Non-recurse events will be invoked directly

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -670,8 +670,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         // in this case we dont discard events when ctx.is_handled is set but just dont set our hot
         // state to true
         let follow_up_event = event.is_pointer_event() && self.state.has_active;
-        if ctx.is_handled && !follow_up_event
-        {
+        if ctx.is_handled && !follow_up_event {
             // This function is called by containers to propagate an event from
             // containers to children. Non-recurse events will be invoked directly
             // from other points in the library.

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -451,9 +451,9 @@ impl Event {
 
     pub fn is_pointer_event(&self) -> bool {
         matches!(
-                event,
-                Event::MouseDown(_) | Event::MouseUp(_) | Event::MouseMove(_)
-            )
+            event,
+            Event::MouseDown(_) | Event::MouseUp(_) | Event::MouseMove(_)
+        )
     }
 }
 

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -448,6 +448,13 @@ impl Event {
             | Event::Zoom(_) => false,
         }
     }
+
+    pub fn is_pointer_event(&self) -> bool {
+        matches!(
+                event,
+                Event::MouseDown(_) | Event::MouseUp(_) | Event::MouseMove(_)
+            )
+    }
 }
 
 impl LifeCycle {

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -449,10 +449,13 @@ impl Event {
         }
     }
 
+    /// Returns true if the event involves a cursor.
+    ///
+    /// These events interact with the hot state and
     pub fn is_pointer_event(&self) -> bool {
         matches!(
-            event,
-            Event::MouseDown(_) | Event::MouseUp(_) | Event::MouseMove(_)
+            self,
+            Event::MouseDown(_) | Event::MouseUp(_) | Event::MouseMove(_) | Event::Wheel(_)
         )
     }
 }

--- a/druid/src/widget/z_stack.rs
+++ b/druid/src/widget/z_stack.rs
@@ -98,7 +98,9 @@ impl<T: Data> Widget<T> for ZStack<T> {
                     ctx.set_handled();
                     layer.child.event(ctx, event, data, env);
                 } else {
-                    layer.child.event(ctx, &Event::Internal(InternalEvent::MouseLeave), data, env);
+                    layer
+                        .child
+                        .event(ctx, &Event::Internal(InternalEvent::MouseLeave), data, env);
                 }
             } else {
                 layer.child.event(ctx, event, data, env);

--- a/druid/src/widget/z_stack.rs
+++ b/druid/src/widget/z_stack.rs
@@ -1,7 +1,4 @@
-use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
-    Point, Rect, Size, UnitPoint, UpdateCtx, Vec2, Widget, WidgetExt, WidgetPod,
-};
+use crate::{BoxConstraints, Data, Env, Event, EventCtx, InternalEvent, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Point, Rect, Size, UnitPoint, UpdateCtx, Vec2, Widget, WidgetExt, WidgetPod};
 
 /// A container that stacks its children on top of each other.
 ///
@@ -94,17 +91,20 @@ impl<T: Data> ZStack<T> {
 
 impl<T: Data> Widget<T> for ZStack<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
-        let is_pointer_event = matches!(
-            event,
-            Event::MouseDown(_) | Event::MouseMove(_) | Event::MouseUp(_) | Event::Wheel(_)
-        );
-
+        let mut previous_hot = false;
         for layer in self.layers.iter_mut() {
-            layer.child.event(ctx, event, data, env);
-
-            if is_pointer_event && layer.child.is_hot() {
-                ctx.set_handled();
+            if event.is_pointer_event() && previous_hot {
+                if layer.child.is_active() {
+                    ctx.set_handled();
+                    layer.child.event(ctx, event, data, env);
+                } else {
+                    layer.child.event(ctx, &Event::Internal(InternalEvent::MouseLeave), data, env);
+                }
+            } else {
+                layer.child.event(ctx, event, data, env);
             }
+
+            previous_hot |= layer.child.is_hot();
         }
     }
 

--- a/druid/src/widget/z_stack.rs
+++ b/druid/src/widget/z_stack.rs
@@ -1,4 +1,7 @@
-use crate::{BoxConstraints, Data, Env, Event, EventCtx, InternalEvent, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Point, Rect, Size, UnitPoint, UpdateCtx, Vec2, Widget, WidgetExt, WidgetPod};
+use crate::{
+    BoxConstraints, Data, Env, Event, EventCtx, InternalEvent, LayoutCtx, LifeCycle, LifeCycleCtx,
+    PaintCtx, Point, Rect, Size, UnitPoint, UpdateCtx, Vec2, Widget, WidgetExt, WidgetPod,
+};
 
 /// A container that stacks its children on top of each other.
 ///


### PR DESCRIPTION
This PR makes it possible for a parent widget to use mouse events (for an example scrolling) while hovering over a `ZStack`.

TODOs:
- [x]  decide whether Event::Wheel is a follow up event when the widget is active.