### PR TITLE
Fix meta not being a modifier.

### DIFF
--- a/druid-shell/src/backend/gtk/window.rs
+++ b/druid-shell/src/backend/gtk/window.rs
@@ -1448,6 +1448,7 @@ const MODIFIER_MAP: &[(ModifierType, Modifiers)] = &[
     // Note: this is the usual value on X11, not sure how consistent it is.
     // Possibly we should use `Keymap::get_num_lock_state()` instead.
     (ModifierType::MOD2_MASK, Modifiers::NUM_LOCK),
+    (ModifierType::MOD4_MASK, Modifiers::META),
 ];
 
 fn get_modifiers(modifiers: ModifierType) -> Modifiers {


### PR DESCRIPTION
We added super -> meta for GTK in https://github.com/linebender/druid/pull/331, however we didn't convert the modifier state. This has left inconsistency for super key events from GTK which is converted to a regular meta key by us. This causes issues in lapce when super key is used as a modifier key, e.g: when adding a key binding for save by pressing `super + s`, only `s` is captured as shown below:
before this fix - press `super + s`:
![image](https://user-images.githubusercontent.com/1444104/204115768-66e9a9e6-5018-4f56-b549-ac1f6eb52bba.png)
after this fix - press `super + s`:
![image](https://user-images.githubusercontent.com/1444104/204115773-c42fc747-0ada-4260-aab4-b4bb8e980a72.png)

We can also see the issue in the example app [event_viewer](https://github.com/linebender/druid/blob/master/druid/examples/event_viewer.rs):
before this fix - press `ctrl` key:
![image](https://user-images.githubusercontent.com/1444104/204115973-f894f926-c182-464e-9ddd-b891a67a4558.png)

before this fix - press `super` key:
![image](https://user-images.githubusercontent.com/1444104/204115965-bf58a2f5-2a84-4918-a3c2-b1b07daba70c.png)

after this fix - press `super` key:
![image](https://user-images.githubusercontent.com/1444104/204115839-27292285-865e-484b-a581-33792535478e.png)
