### PR TITLE
Properly handle mouse leave event on GTK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - Do not panic in Application::try_global if Application is not created ([#1996] by [@Maan2003])
 - X11: window focus events ([#1938] by [@Maan2003]
 - Preserve the aspect ratio of a clipped region in an Image ([#2195] by [@barsae])
+- GTK: Hot state now properly resets when the mouse leaves the window via an occluded part. ([#2324] by [@xStrom])
 
 ### Visual
 
@@ -874,6 +875,7 @@ Last release without a changelog :(
 [#2274]: https://github.com/linebender/druid/pull/2274
 [#2284]: https://github.com/linebender/druid/pull/2284
 [#2320]: https://github.com/linebender/druid/pull/2320
+[#2324]: https://github.com/linebender/druid/pull/2324
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid-shell/src/backend/gtk/window.rs
+++ b/druid-shell/src/backend/gtk/window.rs
@@ -642,21 +642,9 @@ impl WindowBuilder {
         );
 
         win_state.drawing_area.connect_leave_notify_event(
-            clone!(handle => move |_widget, crossing| {
+            clone!(handle => move |_widget, _crossing| {
                 if let Some(state) = handle.state.upgrade() {
-                    let scale = state.scale.get();
-                    let crossing_state = crossing.state();
-                    let mouse_event = MouseEvent {
-                        pos: Point::from(crossing.position()).to_dp(scale),
-                        buttons: get_mouse_buttons_from_modifiers(crossing_state),
-                        mods: get_modifiers(crossing_state),
-                        count: 0,
-                        focus: false,
-                        button: MouseButton::None,
-                        wheel_delta: Vec2::ZERO
-                    };
-
-                    state.with_handler(|h| h.mouse_move(&mouse_event));
+                    state.with_handler(|h| h.mouse_leave());
                 }
 
                 Inhibit(true)


### PR DESCRIPTION
This issue has been reported in #828, #852, and #927. The original GTK mouse leave implementationed added via #552 does not work when part of the window is occluded. For a simple reproduction with the `multiwin` example see the GIF in #927.

This PR properly wires up the `mouse_leave` event handler and thus fixes the issue.

Fixes #852