### PR TITLE
Remove outdated documentation in LifeCycle events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - Fix `Controller` links for `Click` ([#2158] by [@yrns])
 - Delete inaccurate line for `KeyEvent` ([#2247] by [@amtep])
 - Added examples in `TextBox` ([#2284] by [@ThomasMcandrew])
+- Removed outdated section in docs for `LifeCycle::WidgetAdded` ([#2320] by [@sprocklem])
 
 ### Examples
 - Add readme ([#1423] by [@JAicewizard])
@@ -570,6 +571,7 @@ Last release without a changelog :(
 [@barsae]: https://github.com/barsae
 [@amtep]: https://github.com/amtep
 [@ThomasMcandrew]: https:github.com/ThomasMcandrew
+[@sprocklem]: https://github.com/sprocklem
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611
@@ -871,6 +873,7 @@ Last release without a changelog :(
 [#2247]: https://github.com/linebender/druid/pull/2247
 [#2274]: https://github.com/linebender/druid/pull/2274
 [#2284]: https://github.com/linebender/druid/pull/2284
+[#2320]: https://github.com/linebender/druid/pull/2320
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -249,14 +249,7 @@ pub enum LifeCycle {
     /// itself will handle registering those children with the system; this is
     /// required for things like correct routing of events.
     ///
-    /// ## Participating in focus
-    ///
-    /// Widgets which wish to participate in automatic focus (using tab to change
-    /// focus) must handle this event and call [`LifeCycleCtx::register_for_focus`].
-    ///
-    /// [`LifeCycleCtx::register_child`]: struct.LifeCycleCtx.html#method.register_child
     /// [`WidgetPod`]: struct.WidgetPod.html
-    /// [`LifeCycleCtx::register_for_focus`]: struct.LifeCycleCtx.html#method.register_for_focus
     WidgetAdded,
     /// Called when the [`Size`] of the widget changes.
     ///
@@ -287,7 +280,7 @@ pub enum LifeCycle {
     /// This is called when the widget-tree changes and druid wants to rebuild the
     /// Focus-chain.
     ///
-    /// It is the only place from witch [`register_for_focus`] should be called.
+    /// It is the only place from which [`register_for_focus`] should be called.
     /// By doing so the widget can get focused by other widgets using [`focus_next`] or [`focus_prev`].
     ///
     /// [`register_for_focus`]: crate::LifeCycleCtx::register_for_focus


### PR DESCRIPTION
The documentation previously included an outdated claim that users interested in automatic focus should call `register_for_focus()` in response to `LifeCycle::WidgetAdded`. This is no longer true since the addition of `LifeCycle::BuildFocusChain`, so the relevant section was deleted. Additionally, this commit fixes a minor spelling error in the documentation of the latter.

Fixes #2318 .