### PR TITLE
Add xkbcommon path to build script.

### DIFF
--- a/druid-shell/build.rs
+++ b/druid-shell/build.rs
@@ -14,7 +14,7 @@ fn main() {
         return;
     }
 
-    probe_library("xkbcommon").unwrap();
+    let xkbcommon = probe_library("xkbcommon").unwrap();
 
     #[cfg(feature = "x11")]
     probe_library("xkbcommon-x11").unwrap();
@@ -34,6 +34,12 @@ fn main() {
         // The input header we would like to generate
         // bindings for.
         .header_contents("wrapper.h", &header)
+        .clang_args(
+            xkbcommon
+                .include_paths
+                .iter()
+                .filter_map(|path| path.to_str().map(|s| format!("-I{}", s))),
+        )
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
@@ -48,7 +54,6 @@ fn main() {
         // we use FILE from libc
         .blocklist_type("FILE")
         .blocklist_type("va_list")
-        .blocklist_type("_.*")
         .generate()
         .expect("Unable to generate bindings");
 

--- a/druid-shell/src/backend/shared/xkb/xkbcommon_sys.rs
+++ b/druid-shell/src/backend/shared/xkb/xkbcommon_sys.rs
@@ -1,4 +1,4 @@
-#![allow(unused, non_upper_case_globals, non_camel_case_types)]
+#![allow(unused, non_upper_case_globals, non_camel_case_types, non_snake_case)]
 // unknown lints to make compile on older rust versions
 #![cfg_attr(test, allow(unknown_lints, deref_nullptr))]
 // generated code has some redundant static lifetimes, I don't think we can change that.


### PR DESCRIPTION
This was suggested by @ngortheone in #2283. @Maan2003 do you know why we were blocklisting `_.*` before?