### PR TITLE
Update dependencies

### DIFF
--- a/docs/book_examples/Cargo.toml
+++ b/docs/book_examples/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 druid = { path = "../../druid", features = [ "im" ] }
-im = { version = "15.0.0" }
+im = { version = "15.1.0" }

--- a/druid-derive/Cargo.toml
+++ b/druid-derive/Cargo.toml
@@ -15,9 +15,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 default-target = "x86_64-pc-windows-msvc"
 
 [dependencies]
-syn = "1.0.39"
-quote = "1.0.7"
-proc-macro2 = "1.0.19"
+syn = "1.0.107"
+quote = "1.0.23"
+proc-macro2 = "1.0.49"
 
 [dev-dependencies]
 druid = { version = "0.7.0", path = "../druid" }

--- a/druid-derive/Cargo.toml
+++ b/druid-derive/Cargo.toml
@@ -23,4 +23,4 @@ proc-macro2 = "1.0.49"
 druid = { version = "0.7.0", path = "../druid" }
 trybuild = "1.0"
 
-float-cmp = { version = "0.8.0", features = ["std"], default-features = false }
+float-cmp = { version = "0.9.0", features = ["std"], default-features = false }

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -135,4 +135,4 @@ unicode-segmentation = "1.10.0"
 
 [build-dependencies]
 bindgen = { version = "0.61.0", optional = true }
-pkg-config = { version = "0.3.0", optional = true }
+pkg-config = { version = "0.3.26", optional = true }

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -64,14 +64,14 @@ serde = ["kurbo/serde"]
 # NOTE: When changing the piet or kurbo versions, ensure that
 #       the kurbo version included in piet is compatible with the kurbo version specified here.
 piet-common = "0.6.0"
-kurbo = "0.9"
+kurbo = "0.9.0"
 
-tracing = "0.1.22"
-once_cell = "1.14.0"
-time = "0.3.0"
+tracing = "0.1.37"
+once_cell = "1.17.0"
+time = "0.3.17"
 cfg-if = "1.0.0"
-instant = { version = "0.1.6", features = ["wasm-bindgen"] }
-anyhow = "1.0.32"
+instant = { version = "0.1.12", features = ["wasm-bindgen"] }
+anyhow = "1.0.68"
 keyboard-types = { version = "0.6.2", default_features = false }
 
 # Optional dependencies
