### PR TITLE
Windows: file open dialog multiselect fix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,3 +23,4 @@ Manmeet Singh
 Simon Fell
 Nick Larsen
 Thomas McAndrew
+Paweł Pykało

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - X11: window focus events ([#1938] by [@Maan2003]
 - Preserve the aspect ratio of a clipped region in an Image ([#2195] by [@barsae])
 - GTK: Hot state now properly resets when the mouse leaves the window via an occluded part. ([#2324] by [@xStrom])
+- Windows: generate `commands::OPEN_FILES` when using multiselect in file open dialog. ([#2331] by [@ppykalo])
 
 ### Visual
 
@@ -576,6 +577,7 @@ Last release without a changelog :(
 [@ThomasMcandrew]: https:github.com/ThomasMcandrew
 [@benoitryder]: https://github.com/benoitryder
 [@sprocklem]: https://github.com/sprocklem
+[@ppykalo]: https://github.com/ppykalo
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611

--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -622,23 +622,38 @@ impl MyWndProc {
                     let info = unsafe {
                         get_file_dialog_path(hwnd, FileDialogType::Save, options)
                             .ok()
-                            .map(|os_str| FileInfo {
-                                path: os_str.into(),
+                            .map(|s| FileInfo {
+                                // TODO: check if `get_file_dialog_path` guarantees that save dialogs
+                                // only return on path
+                                path: s.first().unwrap().into(),
                                 format: None,
                             })
                     };
                     self.with_wnd_state(|s| s.handler.save_as(token, info));
                 }
                 DeferredOp::Open(options, token) => {
-                    let info = unsafe {
-                        get_file_dialog_path(hwnd, FileDialogType::Open, options)
-                            .ok()
-                            .map(|s| FileInfo {
-                                path: s.into(),
-                                format: None,
-                            })
+                    let multi_selection = options.multi_selection;
+                    let infos = unsafe {
+                        match get_file_dialog_path(hwnd, FileDialogType::Open, options) {
+                            Ok(infos) => infos
+                                .iter()
+                                .map(|path| FileInfo {
+                                    path: path.into(),
+                                    format: None,
+                                })
+                                .collect(),
+                            Err(err) => {
+                                tracing::error!("Error trying to open file: {}", err);
+                                vec![]
+                            }
+                        }
                     };
-                    self.with_wnd_state(|s| s.handler.open_file(token, info));
+
+                    if multi_selection {
+                        self.with_wnd_state(|s| s.handler.open_files(token,  infos));
+                    } else {
+                        self.with_wnd_state(|s| s.handler.open_file(token, infos.first().cloned()));
+                    }
                 }
                 DeferredOp::ContextMenu(menu, pos) => {
                     let hmenu = menu.into_hmenu();

--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -650,7 +650,7 @@ impl MyWndProc {
                     };
 
                     if multi_selection {
-                        self.with_wnd_state(|s| s.handler.open_files(token,  infos));
+                        self.with_wnd_state(|s| s.handler.open_files(token, infos));
                     } else {
                         self.with_wnd_state(|s| s.handler.open_file(token, infos.first().cloned()));
                     }

--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -623,7 +623,7 @@ impl MyWndProc {
                         get_file_dialog_path(hwnd, FileDialogType::Save, options)
                             .ok()
                             .map(|s| FileInfo {
-                                // TODO: check if `get_file_dialog_path` guarantees that save dialogs
+                                // `get_file_dialog_path` guarantees that save dialogs
                                 // only return on path
                                 path: s.first().unwrap().into(),
                                 format: None,


### PR DESCRIPTION
Using multi selection option for `SHOW_OPEN_PANEL` command on Windows correctly generates `commands::OPEN_FILES` now. Previously `commands::OPEN_PANEL_CANCELLED` was generated when more than one file was selected.