### PR TITLE
Update repository documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # How to contribute
 
 **IMPORTANT:** The Druid project is being discontinued. While we will still accept
-all contributions, we'll prefer bugfixes and documentations improvements to new
+all contributions, we'll prefer bug fixes and documentation improvements to new
 features.
 
 If you still want to contribute, here are the guidelines you need to follow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,9 +38,9 @@ set -e
 echo "cargo fmt"
 cargo fmt --all -- --check
 echo "cargo clippy druid-shell"
-cargo clippy --manifest-path=druid-shell/Cargo.toml --all-targets -- -D warnings
+cargo clippy --manifest-path=druid-shell/Cargo.toml --all-targets --features=raw-win-handle -- -D warnings
 echo "cargo clippy druid"
-cargo clippy --manifest-path=druid/Cargo.toml --all-targets --features=svg,image,im -- -D warnings
+cargo clippy --manifest-path=druid/Cargo.toml --all-targets --features=svg,image,im,raw-win-handle -- -D warnings
 echo "cargo clippy druid (wasm)"
 cargo clippy --manifest-path=druid/Cargo.toml --all-targets --features=image,im --target wasm32-unknown-unknown -- -D warnings
 echo "cargo clippy druid-derive"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,34 +126,27 @@ old versions of our sub-dependencies and so we shouldn't claim that the old vers
 
 #### Prerequisites for updating the dependency specifications
 
-An easy way to do this is to use the `cargo upgrade` tool available via [cargo-edit].
+An easy way to do this is to use the `cargo upgrade` tool available via [`cargo-edit`].
 
 ```sh
 cargo install cargo-edit
 ```
 
+*Note that the following instructions were written for `cargo-edit` v0.11. If you have a newer
+major version there may have been changes to the way `cargo-edit` works.*
+
 #### Performing the update
 
-All of the following commands must be run from the root workspace.
-
-First we want to update our `Cargo.lock` file to contain the newest versions
-which are still [semver] compatible with what we have specified in our `Cargo.toml` files.
+We want to update our `Cargo.toml` files to specify the newest versions which are still
+[semver] compatible with what we have previously specified in our `Cargo.toml` files.
 
 If you just want to see what would happen you can add the `--dry-run` option.
 
 ```sh
-cargo update
+cargo upgrade
 ```
 
-Next we'll update all the versions in the `Cargo.toml` files to match the versions
-specified in `Cargo.lock`. We'll do this using the `--to-lockfile` option of `cargo upgrade`.
-It's crucial that we use `--to-lockfile` because without it `cargo upgrade` won't respect semver.
-
-If you just want to see what would happen you can add the `--dry-run` option.
-
-```sh
-cargo upgrade --workspace --to-lockfile
-```
+Running this command will update all the `Cargo.toml` files in the workspace and also `Cargo.lock`.
 
 #### Semver incompatible updates
 
@@ -161,7 +154,7 @@ Incompatible version updates should be done manually after carefully reviewing t
 However you can still use the `cargo upgrade` tool to find out which dependencies could be updated.
 
 ```sh
-cargo upgrade --workspace --dry-run
+cargo upgrade -i --dry-run
 ```
 
 Then based on the reported potential updates you should manually go and check out what has changed,
@@ -201,6 +194,6 @@ Finally, we [create a new Github release](https://docs.github.com/en/github/admi
 [GitHub Help]: https://help.github.com/articles/about-pull-requests/
 [AUTHORS]: AUTHORS
 [changelog]: CHANGELOG.md
-[cargo-edit]: https://github.com/killercup/cargo-edit
+[`cargo-edit`]: https://crates.io/crates/cargo-edit
 [semver]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html
 [git `pre-push` hook]: https://githooks.com

--- a/README.md
+++ b/README.md
@@ -13,16 +13,29 @@ performance, a rich palette of interactions (hence a widget library to support
 them), and playing well with the native platform.
 See the [goals section](#Goals) for more details.
 
-**IMPORTANT:** The Druid project is being discontinued. While we will still accept
-all contributions, we'll prefer bugfixes and documentations improvements to new
-features. Current development effort is focused on [Xilem](https://github.com/linebender/xilem).
-
 We have been doing periodic releases of Druid on crates.io, but the API is still unstable. All changes are documented
 in [the changelog](https://github.com/linebender/druid/blob/master/CHANGELOG.md).
 
 For an overview of some key concepts, see the (work in progress) [Druid book].
 
+## Project status
+
+**The Druid project is being discontinued by the core developer team.**
+
+New development effort is focused on [Xilem], which has a lot of fundamental changes to allow for
+a wider variety of applications with better performance, but it also heavily inherits from Druid.
+We see [Xilem] as the future of Druid.
+
+Druid is reasonably usable for [some subset of applications](https://github.com/linebender/druid/issues/1360)
+and has a significant testing history, which ensures some stability and correctness.
+However we don't expect any major new features to be added to Druid. As such we don't recommend
+using Druid for brand new applications. If you insist, then at least make sure your application
+doesn't require a feature that Druid doesn't have, e.g. accessibility or 3D support.
+
 ## Contributions
+
+As the Druid project is being discontinued, we will still accept all contributions,
+but we'll prefer bug fixes and documentation improvements to new features.
 
 A very good place to ask questions and discuss development work is our [Zulip
 chat instance], in the #druid-help and #druid channels, respectively.
@@ -324,3 +337,4 @@ active and friendly community.
 [Relm]: https://github.com/antoyo/relm
 [Moxie]: https://github.com/anp/moxie
 [Slint]: https://github.com/slint-ui/slint
+[Xilem]: https://github.com/linebender/xilem

--- a/docs/src/01_overview.md
+++ b/docs/src/01_overview.md
@@ -18,7 +18,7 @@ Druid works without special difficulty.
 
 ## Prerequisites
 
-This tutorial assumes basic familliarity with Rust and a working setup with the basic tooling like
+This tutorial assumes basic familiarity with Rust and a working setup with the basic tooling like
 Rustup and Cargo. This tutorial will use stable Rust (v1.65.0 at the time of writing) and the latest
 released version of Druid (v0.8).
 


### PR DESCRIPTION
This PR contains some minor word adjustments and the following:

* The `CONTRIBUTING.md` git hook was given the `raw-win-handle` feature.
* The dependency updating section of `CONTRIBUTING.md` was updated to reflect a newer version of `cargo-edit`.
    - It's no longer a case of `cargo update` followed by `cargo upgrade --workspace --to-lockfile` -- now our workflow is the default for the tool and can be done with just `cargo upgrade`. :tada:
* A new prominent project status section in `README.md` informing everyone that [Xilem](https://github.com/linebender/xilem) is the future and Druid is discontinued.