@@ -91,48 +91,48 @@ features = ["d2d1_1", "dwrite", "winbase", "libloaderapi", "errhandlingapi", "wi
 
 [target.'cfg(target_os="macos")'.dependencies]
 block = "0.1.6"
-cocoa = "0.24.0"
+cocoa = "0.24.1"
 objc = "0.2.7"
-core-graphics = "0.22.0"
+core-graphics = "0.22.3"
 foreign-types = "0.3.2"
-bitflags = "1.2.1"
+bitflags = "1.3.2"
 
 [target.'cfg(any(target_os = "freebsd", target_os="linux", target_os="openbsd"))'.dependencies]
-ashpd = { version = "0.3.0", optional = true }
+ashpd = { version = "0.3.2", optional = true }
 # TODO(x11/dependencies): only use feature "xcb" if using X11
 cairo-rs = { version = "0.16.3", default_features = false, features = ["xcb"] }
 cairo-sys-rs = { version = "0.16.3", default_features = false, optional = true }
-futures = { version = "0.3.21", optional = true, features = ["executor"]}
+futures = { version = "0.3.25", optional = true, features = ["executor"]}
 gdk-sys = { version = "0.16.0", optional = true }
 # `gtk` gets renamed to `gtk-rs` so that we can use `gtk` as the feature name.
-gtk-rs = { version = "0.16.1", package = "gtk", optional = true }
+gtk-rs = { version = "0.16.2", package = "gtk", optional = true }
 glib-sys = { version = "0.16.3", optional = true }
 gtk-sys = { version = "0.16.0", optional = true }
-nix = { version = "0.24.0", optional = true }
-x11rb = { version = "0.10", features = ["allow-unsafe-code", "present", "render", "randr", "xfixes", "xkb", "resource_manager", "cursor"], optional = true }
-wayland-client = { version = "0.29", optional = true }
-wayland-protocols = { version = "0.29", optional = true }
-wayland-cursor = { version = "0.29", optional = true }
-rand = { version = "0.8.0", optional = true }
-calloop = { version = "0.7.1", optional = true }
-log = { version = "0.4.14", optional = true }
-im = { version = "15.0.0", optional = true }
+nix = { version = "0.24.3", optional = true }
+x11rb = { version = "0.10.1", features = ["allow-unsafe-code", "present", "render", "randr", "xfixes", "xkb", "resource_manager", "cursor"], optional = true }
+wayland-client = { version = "0.29.5", optional = true }
+wayland-protocols = { version = "0.29.5", optional = true }
+wayland-cursor = { version = "0.29.5", optional = true }
+rand = { version = "0.8.5", optional = true }
+calloop = { version = "0.7.2", optional = true }
+log = { version = "0.4.17", optional = true }
+im = { version = "15.1.0", optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
-wasm-bindgen = "0.2.67"
-js-sys = "0.3.44"
+wasm-bindgen = "0.2.83"
+js-sys = "0.3.60"
 
 [target.'cfg(target_arch="wasm32")'.dependencies.web-sys]
-version = "0.3.44"
+version = "0.3.60"
 features = ["Window", "MouseEvent", "CssStyleDeclaration", "WheelEvent", "KeyEvent", "KeyboardEvent", "Navigator"]
 
 [dev-dependencies]
 piet-common = { version = "0.6.0", features = ["png"] }
 static_assertions = "1.1.0"
-test-log = { version = "0.2.5", features = ["trace"], default-features = false }
-tracing-subscriber = { version = "0.3.2", features = ["env-filter"] }
-unicode-segmentation = "1.7.0"
+test-log = { version = "0.2.11", features = ["trace"], default-features = false }
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+unicode-segmentation = "1.10.0"
 
 [build-dependencies]
-bindgen = { version = "0.61", optional = true }
-pkg-config = { version = "0.3", optional = true }
+bindgen = { version = "0.61.0", optional = true }
+pkg-config = { version = "0.3.0", optional = true }

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -78,7 +78,7 @@ tracing-wasm = { version = "0.2.1" }
 console_error_panic_hook = { version = "0.1.7" }
 
 [dev-dependencies]
-float-cmp = { version = "0.8.0", features = ["std"], default-features = false }
+float-cmp = { version = "0.9.0", features = ["std"], default-features = false }
 tempfile = "3.3.0"
 piet-common = { version = "0.6.0", features = ["png"] }
 pulldown-cmark = { version = "0.8.0", default-features = false }

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -57,38 +57,37 @@ image-all = ["image", "svg", "png", "jpeg", "jpeg_rayon", "gif", "bmp", "ico", "
 druid-shell = { version = "0.7.0", default-features = false, path = "../druid-shell" }
 druid-derive = { version = "0.4.0", path = "../druid-derive" }
 
-tracing = { version = "0.1.22" }
-tracing-subscriber = { version = "0.3.2", features = ["fmt", "ansi"], default-features = false }
-fluent-bundle = "0.15.1"
+tracing = { version = "0.1.37" }
+tracing-subscriber = { version = "0.3.16", features = ["fmt", "ansi"], default-features = false }
+fluent-bundle = "0.15.2"
 fluent-langneg = "0.13.0"
 fluent-syntax = "0.11.0"
-unic-langid = "0.9.0"
-unicode-segmentation = "1.6.0"
+unic-langid = "0.9.1"
+unicode-segmentation = "1.10.0"
 xi-unicode = "0.3.0"
 fnv = "1.0.7"
-instant = { version = "0.1.6", features = ["wasm-bindgen"] }
+instant = { version = "0.1.12", features = ["wasm-bindgen"] }
 
 # Optional dependencies
-chrono = { version = "0.4.19", optional = true }
-im = { version = "15.0.0", optional = true }
+chrono = { version = "0.4.23", optional = true }
+im = { version = "15.1.0", optional = true }
 usvg = { version = "0.14.1", optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
-tracing-wasm = { version = "0.2.0" }
-console_error_panic_hook = { version = "0.1.6" }
+tracing-wasm = { version = "0.2.1" }
+console_error_panic_hook = { version = "0.1.7" }
 
 [dev-dependencies]
 float-cmp = { version = "0.8.0", features = ["std"], default-features = false }
-# tempfile 3.2.0 broke wasm; I assume it will be yanked (Jan 12, 2021)
-tempfile = "=3.1.0"
+tempfile = "3.3.0"
 piet-common = { version = "0.6.0", features = ["png"] }
-pulldown-cmark = { version = "0.8", default-features = false }
-test-log = { version = "0.2.5", features = ["trace"], default-features = false }
+pulldown-cmark = { version = "0.8.0", default-features = false }
+test-log = { version = "0.2.11", features = ["trace"], default-features = false }
 # test-env-log needs it
-tracing-subscriber = { version = "0.3.2", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 
 [target.'cfg(not(target_arch="wasm32"))'.dev-dependencies]
-open = "1.6"
+open = "1.7.1"
 
 [[example]]
 name = "cursor"

--- a/druid/examples/hello_web/Cargo.toml
+++ b/druid/examples/hello_web/Cargo.toml
@@ -13,5 +13,5 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 druid = { path="../.." }
 
-wasm-bindgen = "0.2.67"
-console_error_panic_hook = "0.1.6"
+wasm-bindgen = "0.2.83"
+console_error_panic_hook = "0.1.7"

--- a/druid/examples/web/Cargo.toml
+++ b/druid/examples/web/Cargo.toml
@@ -12,11 +12,11 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 druid = { path="../..", features = ["im", "image", "png"] }
-tracing = "0.1.22"
-wasm-bindgen = "0.2.67"
-console_error_panic_hook = "0.1.6"
-log = "0.4.11"
-instant = { version = "0.1.6", features = ["wasm-bindgen"] }
+tracing = "0.1.37"
+wasm-bindgen = "0.2.83"
+console_error_panic_hook = "0.1.7"
+log = "0.4.17"
+instant = { version = "0.1.12", features = ["wasm-bindgen"] }
 
 [target.'cfg(not(target_arch="wasm32"))'.dependencies]
-simple_logger = { version = "1.9.0", default-features = false }
+simple_logger = { version = "1.16.0", default-features = false }


### PR DESCRIPTION
In preparation for the 0.8 release this PR updates the `Cargo.toml` dependency specifications to the latest semver compatible versions. The rationale for this can be found in [`CONTRIBUTING.md`](https://github.com/linebender/druid/blob/master/CONTRIBUTING.md#dependencies).

Additionally there is one semver incompatible update. The `float-cmp` crate got bumped from `0.8.0` to `0.9.0`. Unfortunately they don't have a changelog, but I checked the git diff and it's only a few commits. Most interesting was a macro fix, which previously could generate code that clippy would complain about. I didn't see any breaking changes.