### PR TITLE
Add missing copyright headers.

### DIFF
--- a/druid-derive/tests/data.rs
+++ b/druid-derive/tests/data.rs
@@ -1,3 +1,17 @@
+// Copyright 2019 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Test #[derive(Data)]
 
 use druid::Data;

--- a/druid-derive/tests/ignore.rs
+++ b/druid-derive/tests/ignore.rs
@@ -1,3 +1,17 @@
+// Copyright 2019 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! testing the ignore attribute
 
 use druid::Data;

--- a/druid-derive/tests/lens_generic.rs
+++ b/druid-derive/tests/lens_generic.rs
@@ -1,3 +1,17 @@
+// Copyright 2020 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use druid::{Lens, LensExt};
 use std::fmt::Debug;
 use std::marker::PhantomData;

--- a/druid-derive/tests/ui.rs
+++ b/druid-derive/tests/ui.rs
@@ -1,3 +1,17 @@
+// Copyright 2021 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // https://github.com/dtolnay/trybuild
 // trybuild is a crate that essentially runs cargo on the provided files, and checks the output.
 // Tests may suddenly fail after a new compiler release, and there's not much we can do about that.

--- a/druid-derive/tests/with_lens.rs
+++ b/druid-derive/tests/with_lens.rs
@@ -1,3 +1,17 @@
+// Copyright 2020 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use float_cmp::approx_eq;
 
 use druid::Data;

--- a/druid-derive/tests/with_same.rs
+++ b/druid-derive/tests/with_same.rs
@@ -1,3 +1,17 @@
+// Copyright 2019 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use druid::Data;
 
 #[test]

--- a/druid-shell/build.rs
+++ b/druid-shell/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2021 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #[cfg(not(any(feature = "x11", feature = "wayland")))]
 fn main() {}
 

