### PR TITLE
Update Rust edition to 2021.

### DIFF
--- a/docs/book_examples/Cargo.toml
+++ b/docs/book_examples/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "book_examples"
 version = "0.1.0"
+license = "Apache-2.0"
+repository = "https://github.com/linebender/druid"
 authors = ["Colin Rofls <colin@cmyr.net>"]
-edition = "2018"
+edition = "2021"
+publish = false
 
 [dependencies]
 druid = { path = "../../druid", features = [ "im" ] }

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -7,7 +7,7 @@ description = "Platform abstracting application shell used for druid toolkit."
 repository = "https://github.com/linebender/druid"
 readme = "README.md"
 categories = ["os::macos-apis", "os::windows-apis", "gui"]
-edition = "2018"
+edition = "2021"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/druid-shell/src/backend/web/window.rs
+++ b/druid-shell/src/backend/web/window.rs
@@ -601,7 +601,6 @@ impl WindowHandle {
     }
 
     pub fn request_timer(&self, deadline: Instant) -> TimerToken {
-        use std::convert::TryFrom;
         let interval = deadline.duration_since(Instant::now()).as_millis();
         let interval = match i32::try_from(interval) {
             Ok(iv) => iv,

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/linebender/druid"
 categories = ["gui"]
 readme = "README.md"
 keywords = ["gui", "ui", "toolkit"]
-edition = "2018"
+edition = "2021"
 
 [package.metadata.docs.rs]
 # The "svg" and "image" features have doc clashes that cause undefined output in docs.

--- a/druid/examples/hello_web/Cargo.toml
+++ b/druid/examples/hello_web/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 license = "Apache-2.0"
 description = "Minimal web example"
 repository = "https://github.com/linebender/druid"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/druid/examples/value_formatting/Cargo.toml
+++ b/druid/examples/value_formatting/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "value-formatting"
 version = "0.1.0"
+license = "Apache-2.0"
+repository = "https://github.com/linebender/druid"
 authors = ["Colin Rofls <colin@cmyr.net>"]
-edition = "2018"
+edition = "2021"
+publish = false
 
 [dependencies]
 druid = { path = "../../" }

--- a/druid/examples/web/Cargo.toml
+++ b/druid/examples/web/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 license = "Apache-2.0"
 description = "Scaffolding for druid web examples"
 repository = "https://github.com/linebender/druid"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]


### PR DESCRIPTION
It seems that we can rather easily upgrade to Rust 2021 and there is currently a direct benefit, so I think we should do it. Specifically clippy 1.67 (beta) is buggy with Rust 2018 as I found out in #2326. Upgrading to Rust 2021 will solve that issue for us.

---

There is an exception in `druid-derive` which will remain Rust 2018. We have macros that use syntax which is [no longer allowed in Rust 2021](https://doc.rust-lang.org/edition-guide/rust-2021/reserving-syntax.html).

> This is mostly relevant to macros. E.g. `quote!{ #a#b }` is no longer accepted.

```rust
quote! {
    #[doc = #struct_docs]
    #[allow(non_camel_case_types)]
    #[derive(Debug, Copy, Clone)]
    pub struct #field_name#lens_ty_generics(#(#phantom_decls),*); // <- Illegal in Rust 2021

    impl #lens_ty_generics #field_name#lens_ty_generics{ // <- Illegal in Rust 2021
        #[doc = #fn_docs]
        pub const fn new()->Self{
            Self(#(#phantom_inits),*)
        }
    }
}
```

As `druid-derive` doesn't have any `assert!` or `debug_assert!` usage that clippy complains about, staying at 2018 there isn't an issue for us right now.