### PR TITLE
Add a public constructor to StringCursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - Windows: Dark mode support for the title bar ([#2196] by [@dristic])
 - `ZStack` widget ([#2235] by [@xarvic])
 - `Lifecycle::ViewStateChanged`, `InternalLifecycle::RouteViewStateChanged`, `ChangeCtx`, and `RequestCtx` ([#2149] by [@xarvic])
+- Add a public constructor to `StringCursor` ([#2319] by [@benoitryder])
 
 ### Changed
 
@@ -570,6 +571,7 @@ Last release without a changelog :(
 [@barsae]: https://github.com/barsae
 [@amtep]: https://github.com/amtep
 [@ThomasMcandrew]: https:github.com/ThomasMcandrew
+[@benoitryder]: https://github.com/benoitryder
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611
@@ -871,6 +873,7 @@ Last release without a changelog :(
 [#2247]: https://github.com/linebender/druid/pull/2247
 [#2274]: https://github.com/linebender/druid/pull/2274
 [#2284]: https://github.com/linebender/druid/pull/2284
+[#2319]: https://github.com/linebender/druid/pull/2319
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid/src/text/editable_text.rs
+++ b/druid/src/text/editable_text.rs
@@ -278,6 +278,13 @@ pub struct StringCursor<'a> {
     position: usize,
 }
 
+impl<'a> StringCursor<'a> {
+    /// Create a new cursor.
+    pub fn new(text: &'a str) -> Self {
+        Self { text, position: 0 }
+    }
+}
+
 impl<'a> EditableTextCursor<&'a String> for StringCursor<'a> {
     fn set(&mut self, position: usize) {
         self.position = position;


### PR DESCRIPTION
`StringCursor` fields being private is the only thing preventing a user to define its own `EditableText`, unless it directly wraps an existing one.

As an exemple, with this patch it is possible to wrap a `RichText`, implement few traits, and use it in a `TextBox`.