--- a/druid-shell/src/backend/shared/linux/env.rs
+++ b/druid-shell/src/backend/shared/linux/env.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub fn locale() -> String {
     fn locale_env_var(var: &str) -> Option<String> {
         match std::env::var(var) {

--- a/druid-shell/src/backend/shared/linux/mod.rs
+++ b/druid-shell/src/backend/shared/linux/mod.rs
@@ -1,2 +1,16 @@
+// Copyright 2022 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // environment based utilities
 pub mod env;

--- a/druid-shell/src/backend/shared/timer.rs
+++ b/druid-shell/src/backend/shared/timer.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::TimerToken;
 use std::{cmp::Ordering, time::Instant};
 

--- a/druid-shell/src/backend/shared/xkb/keycodes.rs
+++ b/druid-shell/src/backend/shared/xkb/keycodes.rs
@@ -1,3 +1,17 @@
+// Copyright 2020 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![allow(non_upper_case_globals)]
 
 use keyboard_types::Key;

--- a/druid-shell/src/backend/shared/xkb/xkbcommon_sys.rs
+++ b/druid-shell/src/backend/shared/xkb/xkbcommon_sys.rs
@@ -1,3 +1,17 @@
+// Copyright 2021 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![allow(unused, non_upper_case_globals, non_camel_case_types, non_snake_case)]
 // unknown lints to make compile on older rust versions
 #![cfg_attr(test, allow(unknown_lints, deref_nullptr))]

--- a/druid-shell/src/backend/wayland/display.rs
+++ b/druid-shell/src/backend/wayland/display.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![allow(clippy::single_match)]
 use super::error;
 use std::collections::BTreeMap;

--- a/druid-shell/src/backend/wayland/events.rs
+++ b/druid-shell/src/backend/wayland/events.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Multiplexing events.
 //!
 //! Calloop is a wrapper around `epoll` essentially allowing us to *select* multiple file

--- a/druid-shell/src/backend/wayland/keyboard.rs
+++ b/druid-shell/src/backend/wayland/keyboard.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::convert::TryInto;
 use wayland_client as wlc;
 use wayland_client::protocol::wl_keyboard;

--- a/druid-shell/src/backend/wayland/outputs/mod.rs
+++ b/druid-shell/src/backend/wayland/outputs/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use wayland_client as wlc;
 use wayland_client::protocol::wl_output;
 

--- a/druid-shell/src/backend/wayland/outputs/output.rs
+++ b/druid-shell/src/backend/wayland/outputs/output.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::super::display;
 use super::super::error;
 use super::super::outputs;

--- a/druid-shell/src/backend/wayland/pointers.rs
+++ b/druid-shell/src/backend/wayland/pointers.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::VecDeque;
 use wayland_client::protocol::wl_pointer;
 use wayland_client::protocol::wl_surface::{self, WlSurface};

--- a/druid-shell/src/backend/wayland/surfaces/buffers.rs
+++ b/druid-shell/src/backend/wayland/surfaces/buffers.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use kurbo::{Rect, Size};
 use nix::{
     errno::Errno,

--- a/druid-shell/src/backend/wayland/surfaces/idle.rs
+++ b/druid-shell/src/backend/wayland/surfaces/idle.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::common_util::IdleCallback;
 use crate::window;
 

--- a/druid-shell/src/backend/wayland/surfaces/layershell.rs
+++ b/druid-shell/src/backend/wayland/surfaces/layershell.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use wayland_client as wlc;
 use wayland_protocols::wlr::unstable::layer_shell::v1::client as layershell;
 use wayland_protocols::xdg_shell::client::xdg_surface;

--- a/druid-shell/src/backend/wayland/surfaces/mod.rs
+++ b/druid-shell/src/backend/wayland/surfaces/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use wayland_client::protocol::wl_shm::WlShm;
 use wayland_client::{self as wlc, protocol::wl_surface::WlSurface};
 use wayland_protocols::wlr::unstable::layer_shell::v1::client::zwlr_layer_shell_v1::ZwlrLayerShellV1;

--- a/druid-shell/src/backend/wayland/surfaces/popup.rs
+++ b/druid-shell/src/backend/wayland/surfaces/popup.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use wayland_client as wlc;
 use wayland_protocols::xdg_shell::client::xdg_popup;
 use wayland_protocols::xdg_shell::client::xdg_positioner;

--- a/druid-shell/src/backend/wayland/surfaces/surface.rs
+++ b/druid-shell/src/backend/wayland/surfaces/surface.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use wayland_client as wlc;

--- a/druid-shell/src/backend/wayland/surfaces/toplevel.rs
+++ b/druid-shell/src/backend/wayland/surfaces/toplevel.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use wayland_client as wlc;
 use wayland_protocols::xdg_shell::client::xdg_surface;
 use wayland_protocols::xdg_shell::client::xdg_toplevel;

--- a/druid-shell/src/backend/wayland/window.rs
+++ b/druid-shell/src/backend/wayland/window.rs
@@ -1,3 +1,4 @@
+// Copyright 2022 The Druid Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid-shell/src/backend/x11/dialog.rs
+++ b/druid-shell/src/backend/x11/dialog.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! This module contains functions for opening file dialogs using DBus.
 
 use ashpd::desktop::file_chooser;

--- a/druid-shell/src/region.rs
+++ b/druid-shell/src/region.rs
@@ -1,3 +1,17 @@
+// Copyright 2020 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use kurbo::{BezPath, Rect, Shape, Vec2};
 
 /// A union of rectangles, useful for describing an area that needs to be repainted.

--- a/druid/examples/sub_window.rs
+++ b/druid/examples/sub_window.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Example of sub windows.
+
 // On Windows platform, don't show a console when opening the app.
 #![windows_subsystem = "windows"]
 

--- a/druid/examples/switches.rs
+++ b/druid/examples/switches.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Example of switches
+
 // On Windows platform, don't show a console when opening the app.
 #![windows_subsystem = "windows"]
 

--- a/druid/examples/tabs.rs
+++ b/druid/examples/tabs.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Example of tabs
+
 // On Windows platform, don't show a console when opening the app.
 #![windows_subsystem = "windows"]
 

--- a/druid/examples/widget_gallery.rs
+++ b/druid/examples/widget_gallery.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! An example showcasing various widgets.
+
 // On Windows platform, don't show a console when opening the app.
 #![windows_subsystem = "windows"]
 

--- a/druid/src/debug_state.rs
+++ b/druid/src/debug_state.rs
@@ -1,3 +1,17 @@
+// Copyright 2021 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! A data structure for representing widget trees.
 
 use std::collections::HashMap;

--- a/druid/src/widget/intrinsic_width.rs
+++ b/druid/src/widget/intrinsic_width.rs
@@ -1,3 +1,19 @@
+// Copyright 2022 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A widget that sizes its child to the child's maximum intrinsic width.
+
 use crate::widget::Axis;
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Size,

--- a/druid/src/widget/scope.rs
+++ b/druid/src/widget/scope.rs
@@ -1,3 +1,17 @@
+// Copyright 2020 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::marker::PhantomData;
 
 use crate::widget::prelude::*;

--- a/druid/src/widget/widget_wrapper.rs
+++ b/druid/src/widget/widget_wrapper.rs
@@ -1,3 +1,17 @@
+// Copyright 2021 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /// A trait for widgets that wrap a single child to expose that child for access and mutation
 pub trait WidgetWrapper {
     /// The type of the wrapped widget.

--- a/druid/src/widget/z_stack.rs
+++ b/druid/src/widget/z_stack.rs
@@ -1,3 +1,19 @@
+// Copyright 2022 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A ZStack widget.
+
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, InternalEvent, LayoutCtx, LifeCycle, LifeCycleCtx,
     PaintCtx, Point, Rect, Size, UnitPoint, UpdateCtx, Vec2, Widget, WidgetExt, WidgetPod,


### PR DESCRIPTION
Over the years a bunch of source files have been introduced without the standard copyright header we use in most files. I went and added the missing header where needed, basing the year on the year the file was introduced in git history.