### PR TITLE
Update AnimFrame docs with info about when paint happens.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - Delete inaccurate line for `KeyEvent` ([#2247] by [@amtep])
 - Added examples in `TextBox` ([#2284] by [@ThomasMcandrew])
 - Removed outdated section in docs for `LifeCycle::WidgetAdded` ([#2320] by [@sprocklem])
+- Updated `Event::AnimFrame` docs with info about when `paint` happens. ([#2323] by [@xStrom])
 
 ### Examples
 - Add readme ([#1423] by [@JAicewizard])
@@ -875,6 +876,7 @@ Last release without a changelog :(
 [#2274]: https://github.com/linebender/druid/pull/2274
 [#2284]: https://github.com/linebender/druid/pull/2284
 [#2320]: https://github.com/linebender/druid/pull/2320
+[#2323]: https://github.com/linebender/druid/pull/2323
 [#2324]: https://github.com/linebender/druid/pull/2324
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master

--- a/druid-shell/src/screen.rs
+++ b/druid-shell/src/screen.rs
@@ -21,7 +21,7 @@ use std::fmt::Display;
 
 /// Monitor struct containing data about a monitor on the system
 ///
-/// Use Screen::get_monitors() to return a Vec<Monitor> of all the monitors on the system
+/// Use `Screen::get_monitors()` to return a `Vec<Monitor>` of all the monitors on the system
 #[derive(Clone, Debug, PartialEq)]
 pub struct Monitor {
     primary: bool,

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -578,7 +578,7 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
     ///
     /// Receiving [`AnimFrame`] does not inherently mean a `paint` invocation will follow.
     /// If you want something actually painted you need to explicitly call [`request_paint`]
-    /// or [`request_paint_rect`].
+    /// or [`request_paint_rect`] when handling the [`AnimFrame`] event.
     ///
     /// Note that not requesting paint when handling the [`AnimFrame`] event and then
     /// recursively requesting another [`AnimFrame`] will lead to rapid event fire,

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -580,7 +580,7 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
     /// If you want something actually painted you need to explicitly call [`request_paint`]
     /// or [`request_paint_rect`].
     ///
-    /// Note that not requesting paint when when handling the [`AnimFrame`] event and then
+    /// Note that not requesting paint when handling the [`AnimFrame`] event and then
     /// recursively requesting another [`AnimFrame`] will lead to rapid event fire,
     /// which is probably not what you want and would most likely be wasted compute cycles.
     ///

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -576,10 +576,13 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
 
     /// Request an [`AnimFrame`] event.
     ///
-    /// Note that if you call this when handling an [`AnimFrame`] event,
-    /// you should also call [`request_paint`] or [`request_paint_rect`] to ensure
-    /// an actual rendered frame. Otherwise you will end up with a lot of useless
-    /// animation frames for every actual frame.
+    /// Receiving [`AnimFrame`] does not inherently mean a `paint` invocation will follow.
+    /// If you want something actually painted you need to explicitly call [`request_paint`]
+    /// or [`request_paint_rect`].
+    ///
+    /// Note that not requesting paint when when handling the [`AnimFrame`] event and then
+    /// recursively requesting another [`AnimFrame`] will lead to rapid event fire,
+    /// which is probably not what you want and would most likely be wasted compute cycles.
     ///
     /// [`AnimFrame`]: crate::Event::AnimFrame
     /// [`request_paint`]: #method.request_paint

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -581,7 +581,7 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
     /// or [`request_paint_rect`] when handling the [`AnimFrame`] event.
     ///
     /// Note that not requesting paint when handling the [`AnimFrame`] event and then
-    /// recursively requesting another [`AnimFrame`] will lead to rapid event fire,
+    /// recursively requesting another [`AnimFrame`] can lead to rapid event fire,
     /// which is probably not what you want and would most likely be wasted compute cycles.
     ///
     /// [`AnimFrame`]: crate::Event::AnimFrame

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -574,7 +574,16 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
         self.widget_state.needs_layout = true;
     }
 
-    /// Request an animation frame.
+    /// Request an [`AnimFrame`] event.
+    ///
+    /// Note that if you call this when handling an [`AnimFrame`] event,
+    /// you should also call [`request_paint`] or [`request_paint_rect`] to ensure
+    /// an actual rendered frame. Otherwise you will end up with a lot of useless
+    /// animation frames for every actual frame.
+    ///
+    /// [`AnimFrame`]: crate::Event::AnimFrame
+    /// [`request_paint`]: #method.request_paint
+    /// [`request_paint_rect`]: #method.request_paint_rect
     pub fn request_anim_frame(&mut self) {
         trace!("request_anim_frame");
         self.widget_state.request_anim = true;

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -133,8 +133,8 @@ pub enum Event {
     /// will be 0. (This logic is presently per-window but might change to
     /// per-widget to make it more consistent). Otherwise it is in nanoseconds.
     ///
-    /// Note that receiving `AnimFrame` does not necessarily mean a rendered frame will follow.
-    /// If you want something actually rendered you need to explicitly call [`request_paint`]
+    /// Receiving `AnimFrame` does not inherently mean a `paint` invocation will follow.
+    /// If you want something actually painted you need to explicitly call [`request_paint`]
     /// or [`request_paint_rect`].
     ///
     /// If you do that, then the `paint` method will be called shortly after this event is finished.
@@ -142,8 +142,11 @@ pub enum Event {
     /// intensive in response to an `AnimFrame` event: it might make Druid miss
     /// the monitor's refresh, causing lag or jerky animation.
     ///
+    /// You can request an `AnimFrame` via [`request_anim_frame`].
+    ///
     /// [`request_paint`]: crate::EventCtx::request_paint
     /// [`request_paint_rect`]: crate::EventCtx::request_paint_rect
+    /// [`request_anim_frame`]: crate::EventCtx::request_anim_frame
     AnimFrame(u64),
     /// An event containing a [`Command`] to be handled by the widget.
     ///

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -133,10 +133,17 @@ pub enum Event {
     /// will be 0. (This logic is presently per-window but might change to
     /// per-widget to make it more consistent). Otherwise it is in nanoseconds.
     ///
-    /// The `paint` method will be called shortly after this event is finished.
+    /// Note that receiving `AnimFrame` does not necessarily mean a rendered frame will follow.
+    /// If you want something actually rendered you need to explicitly call [`request_paint`]
+    /// or [`request_paint_rect`].
+    ///
+    /// If you do that, then the `paint` method will be called shortly after this event is finished.
     /// As a result, you should try to avoid doing anything computationally
     /// intensive in response to an `AnimFrame` event: it might make Druid miss
     /// the monitor's refresh, causing lag or jerky animation.
+    ///
+    /// [`request_paint`]: crate::EventCtx::request_paint
+    /// [`request_paint_rect`]: crate::EventCtx::request_paint_rect
     AnimFrame(u64),
     /// An event containing a [`Command`] to be handled by the widget.
     ///

--- a/druid/src/widget/widget_wrapper.rs
+++ b/druid/src/widget/widget_wrapper.rs
@@ -15,8 +15,8 @@
 /// A trait for widgets that wrap a single child to expose that child for access and mutation
 pub trait WidgetWrapper {
     /// The type of the wrapped widget.
-    /// Maybe we would like to constrain this to Widget<impl Data> (if existential bounds were supported).
-    /// Any other scheme leads to T being unconstrained in unification at some point
+    /// Maybe we would like to constrain this to `Widget<impl Data>` (if existential bounds were supported).
+    /// Any other scheme leads to `T` being unconstrained in unification at some point
     type Wrapped;
     /// Get immutable access to the wrapped child
     fn wrapped(&self) -> &Self::Wrapped;


### PR DESCRIPTION
The `AnimFrame` docs were still from an era before we had partial invalidation. Nowadays an `AnimFrame` event does not necessarily lead to a `paint`, because `paint` is guarded by a check for invalid regions existing.

I also fixed a few rustdoc warnings around doc formating.