### PR TITLE
Increase crate versions in preparation for releasing v0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ fn ui_builder() -> impl Widget<u32> {
     Flex::column().with_child(label).with_child(button)
 }
 ```
-This example works with the `master` branch. Here's an example for 0.8.0: https://docs.rs/druid/0.8.0/druid/#examples
 
 Check out the [the examples folder] for a more comprehensive demonstration of
 Druid's existing functionality and widgets. Check [druid_widget_nursery](https://github.com/linebender/druid-widget-nursery) for more widgets.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ fn ui_builder() -> impl Widget<u32> {
     Flex::column().with_child(label).with_child(button)
 }
 ```
-This example works with master. Here's an example for 0.7.0: https://docs.rs/druid/latest/druid/#examples
+This example works with the `master` branch. Here's an example for 0.8.0: https://docs.rs/druid/0.8.0/druid/#examples
 
 Check out the [the examples folder] for a more comprehensive demonstration of
 Druid's existing functionality and widgets. Check [druid_widget_nursery](https://github.com/linebender/druid-widget-nursery) for more widgets.
@@ -90,7 +90,7 @@ a lone dependency (it re-exports all the parts of `druid-shell`, `piet`, and `ku
 that you'll need):
 
 ```toml
-druid = "0.7.0"
+druid = "0.8.0"
 ```
 
 Since Druid is currently in fast-evolving state, you might prefer to drink from
@@ -323,14 +323,14 @@ active and friendly community. See the AUTHORS file for more.
 [Zulip chat instance]: https://xi.zulipchat.com
 [non-`druid` examples]: /druid-shell/examples/shello.rs
 [crates.io]: https://crates.io/crates/druid
-[EventCtx]: https://docs.rs/druid/0.7.0/druid/struct.EventCtx.html
-[LifeCycleCtx]: https://docs.rs/druid/0.7.0/druid/struct.LifeCycleCtx.html
-[LayoutCtx]: https://docs.rs/druid/0.7.0/druid/struct.LayoutCtx.html
-[PaintCtx]: https://docs.rs/druid/0.7.0/druid/struct.PaintCtx.html
-[UpdateCtx]: https://docs.rs/druid/0.7.0/druid/struct.UpdateCtx.html
-[Widget trait]: https://docs.rs/druid/0.7.0/druid/trait.Widget.html
-[Data trait]: https://docs.rs/druid/0.7.0/druid/trait.Data.html
-[Lens datatype]: https://docs.rs/druid/0.7.0/druid/trait.Lens.html
+[EventCtx]: https://docs.rs/druid/0.8.0/druid/struct.EventCtx.html
+[LifeCycleCtx]: https://docs.rs/druid/0.8.0/druid/struct.LifeCycleCtx.html
+[LayoutCtx]: https://docs.rs/druid/0.8.0/druid/struct.LayoutCtx.html
+[PaintCtx]: https://docs.rs/druid/0.8.0/druid/struct.PaintCtx.html
+[UpdateCtx]: https://docs.rs/druid/0.8.0/druid/struct.UpdateCtx.html
+[Widget trait]: https://docs.rs/druid/0.8.0/druid/trait.Widget.html
+[Data trait]: https://docs.rs/druid/0.8.0/druid/trait.Data.html
+[Lens datatype]: https://docs.rs/druid/0.8.0/druid/trait.Lens.html
 [Druid book]: https://linebender.org/druid/
 [Iced]: https://github.com/hecrj/iced
 [Conrod]: https://github.com/PistonDevelopers/conrod

--- a/docs/src/08_widgets_in_depth.md
+++ b/docs/src/08_widgets_in_depth.md
@@ -66,10 +66,10 @@ textbox fire some action (say doing a search) 300ms after the last keypress:
 {{#include ../book_examples/src/custom_widgets_md.rs:annoying_textbox}}
 ```
 
-[`Controller`]: https://docs.rs/druid/0.7.0/druid/widget/trait.Controller.html
+[`Controller`]: https://docs.rs/druid/0.8.0/druid/widget/trait.Controller.html
 [`Widget`]: ./widget.md
-[`Painter`]: https://docs.rs/druid/0.7.0/druid/widget/struct.Painter.html
-[`SizedBox`]: https://docs.rs/druid/0.7.0/druid/widget/struct.SizedBox.html
-[`Container`]: https://docs.rs/druid/0.7.0/druid/widget/struct.Container.html
-[`WidgetExt`]: https://docs.rs/druid/0.7.0/druid/trait.WidgetExt.html
-[`background`]: https://docs.rs/druid/0.7.0/druid/trait.WidgetExt.html#background
+[`Painter`]: https://docs.rs/druid/0.8.0/druid/widget/struct.Painter.html
+[`SizedBox`]: https://docs.rs/druid/0.8.0/druid/widget/struct.SizedBox.html
+[`Container`]: https://docs.rs/druid/0.8.0/druid/widget/struct.Container.html
+[`WidgetExt`]: https://docs.rs/druid/0.8.0/druid/trait.WidgetExt.html
+[`background`]: https://docs.rs/druid/0.8.0/druid/trait.WidgetExt.html#background

--- a/druid-derive/Cargo.toml
+++ b/druid-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "druid-derive"
-version = "0.4.0"
+version = "0.5.0"
 license = "Apache-2.0"
 authors = ["Druid authors"]
 description = "derive impls for Druid, a Rust UI toolkit."
@@ -20,7 +20,7 @@ quote = "1.0.23"
 proc-macro2 = "1.0.50"
 
 [dev-dependencies]
-druid = { version = "0.7.0", path = "../druid" }
+druid = { version = "0.8.0", path = "../druid" }
 trybuild = "1.0"
 
 float-cmp = { version = "0.9.0", features = ["std"], default-features = false }

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "druid-shell"
-version = "0.7.0"
+version = "0.8.0"
 license = "Apache-2.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Platform abstracting application shell used for Druid toolkit."

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "druid"
-version = "0.7.0"
+version = "0.8.0"
 license = "Apache-2.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Data-oriented Rust UI design toolkit."
@@ -54,8 +54,8 @@ hdr = ["druid-shell/hdr"]
 image-all = ["image", "svg", "png", "jpeg", "jpeg_rayon", "gif", "bmp", "ico", "tiff", "webp", "pnm", "dds", "tga", "farbfeld", "dxt", "hdr"]
 
 [dependencies]
-druid-shell = { version = "0.7.0", default-features = false, path = "../druid-shell" }
-druid-derive = { version = "0.4.0", path = "../druid-derive" }
+druid-shell = { version = "0.8.0", default-features = false, path = "../druid-shell" }
+druid-derive = { version = "0.5.0", path = "../druid-derive" }
 
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.16", features = ["fmt", "ansi"], default-features = false }

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -125,7 +125,7 @@
 //! Features can be added with `cargo`. For example, in your `Cargo.toml`:
 //! ```no_compile
 //! [dependencies.druid]
-//! version = "0.7.0"
+//! version = "0.8.0"
 //! features = ["im", "svg", "image"]
 //! ```
 //!
@@ -142,7 +142,7 @@
 //! [`Event`]: enum.Event.html
 //! [`druid-shell`]: druid_shell
 //! [`piet`]: piet
-//! [`druid/examples`]: https://github.com/linebender/druid/tree/v0.7.0/druid/examples
+//! [`druid/examples`]: https://github.com/linebender/druid/tree/v0.8.0/druid/examples
 //! [Druid book]: https://linebender.org/druid/
 //! [`im` crate]: https://crates.io/crates/im
 //! [`im` module]: im/index.html


### PR DESCRIPTION
This is quite straightforward. I updated all the relevant links and bumped the versions of the following crates:

* `druid` from `0.7.0` to `0.8.0`
* `druid-shell` from `0.7.0` to `0.8.0`
* `druid-derive` from `0.4.0` to `0.5.0`