### PR TITLE
Relax the Piet dependencies to allow semver compatible updates.

### DIFF
--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -63,7 +63,7 @@ serde = ["kurbo/serde"]
 [dependencies]
 # NOTE: When changing the piet or kurbo versions, ensure that
 #       the kurbo version included in piet is compatible with the kurbo version specified here.
-piet-common = "=0.6.0"
+piet-common = "0.6.0"
 kurbo = "0.9"
 
 tracing = "0.1.22"
@@ -127,7 +127,7 @@ version = "0.3.44"
 features = ["Window", "MouseEvent", "CssStyleDeclaration", "WheelEvent", "KeyEvent", "KeyboardEvent", "Navigator"]
 
 [dev-dependencies]
-piet-common = { version = "=0.6.0", features = ["png"] }
+piet-common = { version = "0.6.0", features = ["png"] }
 static_assertions = "1.1.0"
 test-log = { version = "0.2.5", features = ["trace"], default-features = false }
 tracing-subscriber = { version = "0.3.2", features = ["env-filter"] }

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -82,7 +82,7 @@ console_error_panic_hook = { version = "0.1.6" }
 float-cmp = { version = "0.8.0", features = ["std"], default-features = false }
 # tempfile 3.2.0 broke wasm; I assume it will be yanked (Jan 12, 2021)
 tempfile = "=3.1.0"
-piet-common = { version = "=0.6.0", features = ["png"] }
+piet-common = { version = "0.6.0", features = ["png"] }
 pulldown-cmark = { version = "0.8", default-features = false }
 test-log = { version = "0.2.5", features = ["trace"], default-features = false }
 # test-env-log needs it


### PR DESCRIPTION
The previous strict dependency specification was because cargo was giving us unexpected versions when `0.5.0-pre1` type of versions were at play.

That isn't the case with the `0.6.0` line. Thus it makes sense to relax the specification, so that a potential `0.6.1` will reach Druid automatically.