### PR TITLE
Fix documentation links.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@ You can find its changes [documented below](#070---2021-01-01).
 
 ### Docs
 
+- Fixed all the broken links that originated from Druid crates. ([#2338] by [@xStrom])
 - Fixed docs of derived Lens ([#1523] by [@Maan2003])
 - Fixed docs describing `ViewSwitcher` widget functionality ([#1693] by [@arthmis])
 - Added missing documentation on derived lens items ([#1696] by [@lidin])
@@ -892,6 +893,7 @@ Last release without a changelog :(
 [#2324]: https://github.com/linebender/druid/pull/2324
 [#2331]: https://github.com/linebender/druid/pull/2331
 [#2335]: https://github.com/linebender/druid/pull/2335
+[#2338]: https://github.com/linebender/druid/pull/2338
 [#2340]: https://github.com/linebender/druid/pull/2340
 [#2343]: https://github.com/linebender/druid/pull/2343
 

--- a/druid-shell/src/clipboard.rs
+++ b/druid-shell/src/clipboard.rs
@@ -17,7 +17,7 @@ pub use crate::backend::clipboard as backend;
 
 /// A handle to the system clipboard.
 ///
-/// To get access to the global clipboard, call [`Application::clipboard()`].
+/// To get access to the global clipboard, call [`Application::clipboard`].
 ///
 ///
 /// # Working with text
@@ -118,13 +118,9 @@ pub use crate::backend::clipboard as backend;
 /// # fn do_something_with_data(_: &str, _: Vec<u8>) {}
 /// ```
 ///
-/// [`Application::clipboard()`]: struct.Application.html#method.clipboard
-/// [`Clipboard::put_string`]: struct.Clipboard.html#method.put_string
-/// [`Clipboard::get_string`]: struct.Clipboard.html#method.get_string
-/// [`FormatId`]: type.FormatId.html
+/// [`Application::clipboard`]: crate::Application::clipboard
 /// [`Universal Type Identifier`]: https://escapetech.eu/manuals/qdrop/uti.html
 /// [MIME types]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
-/// [`ClipboardFormat`]: struct.ClipboardFormat.html
 #[derive(Debug, Clone)]
 pub struct Clipboard(pub(crate) backend::Clipboard);
 

--- a/druid-shell/src/dialog.rs
+++ b/druid-shell/src/dialog.rs
@@ -126,20 +126,11 @@ pub enum FileDialogType {
 /// and then clicks on an existing file `/Users/Joe/old.txt` in another directory then the returned
 /// path will actually be `/Users/Joe/foo/old.rtf` if the default type's first extension is `rtf`.
 ///
-/// ## Have a really good save dialog default type
-///
-/// There is no way for the user to choose which extension they want to save a file as via the UI.
-/// They have no way of knowing which extensions are even supported and must manually type it out.
-///
-/// *Hopefully it's a temporary problem and we can find a way to show the file formats in the UI.
-/// This is being tracked in [druid#998].*
-///
 /// [clickable]: #selecting-files-for-overwriting-in-the-save-dialog-is-cumbersome
 /// [packages]: #packages
 /// [`select_directories`]: #method.select_directories
 /// [`allowed_types`]: #method.allowed_types
 /// [`packages_as_directories`]: #method.packages_as_directories
-/// [druid#998]: https://github.com/xi-editor/druid/issues/998
 #[derive(Debug, Clone, Default)]
 pub struct FileDialogOptions {
     pub(crate) show_hidden: bool,

--- a/druid-shell/src/menu.rs
+++ b/druid-shell/src/menu.rs
@@ -54,7 +54,7 @@ impl Menu {
     /// Add an item to this menu.
     ///
     /// The `id` should uniquely identify this item. If the user selects this
-    /// item, the responsible [`WindowHandler`]'s [`command()`] method will
+    /// item, the responsible [`WinHandler`]'s [`command`] method will
     /// be called with this `id`. If the `enabled` argument is false, the menu
     /// item will be grayed out; the hotkey will also be disabled.
     /// If the `selected` argument is `true`, the menu will have a checkmark
@@ -63,9 +63,8 @@ impl Menu {
     /// with the system.
     ///
     ///
-    /// [`WindowHandler`]: trait.WindowHandler.html
-    /// [`command()`]: trait.WindowHandler.html#tymethod.command
-    /// [`HotKey`]: struct.HotKey.html
+    /// [`WinHandler`]: crate::WinHandler
+    /// [`command`]: crate::WinHandler::command
     pub fn add_item(
         &mut self,
         id: u32,

--- a/druid-shell/src/mouse.rs
+++ b/druid-shell/src/mouse.rs
@@ -27,7 +27,7 @@ use crate::Modifiers;
 pub struct MouseEvent {
     /// The location of the mouse in [display points] in relation to the current window.
     ///
-    /// [display points]: struct.Scale.html
+    /// [display points]: crate::Scale
     pub pos: Point,
     /// Mouse buttons being held down during a move or after a click event.
     /// Thus it will contain the `button` that triggered a mouse-down event,
@@ -118,8 +118,6 @@ impl MouseButton {
 }
 
 /// A set of [`MouseButton`]s.
-///
-/// [`MouseButton`]: enum.MouseButton.html
 #[derive(PartialEq, Eq, Clone, Copy, Default)]
 pub struct MouseButtons(u8);
 

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -113,9 +113,6 @@ impl<T: Data> PendingWindow<T> {
     /// Set the title for this window. This is a [`LabelText`]; it can be either
     /// a `String`, a [`LocalizedString`], or a closure that computes a string;
     /// it will be kept up to date as the application's state changes.
-    ///
-    /// [`LabelText`]: widget/enum.LocalizedString.html
-    /// [`LocalizedString`]: struct.LocalizedString.html
     pub fn title(mut self, title: impl Into<LabelText<T>>) -> Self {
         self.title = title.into();
         self
@@ -163,8 +160,6 @@ impl<T: Data> AppLauncher<T> {
     }
 
     /// Set the [`AppDelegate`].
-    ///
-    /// [`AppDelegate`]: trait.AppDelegate.html
     pub fn delegate(mut self, delegate: impl AppDelegate<T> + 'static) -> Self {
         self.delegate = Some(Box::new(delegate));
         self
@@ -246,8 +241,6 @@ impl<T: Data> AppLauncher<T> {
 
     /// Returns an [`ExtEventSink`] that can be moved between threads,
     /// and can be used to submit commands back to the application.
-    ///
-    /// [`ExtEventSink`]: struct.ExtEventSink.html
     pub fn get_external_handle(&self) -> ExtEventSink {
         self.ext_event_host.make_sink()
     }
@@ -333,8 +326,8 @@ impl WindowConfig {
     /// This should be considered a request to the platform to set the size of the window.
     /// The platform might increase the size a tiny bit due to DPI.
     ///
-    /// [`Size`]: struct.Size.html
-    /// [display points]: struct.Scale.html
+    /// [`Size`]: Size
+    /// [display points]: crate::Scale
     pub fn window_size(mut self, size: impl Into<Size>) -> Self {
         self.size = Some(size.into());
         self
@@ -350,7 +343,7 @@ impl WindowConfig {
     /// To set the window's initial drawing area size use [`window_size`].
     ///
     /// [`window_size`]: #method.window_size
-    /// [display points]: struct.Scale.html
+    /// [display points]: crate::Scale
     pub fn with_min_size(mut self, size: impl Into<Size>) -> Self {
         self.min_size = Some(size.into());
         self
@@ -371,23 +364,19 @@ impl WindowConfig {
     /// Sets the window position in virtual screen coordinates.
     /// [`position`] Position in pixels.
     ///
-    /// [`position`]: struct.Point.html
+    /// [`position`]: Point
     pub fn set_position(mut self, position: Point) -> Self {
         self.position = Some(position);
         self
     }
 
     /// Sets the [`WindowLevel`] of the window
-    ///
-    /// [`WindowLevel`]: enum.WindowLevel.html
     pub fn set_level(mut self, level: WindowLevel) -> Self {
         self.level = Some(level);
         self
     }
 
     /// Sets the [`WindowState`] of the window.
-    ///
-    /// [`WindowState`]: enum.WindowState.html
     pub fn set_window_state(mut self, state: WindowState) -> Self {
         self.state = Some(state);
         self
@@ -469,8 +458,6 @@ impl WindowConfig {
 
 impl<T: Data> WindowDesc<T> {
     /// Create a new `WindowDesc`, taking the root [`Widget`] for this window.
-    ///
-    /// [`Widget`]: trait.Widget.html
     pub fn new<W>(root: W) -> WindowDesc<T>
     where
         W: Widget<T> + 'static,
@@ -487,9 +474,6 @@ impl<T: Data> WindowDesc<T> {
     /// it will be kept up to date as the application's state changes.
     ///
     /// If this method isn't called, the default title will be `LocalizedString::new("app-name")`.
-    ///
-    /// [`LabelText`]: widget/enum.LocalizedString.html
-    /// [`LocalizedString`]: struct.LocalizedString.html
     pub fn title(mut self, title: impl Into<LabelText<T>>) -> Self {
         self.pending = self.pending.title(title);
         self
@@ -537,8 +521,7 @@ impl<T: Data> WindowDesc<T> {
     /// This should be considered a request to the platform to set the size of the window.
     /// The platform might increase the size a tiny bit due to DPI.
     ///
-    /// [`Size`]: struct.Size.html
-    /// [display points]: struct.Scale.html
+    /// [display points]: crate::Scale
     pub fn window_size(mut self, size: impl Into<Size>) -> Self {
         self.config.size = Some(size.into());
         self
@@ -554,7 +537,7 @@ impl<T: Data> WindowDesc<T> {
     /// To set the window's initial drawing area size use [`window_size`].
     ///
     /// [`window_size`]: #method.window_size
-    /// [display points]: struct.Scale.html
+    /// [display points]: crate::Scale
     pub fn with_min_size(mut self, size: impl Into<Size>) -> Self {
         self.config = self.config.with_min_size(size);
         self
@@ -592,7 +575,7 @@ impl<T: Data> WindowDesc<T> {
 
     /// Sets the [`WindowLevel`] of the window
     ///
-    /// [`WindowLevel`]: enum.WindowLevel.html
+    /// [`WindowLevel`]: WindowLevel
     pub fn set_level(mut self, level: WindowLevel) -> Self {
         self.config = self.config.set_level(level);
         self

--- a/druid/src/app_delegate.rs
+++ b/druid/src/app_delegate.rs
@@ -22,8 +22,6 @@ use crate::{
 };
 
 /// A context passed in to [`AppDelegate`] functions.
-///
-/// [`AppDelegate`]: trait.AppDelegate.html
 pub struct DelegateCtx<'a> {
     pub(crate) command_queue: &'a mut CommandQueue,
     pub(crate) ext_event_host: &'a ExtEventHost,
@@ -35,12 +33,11 @@ impl<'a> DelegateCtx<'a> {
     ///
     /// Commands are run in the order they are submitted; all commands
     /// submitted during the handling of an event are executed before
-    /// the [`update()`] method is called.
+    /// the [`update`] method is called.
     ///
     /// [`Target::Auto`] commands will be sent to every window (`Target::Global`).
     ///
-    /// [`Command`]: struct.Command.html
-    /// [`update()`]: trait.Widget.html#tymethod.update
+    /// [`update`]: crate::Widget::update
     pub fn submit_command(&mut self, command: impl Into<Command>) {
         self.command_queue
             .push_back(command.into().default_to(Target::Global))
@@ -48,8 +45,6 @@ impl<'a> DelegateCtx<'a> {
 
     /// Returns an [`ExtEventSink`] that can be moved between threads,
     /// and can be used to submit commands back to the application.
-    ///
-    /// [`ExtEventSink`]: struct.ExtEventSink.html
     pub fn get_external_handle(&self) -> ExtEventSink {
         self.ext_event_host.make_sink()
     }
@@ -57,7 +52,7 @@ impl<'a> DelegateCtx<'a> {
     /// Create a new window.
     /// `T` must be the application's root `Data` type (the type provided to [`AppLauncher::launch`]).
     ///
-    /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
+    /// [`AppLauncher::launch`]: crate::AppLauncher::launch
     pub fn new_window<T: Any>(&mut self, desc: WindowDesc<T>) {
         if self.app_data_type == TypeId::of::<T>() {
             self.submit_command(
@@ -86,9 +81,9 @@ pub trait AppDelegate<T: Data> {
     ///
     /// The return value of this function will be passed down the tree. This can
     /// be the event that was passed in, a different event, or no event. In all cases,
-    /// the [`update()`] method will be called as usual.
+    /// the [`update`] method will be called as usual.
     ///
-    /// [`update()`]: trait.Widget.html#tymethod.update
+    /// [`update`]: crate::Widget::update
     fn event(
         &mut self,
         ctx: &mut DelegateCtx,
@@ -111,9 +106,7 @@ pub trait AppDelegate<T: Data> {
     /// To do anything fancier than this, you can submit arbitrary commands
     /// via [`DelegateCtx::submit_command`].
     ///
-    /// [`Target`]: enum.Target.html
-    /// [`Command`]: struct.Command.html
-    /// [`DelegateCtx::submit_command`]: struct.DelegateCtx.html#method.submit_command
+    /// [`DelegateCtx::submit_command`]: DelegateCtx::submit_command
     fn command(
         &mut self,
         ctx: &mut DelegateCtx,

--- a/druid/src/box_constraints.rs
+++ b/druid/src/box_constraints.rs
@@ -32,9 +32,9 @@ use crate::widget::Axis;
 /// The constraints are always [rounded away from zero] to integers
 /// to enable pixel perfect layout.
 ///
-/// [`layout`]: trait.Widget.html#tymethod.layout
+/// [`layout`]: crate::Widget::layout
 /// [Flutter BoxConstraints]: https://api.flutter.dev/flutter/rendering/BoxConstraints-class.html
-/// [rounded away from zero]: struct.Size.html#method.expand
+/// [rounded away from zero]: Size::expand
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BoxConstraints {
     min: Size,
@@ -57,7 +57,7 @@ impl BoxConstraints {
     /// The given sizes are also [rounded away from zero],
     /// so that the layout is aligned to integers.
     ///
-    /// [rounded away from zero]: struct.Size.html#method.expand
+    /// [rounded away from zero]: Size::expand
     pub fn new(min: Size, max: Size) -> BoxConstraints {
         BoxConstraints {
             min: min.expand(),
@@ -72,7 +72,7 @@ impl BoxConstraints {
     /// The given size is also [rounded away from zero],
     /// so that the layout is aligned to integers.
     ///
-    /// [rounded away from zero]: struct.Size.html#method.expand
+    /// [rounded away from zero]: Size::expand
     pub fn tight(size: Size) -> BoxConstraints {
         let size = size.expand();
         BoxConstraints {
@@ -96,7 +96,7 @@ impl BoxConstraints {
     /// The given size is also [rounded away from zero],
     /// so that the layout is aligned to integers.
     ///
-    /// [rounded away from zero]: struct.Size.html#method.expand
+    /// [rounded away from zero]: Size::expand
     pub fn constrain(&self, size: impl Into<Size>) -> Size {
         size.into().expand().clamp(self.min, self.max)
     }
@@ -150,7 +150,7 @@ impl BoxConstraints {
     /// The given size is also [rounded away from zero],
     /// so that the layout is aligned to integers.
     ///
-    /// [rounded away from zero]: struct.Size.html#method.expand
+    /// [rounded away from zero]: Size::expand
     pub fn shrink(&self, diff: impl Into<Size>) -> BoxConstraints {
         let diff = diff.into().expand();
         let min = Size::new(

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -42,7 +42,6 @@ pub(crate) type SelectorSymbol = &'static str;
 /// [`Command`]: struct.Command.html
 /// [`Command::get`]: struct.Command.html#method.get
 /// [`get_unchecked`]: struct.Command.html#method.get_unchecked
-/// [`druid::commands`]: commands/index.html
 #[derive(Debug, PartialEq, Eq)]
 pub struct Selector<T = ()>(SelectorSymbol, PhantomData<T>);
 
@@ -71,9 +70,7 @@ pub struct Selector<T = ()>(SelectorSymbol, PhantomData<T>);
 /// assert_eq!(command.get(selector), Some(&vec![1, 3, 10, 12]));
 /// ```
 ///
-/// [`EventCtx::new_window`]: struct.EventCtx.html#method.new_window
-/// [`SingleUse`]: struct.SingleUse.html
-/// [`Selector`]: struct.Selector.html
+/// [`EventCtx::new_window`]: crate::EventCtx::new_window
 #[derive(Debug, Clone)]
 pub struct Command {
     symbol: SelectorSymbol,
@@ -131,13 +128,9 @@ pub struct Notification {
 /// // subsequent calls will return `None`
 /// assert!(payload.take().is_none());
 /// ```
-///
-/// [`Command`]: struct.Command.html
 pub struct SingleUse<T>(Mutex<Option<T>>);
 
 /// The target of a [`Command`].
-///
-/// [`Command`]: struct.Command.html
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Target {
     /// The target is the top-level application.
@@ -171,8 +164,6 @@ pub enum Target {
 /// Commands with special meaning, defined by druid.
 ///
 /// See [`Command`] for more info.
-///
-/// [`Command`]: ../struct.Command.html
 pub mod sys {
     use std::any::Any;
 
@@ -227,7 +218,7 @@ pub mod sys {
     /// Display a context (right-click) menu. The payload must be the [`ContextMenu`]
     /// object to be displayed.
     ///
-    /// [`ContextMenu`]: ../struct.ContextMenu.html
+    /// [`ContextMenu`]: crate::menu::ContextMenu
     pub(crate) const SHOW_CONTEXT_MENU: Selector<SingleUse<Box<dyn Any>>> =
         Selector::new("druid-builtin.show-context-menu");
 

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -96,9 +96,9 @@ pub struct EventCtx<'a, 'b> {
 /// specific lifecycle events; for instance [`register_child`]
 /// should only be called while handling [`LifeCycle::WidgetAdded`].
 ///
-/// [`lifecycle`]: trait.Widget.html#tymethod.lifecycle
+/// [`lifecycle`]: Widget::lifecycle
 /// [`register_child`]: #method.register_child
-/// [`LifeCycle::WidgetAdded`]: enum.LifeCycle.html#variant.WidgetAdded
+/// [`LifeCycle::WidgetAdded`]: crate::LifeCycle::WidgetAdded
 pub struct LifeCycleCtx<'a, 'b> {
     pub(crate) state: &'a mut ContextState<'b>,
     pub(crate) widget_state: &'a mut WidgetState,
@@ -165,8 +165,6 @@ pub struct State<'a> {
 ///
 /// Methods that deal with commands and timers.
 /// Available to all contexts but [`PaintCtx`].
-///
-/// [`PaintCtx`](PaintCtx)
 pub trait ChangeCtx {
     /// Submit a [`Command`] to be run after this event is handled. See [`submit_command`].
     ///
@@ -374,7 +372,7 @@ impl_context_method!(
         /// Generally it will be the same as the size returned by the child widget's
         /// [`layout`] method.
         ///
-        /// [`layout`]: trait.Widget.html#tymethod.layout
+        /// [`layout`]: Widget::layout
         pub fn size(&self) -> Size {
             self.widget_state.size()
         }
@@ -404,16 +402,18 @@ impl_context_method!(
 
         /// Query the "hot" state of the widget.
         ///
-        /// See [`WidgetPod::is_hot`](struct.WidgetPod.html#method.is_hot) for
-        /// additional information.
+        /// See [`WidgetPod::is_hot`] for additional information.
+        ///
+        /// [`WidgetPod::is_hot`]: crate::WidgetPod::is_hot
         pub fn is_hot(&self) -> bool {
             self.widget_state.is_hot
         }
 
         /// Query the "active" state of the widget.
         ///
-        /// See [`WidgetPod::is_active`](struct.WidgetPod.html#method.is_active) for
-        /// additional information.
+        /// See [`WidgetPod::is_active`] for additional information.
+        ///
+        /// [`WidgetPod::is_active`]: crate::WidgetPod::is_active
         pub fn is_active(&self) -> bool {
             self.widget_state.is_active
         }
@@ -433,9 +433,9 @@ impl_context_method!(
         /// Only one widget at a time is focused. However due to the way events are routed,
         /// all ancestors of that widget will also receive keyboard events.
         ///
-        /// [`request_focus`]: struct.EventCtx.html#method.request_focus
-        /// [`register_for_focus`]: struct.LifeCycleCtx.html#method.register_for_focus
-        /// [`LifeCycle::FocusChanged`]: enum.LifeCycle.html#variant.FocusChanged
+        /// [`request_focus`]: EventCtx::request_focus
+        /// [`register_for_focus`]: LifeCycleCtx::register_for_focus
+        /// [`LifeCycle::FocusChanged`]: crate::LifeCycle::FocusChanged
         /// [`has_focus`]: #method.has_focus
         pub fn is_focused(&self) -> bool {
             self.state.focus_widget == Some(self.widget_id())
@@ -536,9 +536,9 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
     /// Request a [`paint`] pass. This is equivalent to calling
     /// [`request_paint_rect`] for the widget's [`paint_rect`].
     ///
-    /// [`paint`]: trait.Widget.html#tymethod.paint
+    /// [`paint`]: Widget::paint
     /// [`request_paint_rect`]: #method.request_paint_rect
-    /// [`paint_rect`]: struct.WidgetPod.html#method.paint_rect
+    /// [`paint_rect`]: crate::WidgetPod::paint_rect
     pub fn request_paint(&mut self) {
         trace!("request_paint");
         self.widget_state.invalid.set_rect(
@@ -549,7 +549,7 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
     /// Request a [`paint`] pass for redrawing a rectangle, which is given
     /// relative to our layout rectangle.
     ///
-    /// [`paint`]: trait.Widget.html#tymethod.paint
+    /// [`paint`]: Widget::paint
     pub fn request_paint_rect(&mut self, rect: Rect) {
         trace!("request_paint_rect {}", rect);
         self.widget_state.invalid.add_rect(rect);
@@ -564,7 +564,7 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
     /// (such as if it would like to change the layout of children in
     /// response to some event) it must call this method.
     ///
-    /// [`layout`]: trait.Widget.html#tymethod.layout
+    /// [`layout`]: Widget::layout
     pub fn request_layout(&mut self) {
         trace!("request_layout");
         self.widget_state.needs_layout = true;
@@ -608,7 +608,7 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
     ///
     /// Calling this method during [`LifeCycle::DisabledChanged`] has no effect.
     ///
-    /// [`LifeCycle::DisabledChanged`]: struct.LifeCycle.html#variant.DisabledChanged
+    /// [`LifeCycle::DisabledChanged`]: crate::LifeCycle::DisabledChanged
     /// [`is_disabled`]: EventCtx::is_disabled
     pub fn set_disabled(&mut self, disabled: bool) {
         // widget_state.children_disabled_changed is not set because we want to be able to delete
@@ -638,7 +638,7 @@ impl_context_method!(EventCtx<'_, '_>, UpdateCtx<'_, '_>, LifeCycleCtx<'_, '_>, 
     /// 'U' must be the type of the nearest surrounding [`WidgetPod`]. The 'data' argument should be
     /// the current value of data  for that widget.
     ///
-    /// [`WidgetPod`]: struct.WidgetPod.html
+    /// [`WidgetPod`]: crate::WidgetPod
     // TODO - dynamically check that the type of the pod we are registering this on is the same as the type of the
     // requirement. Needs type ids recorded. This goes wrong if you don't have a pod between you and a lens.
     pub fn new_sub_window<W: Widget<U> + 'static, U: Data>(
@@ -691,8 +691,7 @@ impl_context_method!(
         ///
         /// [`Target::Auto`] commands will be sent to the window containing the widget.
         ///
-        /// [`Command`]: struct.Command.html
-        /// [`update`]: trait.Widget.html#tymethod.update
+        /// [`update`]: Widget::update
         pub fn submit_command(&mut self, cmd: impl Into<Command>) {
             trace!("submit_command");
             self.state.submit_command(cmd.into())
@@ -700,8 +699,6 @@ impl_context_method!(
 
         /// Returns an [`ExtEventSink`] that can be moved between threads,
         /// and can be used to submit commands back to the application.
-        ///
-        /// [`ExtEventSink`]: struct.ExtEventSink.html
         pub fn get_external_handle(&self) -> ExtEventSink {
             trace!("get_external_handle");
             self.state.ext_handle.clone()
@@ -775,7 +772,7 @@ impl EventCtx<'_, '_> {
     /// Create a new window.
     /// `T` must be the application's root `Data` type (the type provided to [`AppLauncher::launch`]).
     ///
-    /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
+    /// [`AppLauncher::launch`]: crate::AppLauncher::launch
     pub fn new_window<T: Any>(&mut self, desc: WindowDesc<T>) {
         trace!("new_window");
         if self.state.root_app_data_type == TypeId::of::<T>() {
@@ -792,7 +789,7 @@ impl EventCtx<'_, '_> {
     /// Show the context menu in the window containing the current widget.
     /// `T` must be the application's root `Data` type (the type provided to [`AppLauncher::launch`]).
     ///
-    /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
+    /// [`AppLauncher::launch`]: crate::AppLauncher::launch
     pub fn show_context_menu<T: Any>(&mut self, menu: Menu<T>, location: Point) {
         trace!("show_context_menu");
         if self.state.root_app_data_type == TypeId::of::<T>() {
@@ -947,7 +944,7 @@ impl UpdateCtx<'_, '_> {
     /// This should only be needed in advanced cases;
     /// see [`EventCtx::request_update`] for more information.
     ///
-    /// [`EventCtx::request_update`]: struct.EventCtx.html#method.request_update
+    /// [`EventCtx::request_update`]: EventCtx::request_update
     pub fn has_requested_update(&mut self) -> bool {
         self.widget_state.request_update
     }
@@ -955,8 +952,7 @@ impl UpdateCtx<'_, '_> {
     /// Returns `true` if the current [`Env`] has changed since the previous
     /// [`update`] call.
     ///
-    /// [`Env`]: struct.Env.html
-    /// [`update`]: trait.Widget.html#tymethod.update
+    /// [`update`]: Widget::update
     pub fn env_changed(&self) -> bool {
         self.prev_env.is_some()
     }
@@ -967,10 +963,9 @@ impl UpdateCtx<'_, '_> {
     /// The argument can be anything that is resolveable from the [`Env`],
     /// such as a [`Key`] or a [`KeyOrValue`].
     ///
-    /// [`update`]: trait.Widget.html#tymethod.update
-    /// [`Env`]: struct.Env.html
-    /// [`Key`]: struct.Key.html
-    /// [`KeyOrValue`]: enum.KeyOrValue.html
+    /// [`update`]: Widget::update
+    /// [`Key`]: crate::Key
+    /// [`KeyOrValue`]: crate::KeyOrValue
     pub fn env_key_changed<T>(&self, key: &impl KeyLike<T>) -> bool {
         match self.prev_env.as_ref() {
             Some(prev) => key.changed(prev, self.env),
@@ -1016,8 +1011,8 @@ impl LifeCycleCtx<'_, '_> {
     ///
     /// See [`EventCtx::is_focused`] for more information about focus.
     ///
-    /// [`LifeCycle::BuildFocusChain`]: enum.Lifecycle.html#variant.BuildFocusChain
-    /// [`EventCtx::is_focused`]: struct.EventCtx.html#method.is_focused
+    /// [`LifeCycle::BuildFocusChain`]: crate::LifeCycle::BuildFocusChain
+    /// [`EventCtx::is_focused`]: EventCtx::is_focused
     pub fn register_for_focus(&mut self) {
         trace!("register_for_focus");
         self.widget_state.focus_chain.push(self.widget_id());
@@ -1062,8 +1057,7 @@ impl<'a, 'b> LayoutCtx<'a, 'b> {
     ///
     /// For more information, see [`WidgetPod::paint_insets`].
     ///
-    /// [`Insets`]: struct.Insets.html
-    /// [`WidgetPod::paint_insets`]: struct.WidgetPod.html#method.paint_insets
+    /// [`WidgetPod::paint_insets`]: crate::WidgetPod::paint_insets
     pub fn set_paint_insets(&mut self, insets: impl Into<Insets>) {
         let insets = insets.into();
         trace!("set_paint_insets {:?}", insets);

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -46,7 +46,7 @@ pub(crate) type CommandQueue = VecDeque<Command>;
 /// needs to propagate, and to provide the previous data so that a
 /// widget can process a diff between the old value and the new.
 ///
-/// [`update`]: trait.Widget.html#tymethod.update
+/// [`update`]: Widget::update
 pub struct WidgetPod<T, W> {
     state: WidgetState,
     old_data: Option<T>,
@@ -69,8 +69,7 @@ pub struct WidgetPod<T, W> {
 /// that, widgets will generally not interact with it directly,
 /// but it is an important part of the [`WidgetPod`] struct.
 ///
-/// [`paint`]: trait.Widget.html#tymethod.paint
-/// [`WidgetPod`]: struct.WidgetPod.html
+/// [`paint`]: Widget::paint
 #[derive(Clone)]
 pub struct WidgetState {
     pub(crate) id: WidgetId,
@@ -83,7 +82,7 @@ pub struct WidgetState {
     /// The origin of the parent in the window coordinate space.
     ///
     /// Note that this value can be stale after `set_origin` was called
-    /// but before `LifeCycle::ViewContextChanged` has fully propagated.
+    /// but before [`LifeCycle::ViewContextChanged`] has fully propagated.
     pub(crate) parent_window_origin: Point,
     /// A flag used to track and debug missing calls to set_origin.
     is_expecting_set_origin_call: bool,
@@ -216,7 +215,7 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
 
     /// Returns `true` if the widget has received [`LifeCycle::WidgetAdded`].
     ///
-    /// [`LifeCycle::WidgetAdded`]: ./enum.LifeCycle.html#variant.WidgetAdded
+    /// [`LifeCycle::WidgetAdded`]: LifeCycle::WidgetAdded
     pub fn is_initialized(&self) -> bool {
         self.old_data.is_some()
     }
@@ -240,14 +239,14 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
     /// When a widget is active, it gets mouse events even when the mouse
     /// is dragged away.
     ///
-    /// [`set_active`]: struct.EventCtx.html#method.set_active
+    /// [`set_active`]: EventCtx::set_active
     pub fn is_active(&self) -> bool {
         self.state.is_active
     }
 
     /// Returns `true` if any descendant is [`active`].
     ///
-    /// [`active`]: struct.WidgetPod.html#method.is_active
+    /// [`active`]: WidgetPod::is_active
     pub fn has_active(&self) -> bool {
         self.state.has_active
     }
@@ -267,7 +266,7 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
     /// Note: a widget can be hot while another is [`active`] (for example, when
     /// clicking a button and dragging the cursor to another widget).
     ///
-    /// [`active`]: struct.WidgetPod.html#method.is_active
+    /// [`active`]: WidgetPod::is_active
     pub fn is_hot(&self) -> bool {
         self.state.is_hot
     }
@@ -298,12 +297,6 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
     /// in an inconsistent state of the widget tree.
     ///
     /// The child will receive the [`LifeCycle::Size`] event informing them of the final [`Size`].
-    ///
-    /// [`Widget::layout`]: trait.Widget.html#tymethod.layout
-    /// [`Rect`]: struct.Rect.html
-    /// [`Size`]: struct.Size.html
-    /// [`LifeCycle::Size`]: enum.LifeCycle.html#variant.Size
-    /// [`LifeCycle::ViewContextChanged`]: enum.LifeCycle.html#variant.ViewContextChanged
     pub fn set_origin(&mut self, ctx: &mut impl ChangeCtx, origin: Point) {
         self.state.is_expecting_set_origin_call = false;
 
@@ -320,9 +313,7 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
     /// This will be a [`Rect`] with a [`Size`] determined by the child's [`layout`]
     /// method, and the origin that was set by [`set_origin`].
     ///
-    /// [`Rect`]: struct.Rect.html
-    /// [`Size`]: struct.Size.html
-    /// [`layout`]: trait.Widget.html#tymethod.layout
+    /// [`layout`]: Widget::layout
     /// [`set_origin`]: WidgetPod::set_origin
     pub fn layout_rect(&self) -> Rect {
         self.state.layout_rect()
@@ -335,7 +326,6 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
     /// in the general case it is the same as the [`layout_rect`].
     ///
     /// [`layout_rect`]: #method.layout_rect
-    /// [`Rect`]: struct.Rect.html
     /// [`paint_insets`]: #method.paint_insets
     pub fn paint_rect(&self) -> Rect {
         self.state.paint_rect()
@@ -352,23 +342,21 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
     /// A widget can set its insets by calling [`set_paint_insets`] during its
     /// [`layout`] method.
     ///
-    /// [`Insets`]: struct.Insets.html
-    /// [`set_paint_insets`]: struct.LayoutCtx.html#method.set_paint_insets
-    /// [`layout`]: trait.Widget.html#tymethod.layout
+    /// [`set_paint_insets`]: LayoutCtx::set_paint_insets
+    /// [`layout`]: Widget::layout
     pub fn paint_insets(&self) -> Insets {
         self.state.paint_insets
     }
 
-    /// Given a parents layout size, determine the appropriate paint `Insets`
+    /// Given a parents layout size, determine the appropriate paint [`Insets`]
     /// for the parent.
     ///
     /// This is a convenience method to be used from the [`layout`] method
-    /// of a `Widget` that manages a child; it allows the parent to correctly
+    /// of a [`Widget`] that manages a child; it allows the parent to correctly
     /// propagate a child's desired paint rect, if it extends beyond the bounds
     /// of the parent's layout rect.
     ///
-    /// [`layout`]: trait.Widget.html#tymethod.layout
-    /// [`Insets`]: struct.Insets.html
+    /// [`layout`]: Widget::layout
     pub fn compute_parent_paint_insets(&self, parent_size: Size) -> Insets {
         let parent_bounds = Rect::ZERO.with_size(parent_size);
         let union_pant_rect = self.paint_rect().union(parent_bounds);
@@ -381,11 +369,11 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
     }
 
     /// Determines if the provided `mouse_pos` is inside the widget's `layout_rect`
-    /// and if so updates the hot state and sends `LifeCycle::HotChanged`.
+    /// and if so updates the hot state and sends [`LifeCycle::HotChanged`].
     ///
     /// Returns `true` if the hot state changed.
     ///
-    /// The WidgetPod should merge up its state when `true` is returned.
+    /// The `WidgetPod` should merge up its state when `true` is returned.
     fn set_hot_state(
         &mut self,
         state: &mut ContextState,
@@ -434,8 +422,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
     /// Note that this method does not apply the offset of the layout rect.
     /// If that is desired, use [`paint`] instead.
     ///
-    /// [`layout`]: trait.Widget.html#tymethod.layout
-    /// [`Widget::paint`]: trait.Widget.html#tymethod.paint
+    /// [`layout`]: Widget::layout
     /// [`paint`]: #method.paint
     pub fn paint_raw(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         // we need to do this before we borrow from self
@@ -552,7 +539,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
     /// Generally called by container widgets as part of their [`layout`]
     /// method.
     ///
-    /// [`layout`]: trait.Widget.html#tymethod.layout
+    /// [`layout`]: Widget::layout
     pub fn layout(
         &mut self,
         ctx: &mut LayoutCtx,
@@ -617,7 +604,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
     /// flow logic resides, particularly whether to continue propagating
     /// the event.
     ///
-    /// [`event`]: trait.Widget.html#tymethod.event
+    /// [`event`]: Widget::event
     pub fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if !self.is_initialized() {
             debug_panic!(
@@ -903,8 +890,6 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
     }
 
     /// Propagate a [`LifeCycle`] event.
-    ///
-    /// [`LifeCycle`]: enum.LifeCycle.html
     pub fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         // in the case of an internal routing event, if we are at our target
         // we may send an extra event after the actual event
@@ -1153,7 +1138,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
     /// Generally called by container widgets as part of their [`update`]
     /// method.
     ///
-    /// [`update`]: trait.Widget.html#tymethod.update
+    /// [`update`]: Widget::update
     pub fn update(&mut self, ctx: &mut UpdateCtx, data: &T, env: &Env) {
         if !self.state.request_update {
             match (self.old_data.as_ref(), self.env.as_ref()) {

--- a/druid/src/data.rs
+++ b/druid/src/data.rs
@@ -103,8 +103,7 @@ use piet::ImageBuf;
 /// that is where no variant has fields), the implementation that is generated
 /// checks for equality. Therefore, such types must also implement `PartialEq`.
 ///
-/// [`Data::same`]: trait.Data.html#tymethod.same
-/// [`im` crate]: https://docs.rs/im
+/// [`im` crate]: https://crates.io/crates/im
 pub trait Data: Clone + 'static {
     //// ANCHOR: same_fn
     /// Determine whether two values are the same.

--- a/druid/src/env.rs
+++ b/druid/src/env.rs
@@ -47,8 +47,7 @@ use crate::{ArcStr, Color, Data, Insets, Point, Rect, Size};
 /// - [`Key`]s must always be set before they are used.
 /// - Values can only be overwritten by values of the same type.
 ///
-/// [`EnvScope`]: widget/struct.EnvScope.html
-/// [`Key`]: struct.Key.html
+/// [`EnvScope`]: crate::widget::EnvScope
 #[derive(Clone)]
 pub struct Env(Arc<EnvImpl>);
 
@@ -84,9 +83,6 @@ struct EnvImpl {
 ///         });
 /// }
 /// ```
-///
-/// [`ValueType`]: trait.ValueType.html
-/// [`Env`]: struct.Env.html
 #[derive(Clone, Debug, PartialEq, Eq, Data)]
 pub struct Key<T> {
     key: &'static str,
@@ -117,19 +113,11 @@ pub enum Value {
 ///
 /// This is a way to allow widgets to interchangeably use either a specific
 /// value or a value from the environment for some purpose.
-///
-/// [`Key<T>`]: struct.Key.html
-/// [`Env`]: struct.Env.html
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum KeyOrValue<T> {
     /// A concrete [`Value`] of type `T`.
-    ///
-    /// [`Value`]: enum.Value.html
     Concrete(T),
     /// A [`Key<T>`] that can be resolved to a value in the [`Env`].
-    ///
-    /// [`Key<T>`]: struct.Key.html
-    /// [`Env`]: struct.Env.html
     Key(Key<T>),
 }
 
@@ -152,8 +140,6 @@ impl<T: Data> Data for KeyOrValue<T> {
 /// [`KeyOrValue`]: enum.KeyOrValue.html
 pub trait KeyLike<T> {
     /// Returns `true` if this item has changed between the old and new [`Env`].
-    ///
-    /// [`Env`]: struct.Env.html
     fn changed(&self, old: &Env, new: &Env) -> bool;
 }
 
@@ -190,8 +176,6 @@ pub struct ValueTypeError {
 }
 
 /// An error type for when a key is missing from the [`Env`].
-///
-/// [`Env`]: struct.Env.html
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct MissingKeyError {
@@ -203,16 +187,16 @@ impl Env {
     /// State for whether or not to paint colorful rectangles for layout
     /// debugging.
     ///
-    /// Set by the `debug_paint_layout()` method on [`WidgetExt`]'.
+    /// Set by the [`WidgetExt::debug_paint_layout`] method.
     ///
-    /// [`WidgetExt`]: trait.WidgetExt.html
+    /// [`WidgetExt::debug_paint_layout`]: crate::WidgetExt::debug_paint_layout
     pub(crate) const DEBUG_PAINT: Key<bool> = Key::new("org.linebender.druid.built-in.debug-paint");
 
     /// State for whether or not to paint `WidgetId`s, for event debugging.
     ///
-    /// Set by the `debug_widget_id()` method on [`WidgetExt`].
+    /// Set by the [`WidgetExt::debug_widget_id`] method.
     ///
-    /// [`WidgetExt`]: trait.WidgetExt.html
+    /// [`WidgetExt::debug_widget_id`]: crate::WidgetExt::debug_widget_id
     pub(crate) const DEBUG_WIDGET_ID: Key<bool> =
         Key::new("org.linebender.druid.built-in.debug-widget-id");
 
@@ -236,7 +220,7 @@ impl Env {
     /// }
     /// ```
     ///
-    /// [`WidgetExt::debug_widget`]: trait.WidgetExt.html#method.debug_widget
+    /// [`WidgetExt::debug_widget`]: crate::WidgetExt::debug_widget
     pub const DEBUG_WIDGET: Key<bool> = Key::new("org.linebender.druid.built-in.debug-widget");
 
     /// Gets a value from the environment, expecting it to be present.
@@ -281,8 +265,6 @@ impl Env {
     /// # Panics
     ///
     /// Panics if the key is not found.
-    ///
-    /// [`Value`]: enum.Value.html
     pub fn get_untyped<V>(&self, key: impl Borrow<Key<V>>) -> &Value {
         match self.try_get_untyped(key) {
             Ok(val) => val,
@@ -296,8 +278,6 @@ impl Env {
     /// # Note
     /// This is not intended for general use, but only for inspecting an `Env`
     /// e.g. for debugging, theme editing, and theme loading.
-    ///
-    /// [`Value`]: enum.Value.html
     pub fn try_get_untyped<V>(&self, key: impl Borrow<Key<V>>) -> Result<&Value, MissingKeyError> {
         self.0.map.get(key.borrow().key).ok_or(MissingKeyError {
             key: key.borrow().key.into(),
@@ -360,8 +340,6 @@ impl Env {
     /// resources.
     ///
     /// This always exists on the base `Env` configured by druid.
-    ///
-    /// [`L10nManager`]: struct.L10nManager.html
     pub(crate) fn localization_manager(&self) -> Option<&L10nManager> {
         self.0.l10n.as_deref()
     }

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -47,8 +47,8 @@ use crate::{Command, Notification, Point, Scale, WidgetId};
 /// This enum is expected to grow considerably, as there are many, many
 /// different kinds of events that are relevant in a GUI.
 ///
-/// [`event`]: trait.Widget.html#tymethod.event
-/// [`WidgetPod`]: struct.WidgetPod.html
+/// [`event`]: crate::Widget::event
+/// [`WidgetPod`]: crate::WidgetPod
 #[derive(Debug, Clone)]
 pub enum Event {
     /// Sent to all widgets in a given window when that window is first instantiated.
@@ -108,7 +108,7 @@ pub enum Event {
     /// propagated to active or hot widgets.
     ///
     /// [`HotChanged`]: LifeCycle::HotChanged
-    /// [`set_cursor`]: struct.EventCtx.html#method.set_cursor
+    /// [`set_cursor`]: crate::EventCtx::set_cursor
     MouseMove(MouseEvent),
     /// Called when the mouse wheel or trackpad is scrolled.
     Wheel(MouseEvent),
@@ -127,14 +127,14 @@ pub enum Event {
     Zoom(f64),
     /// Called on a timer event.
     ///
-    /// Request a timer event through [`EventCtx::request_timer()`]. That will
+    /// Request a timer event through [`EventCtx::request_timer`]. That will
     /// cause a timer event later.
     ///
     /// Note that timer events from other widgets may be delivered as well. Use
-    /// the token returned from the `request_timer()` call to filter events more
+    /// the token returned from the `request_timer` call to filter events more
     /// precisely.
     ///
-    /// [`EventCtx::request_timer()`]: struct.EventCtx.html#method.request_timer
+    /// [`EventCtx::request_timer`]: crate::EventCtx::request_timer
     Timer(TimerToken),
     /// Called at the beginning of a new animation frame.
     ///
@@ -172,9 +172,8 @@ pub enum Event {
     /// - Widgets and other Druid components can send custom [`Command`]s at
     /// runtime, via methods such as [`EventCtx::submit_command`].
     ///
-    /// [`Command`]: struct.Command.html
-    /// [`Widget`]: trait.Widget.html
-    /// [`EventCtx::submit_command`]: struct.EventCtx.html#method.submit_command
+    /// [`Widget`]: Widget
+    /// [`EventCtx::submit_command`]: crate::EventCtx::submit_command
     /// [`ExtEventSink`]: crate::ExtEventSink
     /// [`MenuItem`]: crate::MenuItem
     Command(Command),
@@ -209,7 +208,7 @@ pub enum Event {
     ///
     /// This should always be passed down to descendant [`WidgetPod`]s.
     ///
-    /// [`WidgetPod`]: struct.WidgetPod.html
+    /// [`WidgetPod`]: crate::WidgetPod
     Internal(InternalEvent),
 }
 
@@ -218,8 +217,7 @@ pub enum Event {
 /// These events are translated into regular [`Event`]s
 /// and should not be used directly.
 ///
-/// [`WidgetPod`]: struct.WidgetPod.html
-/// [`Event`]: enum.Event.html
+/// [`WidgetPod`]: crate::WidgetPod
 #[derive(Debug, Clone)]
 pub enum InternalEvent {
     /// Sent in some cases when the mouse has left the window.
@@ -268,15 +266,15 @@ pub enum LifeCycle {
     /// itself will handle registering those children with the system; this is
     /// required for things like correct routing of events.
     ///
-    /// [`WidgetPod`]: struct.WidgetPod.html
+    /// [`WidgetPod`]: crate::WidgetPod
     WidgetAdded,
     /// Called when the [`Size`] of the widget changes.
     ///
     /// This will be called after [`Widget::layout`], if the [`Size`] returned
     /// by the widget differs from its previous size.
     ///
-    /// [`Size`]: struct.Size.html
-    /// [`Widget::layout`]: trait.Widget.html#tymethod.layout
+    /// [`Size`]: crate::Size
+    /// [`Widget::layout`]: crate::Widget::layout
     Size(Size),
     /// Called when the Disabled state of the widgets is changed.
     ///
@@ -291,9 +289,9 @@ pub enum LifeCycle {
     ///
     /// This will always be called _before_ the event that triggered it; that is,
     /// when the mouse moves over a widget, that widget will receive
-    /// `LifeCycle::HotChanged` before it receives `Event::MouseMove`.
+    /// [`LifeCycle::HotChanged`] before it receives [`Event::MouseMove`].
     ///
-    /// See [`is_hot`](struct.EventCtx.html#method.is_hot) for
+    /// See [`is_hot`](crate::EventCtx::is_hot) for
     /// discussion about the hot status.
     HotChanged(bool),
     /// This is called when the widget-tree changes and druid wants to rebuild the
@@ -314,20 +312,19 @@ pub enum LifeCycle {
     ///
     /// See [`EventCtx::is_focused`] for more information about focus.
     ///
-    /// [`EventCtx::is_focused`]: struct.EventCtx.html#method.is_focused
+    /// [`EventCtx::is_focused`]: crate::EventCtx::is_focused
     FocusChanged(bool),
     /// Called when the [`ViewContext`] of this widget changed.
     ///
     /// See [`view_context_changed`] on how and when to request this event.
     ///
     /// [`view_context_changed`]: crate::EventCtx::view_context_changed
-    /// [`ViewContext`]: ViewContext
     ViewContextChanged(ViewContext),
     /// Internal druid lifecycle event.
     ///
     /// This should always be passed down to descendant [`WidgetPod`]s.
     ///
-    /// [`WidgetPod`]: struct.WidgetPod.html
+    /// [`WidgetPod`]: crate::WidgetPod
     Internal(InternalLifeCycle),
 }
 
@@ -336,8 +333,7 @@ pub enum LifeCycle {
 /// These events are translated into regular [`LifeCycle`] events
 /// and should not be used directly.
 ///
-/// [`WidgetPod`]: struct.WidgetPod.html
-/// [`LifeCycle`]: enum.LifeCycle.html
+/// [`WidgetPod`]: crate::WidgetPod
 #[derive(Debug, Clone)]
 pub enum InternalLifeCycle {
     /// Used to route the `WidgetAdded` event to the required widgets.

--- a/druid/src/ext_event.rs
+++ b/druid/src/ext_event.rs
@@ -43,7 +43,7 @@ pub(crate) struct ExtEventHost {
     queue: Arc<Mutex<VecDeque<ExtCommand>>>,
     /// This doesn't exist when the app starts and it can go away if a window closes, so we keep a
     /// reference here and can update it when needed. Note that this reference is shared with all
-    /// `ExtEventSink`s, so that we can update them too.
+    /// [`ExtEventSink`]s, so that we can update them too.
     handle: Arc<Mutex<Option<IdleHandle>>>,
     /// The window that the handle belongs to, so we can keep track of when
     /// we need to get a new handle.
@@ -95,11 +95,6 @@ impl ExtEventSink {
     /// The `payload` must implement `Any + Send`.
     ///
     /// If the [`Target::Auto`] is equivalent to [`Target::Global`].
-    ///
-    /// [`Command`]: struct.Command.html
-    /// [`Selector`]: struct.Selector.html
-    /// [`Target::Auto`]: enum.Target.html#variant.Auto
-    /// [`Target::Global`]: enum.Target.html#variant.Global
     pub fn submit_command<T: Any + Send>(
         &self,
         selector: Selector<T>,

--- a/druid/src/lens/lens.rs
+++ b/druid/src/lens/lens.rs
@@ -390,9 +390,9 @@ where
     }
 }
 
-/// `Lens` for invoking `Deref` and `DerefMut` on a type
+/// `Lens` for invoking `Deref` and `DerefMut` on a type.
 ///
-/// See also `LensExt::deref`.
+/// See also [`LensExt::deref`].
 #[derive(Debug, Copy, Clone)]
 pub struct Deref;
 
@@ -410,11 +410,8 @@ where
 
 /// [`Lens`] for invoking `AsRef` and `AsMut` on a type.
 ///
-/// [`LensExt::ref`] offers an easy way to apply this,
+/// [`LensExt::as_ref`] offers an easy way to apply this,
 /// as well as more information and examples.
-///
-/// [`Lens`]: ../trait.Lens.html
-/// [`LensExt::ref`]: ../trait.LensExt.html#method.as_ref
 #[derive(Debug, Copy, Clone)]
 pub struct Ref;
 

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -140,8 +140,8 @@
 //! [`Lens`]: trait.Lens.html
 //! [`widget`]: ./widget/index.html
 //! [`Event`]: enum.Event.html
-//! [`druid-shell`]: https://docs.rs/druid-shell
-//! [`piet`]: https://docs.rs/piet
+//! [`druid-shell`]: druid_shell
+//! [`piet`]: piet
 //! [`druid/examples`]: https://github.com/linebender/druid/tree/v0.7.0/druid/examples
 //! [druid book]: https://linebender.org/druid/
 //! [`im` crate]: https://crates.io/crates/im

--- a/druid/src/localization.rs
+++ b/druid/src/localization.rs
@@ -30,9 +30,7 @@
 //!
 //! [Fluent]: https://projectfluent.org
 //! [fluent-rs]: https://github.com/projectfluent/fluent-rs
-//! [`LocalizedString`]: struct.LocalizedString.html
-//! [`Env`]: struct.Env.html
-//! [`Data`]: trait.Data.html
+//! [`Data`]: crate::Data
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/druid/src/mouse.rs
+++ b/druid/src/mouse.rs
@@ -31,7 +31,7 @@ use crate::{Cursor, Data, Modifiers, MouseButton, MouseButtons};
 /// The position may also have changed in relation to the receiver,
 /// because the receiver's location changed without the mouse moving.
 ///
-/// [`Event::MouseMove`]: enum.Event.html#variant.MouseMove
+/// [`Event::MouseMove`]: crate::Event::MouseMove
 #[derive(Debug, Clone)]
 pub struct MouseEvent {
     /// The position of the mouse in the coordinate space of the receiver.

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -94,7 +94,7 @@ impl<T: Data> Harness<'_, T> {
     /// For lifetime reasons™, we cannot just make a harness. It's complicated.
     /// I tried my best.
     ///
-    /// This function is a subset of [create_with_render](struct.Harness.html#create_with_render)
+    /// This function is a subset of [create_with_render](Harness::create_with_render)
     pub fn create_simple(
         data: T,
         root: impl Widget<T> + 'static,

--- a/druid/src/text/attribute.rs
+++ b/druid/src/text/attribute.rs
@@ -81,29 +81,24 @@ struct Span<T> {
 /// let theme_color = Attribute::text_color(theme::SELECTION_COLOR);
 /// ```
 ///
-/// [`KeyOrValue`]: ../enum.KeyOrValue.html
-/// [`theme`]: ../theme
-/// [`Attribute::size`]: #method.size
-/// [`Attribute::text_color`]: #method.text_color
+/// [`theme`]: crate::theme
 #[derive(Debug, Clone)]
 pub enum Attribute {
     /// The font family.
     FontFamily(FontFamily),
     /// The font size, in points.
     FontSize(KeyOrValue<f64>),
-    /// The [`FontWeight`](struct.FontWeight.html).
+    /// The [`FontWeight`].
     Weight(FontWeight),
     /// The foreground color of the text.
     TextColor(KeyOrValue<Color>),
     /// The [`FontStyle`]; either regular or italic.
-    ///
-    /// [`FontStyle`]: enum.FontStyle.html
     Style(FontStyle),
     /// Underline.
     Underline(bool),
     /// Strikethrough
     Strikethrough(bool),
-    /// A [`FontDescriptor`](struct.FontDescriptor.html).
+    /// A [`FontDescriptor`].
     Descriptor(KeyOrValue<FontDescriptor>),
 }
 

--- a/druid/src/text/font_descriptor.rs
+++ b/druid/src/text/font_descriptor.rs
@@ -22,20 +22,18 @@ use crate::{Data, FontFamily, FontStyle, FontWeight};
 /// a single type that represents a specific font face at a specific size.
 #[derive(Debug, Data, Clone, PartialEq)]
 pub struct FontDescriptor {
-    /// The font's [`FontFamily`](struct.FontFamily.html).
+    /// The font's [`FontFamily`].
     pub family: FontFamily,
     /// The font's size.
     pub size: f64,
-    /// The font's [`FontWeight`](struct.FontWeight.html).
+    /// The font's [`FontWeight`].
     pub weight: FontWeight,
-    /// The font's [`FontStyle`](struct.FontStyle.html).
+    /// The font's [`FontStyle`].
     pub style: FontStyle,
 }
 
 impl FontDescriptor {
     /// Create a new descriptor with the provided [`FontFamily`].
-    ///
-    /// [`FontFamily`]: struct.FontFamily.html
     pub const fn new(family: FontFamily) -> Self {
         FontDescriptor {
             family,
@@ -52,16 +50,12 @@ impl FontDescriptor {
     }
 
     /// Buider-style method to set the descriptor's [`FontWeight`].
-    ///
-    /// [`FontWeight`]: struct.FontWeight.html
     pub const fn with_weight(mut self, weight: FontWeight) -> Self {
         self.weight = weight;
         self
     }
 
     /// Buider-style method to set the descriptor's [`FontStyle`].
-    ///
-    /// [`FontStyle`]: enum.FontStyle.html
     pub const fn with_style(mut self, style: FontStyle) -> Self {
         self.style = style;
         self

--- a/druid/src/text/format.rs
+++ b/druid/src/text/format.rs
@@ -68,7 +68,7 @@ pub trait Formatter<T> {
     ///
     /// This must return `Ok()` for any string created by [`format`].
     ///
-    /// [`format`]: #tymethod.format
+    /// [`format`]: Formatter::format
     fn value(&self, input: &str) -> Result<T, ValidationError>;
 }
 

--- a/druid/src/text/layout.rs
+++ b/druid/src/text/layout.rs
@@ -39,11 +39,10 @@ use crate::{Env, FontDescriptor, KeyOrValue, PaintCtx, RenderContext, UpdateCtx}
 /// to call [`rebuild_if_needed`] again, generally by scheduling another [`layout`]
 /// pass.
 ///
-/// [`layout`]: trait.Widget.html#tymethod.layout
-/// [`update`]: trait.Widget.html#tymethod.update
+/// [`layout`]: crate::Widget::layout
+/// [`update`]: crate::Widget::update
 /// [`needs_rebuild_after_update`]: #method.needs_rebuild_after_update
 /// [`rebuild_if_needed`]: #method.rebuild_if_needed
-/// [`Env`]: struct.Env.html
 #[derive(Clone)]
 pub struct TextLayout<T> {
     text: Option<T>,
@@ -77,7 +76,7 @@ impl<T> TextLayout<T> {
     ///
     /// You must set the text ([`set_text`]) before using this object.
     ///
-    /// [`set_text`]: #method.set_text
+    /// [`set_text`]: TextLayout::set_text
     pub fn new() -> Self {
         TextLayout {
             text: None,
@@ -106,9 +105,7 @@ impl<T> TextLayout<T> {
     /// The argument is a [`FontDescriptor`] or a [`Key<FontDescriptor>`] that
     /// can be resolved from the [`Env`].
     ///
-    /// [`FontDescriptor`]: struct.FontDescriptor.html
-    /// [`Env`]: struct.Env.html
-    /// [`Key<FontDescriptor>`]: struct.Key.html
+    /// [`Key<FontDescriptor>`]: crate::Key
     pub fn set_font(&mut self, font: impl Into<KeyOrValue<FontDescriptor>>) {
         let font = font.into();
         if font != self.font {
@@ -122,8 +119,7 @@ impl<T> TextLayout<T> {
     ///
     /// This overrides the size in the [`FontDescriptor`] provided to [`set_font`].
     ///
-    /// [`set_font`]: #method.set_font.html
-    /// [`FontDescriptor`]: struct.FontDescriptor.html
+    /// [`set_font`]: TextLayout::set_font
     pub fn set_text_size(&mut self, size: impl Into<KeyOrValue<f64>>) {
         let size = size.into();
         if Some(&size) != self.text_size_override.as_ref() {
@@ -146,8 +142,6 @@ impl<T> TextLayout<T> {
     }
 
     /// Set the [`TextAlignment`] for this layout.
-    ///
-    /// [`TextAlignment`]: enum.TextAlignment.html
     pub fn set_text_alignment(&mut self, alignment: TextAlignment) {
         if self.alignment != alignment {
             self.alignment = alignment;
@@ -195,15 +189,13 @@ impl<T: TextStorage> TextLayout<T> {
     }
 
     /// Returns the [`TextStorage`] backing this layout, if it exists.
-    ///
-    /// [`TextStorage`]: trait.TextStorage.html
     pub fn text(&self) -> Option<&T> {
         self.text.as_ref()
     }
 
     /// Returns the inner Piet [`TextLayout`] type.
     ///
-    /// [`TextLayout`]: ./piet/trait.TextLayout.html
+    /// [`TextLayout`]: crate::piet::TextLayout
     pub fn layout(&self) -> Option<&PietTextLayout> {
         self.layout.as_ref()
     }
@@ -212,7 +204,7 @@ impl<T: TextStorage> TextLayout<T> {
     ///
     /// This is not meaningful until [`rebuild_if_needed`] has been called.
     ///
-    /// [`rebuild_if_needed`]: #method.rebuild_if_needed
+    /// [`rebuild_if_needed`]: TextLayout::rebuild_if_needed
     pub fn size(&self) -> Size {
         self.layout
             .as_ref()
@@ -224,8 +216,7 @@ impl<T: TextStorage> TextLayout<T> {
     ///
     /// This is not meaningful until [`rebuild_if_needed`] has been called.
     ///
-    /// [`rebuild_if_needed`]: #method.rebuild_if_needed
-    /// [`LayoutMetrics`]: struct.LayoutMetrics.html
+    /// [`rebuild_if_needed`]: TextLayout::rebuild_if_needed
     pub fn layout_metrics(&self) -> LayoutMetrics {
         debug_assert!(
             self.layout.is_some(),
@@ -334,11 +325,13 @@ impl<T: TextStorage> TextLayout<T> {
         text.links().get(*i)
     }
 
-    /// Called during the containing widgets `update` method; this text object
+    /// Called during the containing widget's [`update`] method; this text object
     /// will check to see if any used environment items have changed,
     /// and invalidate itself as needed.
     ///
     /// Returns `true` if the text item needs to be rebuilt.
+    ///
+    /// [`update`]: crate::Widget::update
     pub fn needs_rebuild_after_update(&mut self, ctx: &mut UpdateCtx) -> bool {
         if ctx.env_changed() && self.layout.is_some() {
             let rebuild = ctx.env_key_changed(&self.font)
@@ -371,7 +364,7 @@ impl<T: TextStorage> TextLayout<T> {
     /// A simple way to ensure this is correct is to always call this method
     /// as part of your widget's [`layout`] method.
     ///
-    /// [`layout`]: trait.Widget.html#method.layout
+    /// [`layout`]: crate::Widget::layout
     pub fn rebuild_if_needed(&mut self, factory: &mut PietText, env: &Env) {
         if let Some(text) = &self.text {
             if self.layout.is_none() {

--- a/druid/src/text/rich_text.rs
+++ b/druid/src/text/rich_text.rs
@@ -49,8 +49,6 @@ impl RichText {
     }
 
     /// Builder-style method for adding an [`Attribute`] to a range of text.
-    ///
-    /// [`Attribute`]: enum.Attribute.html
     pub fn with_attribute(mut self, range: impl RangeBounds<usize>, attr: Attribute) -> Self {
         self.add_attribute(range, attr);
         self
@@ -67,8 +65,6 @@ impl RichText {
     }
 
     /// Add an [`Attribute`] to the provided range of text.
-    ///
-    /// [`Attribute`]: enum.Attribute.html
     pub fn add_attribute(&mut self, range: impl RangeBounds<usize>, attr: Attribute) {
         let range = util::resolve_range(range, self.buffer.len());
         Arc::make_mut(&mut self.attrs).add(range, attr);
@@ -122,8 +118,6 @@ impl TextStorage for RichText {
 ///
 /// let rich_text = builder.build();
 /// ```
-///
-/// [`RichText`]: RichText
 #[derive(Default)]
 pub struct RichTextBuilder {
     buffer: String,
@@ -183,7 +177,7 @@ impl RichTextBuilder {
 
 /// Adds Attributes to the text.
 ///
-/// See also: [`RichTextBuilder`](RichTextBuilder)
+/// See also: [`RichTextBuilder`]
 pub struct AttributesAdder<'a> {
     rich_text_builder: &'a mut RichTextBuilder,
     range: Range<usize>,

--- a/druid/src/text/storage.rs
+++ b/druid/src/text/storage.rs
@@ -48,7 +48,7 @@ pub trait TextStorage: PietTextStorage + Data {
     /// require a separate API.
     ///
     /// [`Link`]: super::attribute::Link
-    /// [`piet`]: https://docs.rs/piet
+    /// [`piet`]: crate::piet
     fn links(&self) -> &[Link] {
         &[]
     }
@@ -58,7 +58,9 @@ pub trait TextStorage: PietTextStorage + Data {
 pub struct EnvUpdateCtx<'a, 'b>(&'a UpdateCtx<'a, 'b>);
 
 impl<'a, 'b> EnvUpdateCtx<'a, 'b> {
-    /// Create an EnvChangeCtx for Widget::update
+    /// Create an [`EnvUpdateCtx`] for [`Widget::update`].
+    ///
+    /// [`Widget::update`]: crate::Widget::update
     pub(crate) fn for_update(ctx: &'a UpdateCtx<'a, 'b>) -> Self {
         Self(ctx)
     }
@@ -68,7 +70,7 @@ impl<'a, 'b> EnvUpdateCtx<'a, 'b> {
     ///
     /// See [`UpdateCtx::env_key_changed`] for more details.
     ///
-    /// [`env_update`]: (TextStorage::env_update)
+    /// [`env_update`]: TextStorage::env_update
     pub fn env_key_changed<T>(&self, key: &impl KeyLike<T>) -> bool {
         self.0.env_key_changed(key)
     }

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -34,7 +34,7 @@ pub struct Button<T> {
 impl<T: Data> Button<T> {
     /// Create a new button with a text label.
     ///
-    /// Use the [`.on_click`] method to provide a closure to be called when the
+    /// Use the [`on_click`] method to provide a closure to be called when the
     /// button is clicked.
     ///
     /// # Examples
@@ -47,14 +47,14 @@ impl<T: Data> Button<T> {
     /// });
     /// ```
     ///
-    /// [`.on_click`]: #method.on_click
+    /// [`on_click`]: #method.on_click
     pub fn new(text: impl Into<LabelText<T>>) -> Button<T> {
         Button::from_label(Label::new(text))
     }
 
     /// Create a new button with the provided [`Label`].
     ///
-    /// Use the [`.on_click`] method to provide a closure to be called when the
+    /// Use the [`on_click`] method to provide a closure to be called when the
     /// button is clicked.
     ///
     /// # Examples
@@ -68,8 +68,7 @@ impl<T: Data> Button<T> {
     /// });
     /// ```
     ///
-    /// [`Label`]: struct.Label.html
-    /// [`.on_click`]: #method.on_click
+    /// [`on_click`]: #method.on_click
     pub fn from_label(label: Label<T>) -> Button<T> {
         Button {
             label,

--- a/druid/src/widget/click.rs
+++ b/druid/src/widget/click.rs
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 //! A clickable [`Controller`] widget.
-//!
-//! [`Controller`]: trait.Controller.html
 
 use crate::widget::Controller;
 use crate::{Data, Env, Event, EventCtx, LifeCycle, LifeCycleCtx, MouseButton, Widget};
@@ -31,12 +29,10 @@ use tracing::{instrument, trace};
 /// mouse down, which can be useful for painting based on `ctx.is_active()`
 /// and `ctx.is_hot()`.
 ///
-/// [`Controller`]: trait.Controller.html
-/// [`ControllerHost`]: struct.ControllerHost.html
-/// [`on_click`]: ../trait.WidgetExt.html#method.on_click
-/// [`WidgetExt`]: ../trait.WidgetExt.html
-/// [`Button`]: struct.Button.html
-/// [`LifeCycle::HotChanged`]: ../enum.LifeCycle.html#variant.HotChanged
+/// [`ControllerHost`]: super::ControllerHost
+/// [`on_click`]: super::WidgetExt::on_click
+/// [`WidgetExt`]: super::WidgetExt
+/// [`Button`]: super::Button
 pub struct Click<T> {
     /// A closure that will be invoked when the child widget is clicked.
     action: Box<dyn Fn(&mut EventCtx, &mut T, &Env)>,

--- a/druid/src/widget/clip_box.rs
+++ b/druid/src/widget/clip_box.rs
@@ -144,12 +144,10 @@ impl Viewport {
 
     /// The default handling of the [`SCROLL_TO_VIEW`] notification for a scrolling container.
     ///
-    /// The [`SCROLL_TO_VIEW`] notification is sent when [`scroll_to_view`] or [`scroll_area_to_view`]
-    /// are called.
+    /// The [`SCROLL_TO_VIEW`] notification is sent when [`EventCtx::scroll_to_view`]
+    /// or [`EventCtx::scroll_area_to_view`] are called.
     ///
     /// [`SCROLL_TO_VIEW`]: crate::commands::SCROLL_TO_VIEW
-    /// [`scroll_to_view`]: crate::EventCtx::scroll_to_view()
-    /// [`scroll_area_to_view`]: crate::EventCtx::scroll_area_to_view()
     pub fn default_scroll_to_view_handling(
         &mut self,
         ctx: &mut EventCtx,
@@ -182,12 +180,10 @@ impl Viewport {
 
     /// This method handles SCROLL_TO_VIEW by clipping the view_rect to the content rect.
     ///
-    /// The [`SCROLL_TO_VIEW`] notification is sent when [`scroll_to_view`] or [`scroll_area_to_view`]
-    /// are called.
+    /// The [`SCROLL_TO_VIEW`] notification is sent when [`EventCtx::scroll_to_view`]
+    /// or [`EventCtx::scroll_area_to_view`] are called.
     ///
     /// [`SCROLL_TO_VIEW`]: crate::commands::SCROLL_TO_VIEW
-    /// [`scroll_to_view`]: crate::EventCtx::scroll_to_view()
-    /// [`scroll_area_to_view`]: crate::EventCtx::scroll_area_to_view()
     pub fn fixed_scroll_to_view_handling(
         &self,
         ctx: &mut EventCtx,
@@ -242,7 +238,7 @@ impl<T, W> ClipBox<T, W> {
     ///
     /// The default is `false`. See [`constrain_vertical`] for more details.
     ///
-    /// [`constrain_vertical`]: struct.ClipBox.html#constrain_vertical
+    /// [`constrain_vertical`]: ClipBox::constrain_vertical
     pub fn constrain_horizontal(mut self, constrain: bool) -> Self {
         self.constrain_horizontal = constrain;
         self
@@ -281,7 +277,7 @@ impl<T, W> ClipBox<T, W> {
     /// Returns the size of the rectangular viewport into the child widget.
     /// To get the position of the viewport, see [`viewport_origin`].
     ///
-    /// [`viewport_origin`]: struct.ClipBox.html#method.viewport_origin
+    /// [`viewport_origin`]: ClipBox::viewport_origin
     pub fn viewport_size(&self) -> Size {
         self.port.view_size
     }
@@ -295,7 +291,7 @@ impl<T, W> ClipBox<T, W> {
     ///
     /// See [`constrain_vertical`] for more details.
     ///
-    /// [`constrain_vertical`]: struct.ClipBox.html#constrain_vertical
+    /// [`constrain_vertical`]: ClipBox::constrain_vertical
     pub fn set_constrain_horizontal(&mut self, constrain: bool) {
         self.constrain_horizontal = constrain;
     }
@@ -304,7 +300,7 @@ impl<T, W> ClipBox<T, W> {
     ///
     /// See [`constrain_vertical`] for more details.
     ///
-    /// [`constrain_vertical`]: struct.ClipBox.html#constrain_vertical
+    /// [`constrain_vertical`]: ClipBox::constrain_vertical
     pub fn set_constrain_vertical(&mut self, constrain: bool) {
         self.constrain_vertical = constrain;
     }

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -53,11 +53,8 @@ impl<T: Data> Container<T> {
     /// notably, it can be any [`Color`], a [`Key<Color>`] resolvable in the [`Env`],
     /// any gradient, or a fully custom [`Painter`] widget.
     ///
-    /// [`BackgroundBrush`]: ../enum.BackgroundBrush.html
-    /// [`Color`]: ../enum.Color.html
-    /// [`Key<Color>`]: ../struct.Key.html
-    /// [`Env`]: ../struct.Env.html
-    /// [`Painter`]: struct.Painter.html
+    /// [`Key<Color>`]: crate::Key
+    /// [`Painter`]: super::Painter
     pub fn background(mut self, brush: impl Into<BackgroundBrush<T>>) -> Self {
         self.set_background(brush);
         self
@@ -69,11 +66,8 @@ impl<T: Data> Container<T> {
     /// notably, it can be any [`Color`], a [`Key<Color>`] resolvable in the [`Env`],
     /// any gradient, or a fully custom [`Painter`] widget.
     ///
-    /// [`BackgroundBrush`]: ../enum.BackgroundBrush.html
-    /// [`Color`]: ../enum.Color.html
-    /// [`Key<Color>`]: ../struct.Key.html
-    /// [`Env`]: ../struct.Env.html
-    /// [`Painter`]: struct.Painter.html
+    /// [`Key<Color>`]: crate::Key
+    /// [`Painter`]: super::Painter
     pub fn set_background(&mut self, brush: impl Into<BackgroundBrush<T>>) {
         self.background = Some(brush.into());
     }
@@ -88,7 +82,7 @@ impl<T: Data> Container<T> {
     /// Arguments can be either concrete values, or a [`Key`] of the respective
     /// type.
     ///
-    /// [`Key`]: struct.Key.html
+    /// [`Key`]: crate::Key
     pub fn border(
         mut self,
         color: impl Into<KeyOrValue<Color>>,
@@ -103,7 +97,7 @@ impl<T: Data> Container<T> {
     /// Arguments can be either concrete values, or a [`Key`] of the respective
     /// type.
     ///
-    /// [`Key`]: struct.Key.html
+    /// [`Key`]: crate::Key
     pub fn set_border(
         &mut self,
         color: impl Into<KeyOrValue<Color>>,

--- a/druid/src/widget/controller.rs
+++ b/druid/src/widget/controller.rs
@@ -40,7 +40,7 @@ use crate::widget::{Axis, WidgetWrapper};
 ///
 /// # Examples
 ///
-/// ## A [`TextBox`] that takes focus on launch:
+/// A [`TextBox`] that takes focus on launch:
 ///
 /// ```
 /// # use druid::widget::{Controller, TextBox};
@@ -57,21 +57,15 @@ use crate::widget::{Axis, WidgetWrapper};
 /// }
 /// ```
 ///
-/// [`Widget`]: ../trait.Widget.html
-/// [`TextBox`]: struct.TextBox.html
-/// [`ControllerHost`]: struct.ControllerHost.html
-/// [`WidgetExt::controller`]: ../trait.WidgetExt.html#tymethod.controller
+/// [`TextBox`]: super::TextBox
+/// [`WidgetExt::controller`]: super::WidgetExt::controller
 pub trait Controller<T, W: Widget<T>> {
     /// Analogous to [`Widget::event`].
-    ///
-    /// [`Widget::event`]: ../trait.Widget.html#tymethod.event
     fn event(&mut self, child: &mut W, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         child.event(ctx, event, data, env)
     }
 
     /// Analogous to [`Widget::lifecycle`].
-    ///
-    /// [`Widget::lifecycle`]: ../trait.Widget.html#tymethod.lifecycle
     fn lifecycle(
         &mut self,
         child: &mut W,
@@ -84,17 +78,12 @@ pub trait Controller<T, W: Widget<T>> {
     }
 
     /// Analogous to [`Widget::update`].
-    ///
-    /// [`Widget::update`]: ../trait.Widget.html#tymethod.update
     fn update(&mut self, child: &mut W, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
         child.update(ctx, old_data, data, env)
     }
 }
 
 /// A [`Widget`] that manages a child and a [`Controller`].
-///
-/// [`Widget`]: ../trait.Widget.html
-/// [`Controller`]: trait.Controller.html
 pub struct ControllerHost<W, C> {
     widget: W,
     controller: C,

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -49,7 +49,7 @@ impl<T, W: Widget<T>> EnvScope<T, W> {
     /// # }
     /// ```
     ///
-    /// [`WidgetExt::env_scope`]: ../trait.WidgetExt.html#method.env_scope
+    /// [`WidgetExt::env_scope`]: super::WidgetExt::env_scope
     pub fn new(f: impl Fn(&mut Env, &T) + 'static, child: W) -> EnvScope<T, W> {
         EnvScope {
             f: Box::new(f),

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -128,16 +128,13 @@ use tracing::{instrument, trace};
 /// my_row.add_flex_child(Slider::new(), 1.0);
 /// ```
 ///
-/// [`layout`]: ../trait.Widget.html#tymethod.layout
-/// [`MainAxisAlignment`]: enum.MainAxisAlignment.html
-/// [`CrossAxisAlignment`]: enum.CrossAxisAlignment.html
-/// [`must_fill_main_axis`]: struct.Flex.html#method.must_fill_main_axis
-/// [`FlexParams`]: struct.FlexParams.html
-/// [`WidgetExt`]: ../trait.WidgetExt.html
-/// [`expand_height`]: ../trait.WidgetExt.html#method.expand_height
-/// [`expand_width`]: ../trait.WidgetExt.html#method.expand_width
-/// [`TextBox`]: struct.TextBox.html
-/// [`SizedBox`]: struct.SizedBox.html
+/// [`layout`]: Widget::layout
+/// [`must_fill_main_axis`]: Flex::must_fill_main_axis
+/// [`WidgetExt`]: super::WidgetExt
+/// [`expand_height`]: super::WidgetExt::expand_height
+/// [`expand_width`]: super::WidgetExt::expand_width
+/// [`TextBox`]: super::TextBox
+/// [`SizedBox`]: super::SizedBox
 pub struct Flex<T> {
     direction: Axis,
     cross_alignment: CrossAxisAlignment,

--- a/druid/src/widget/image.rs
+++ b/druid/src/widget/image.rs
@@ -67,7 +67,7 @@ use tracing::{instrument, trace};
 /// image_widget.set_interpolation_mode(InterpolationMode::Bilinear);
 /// ```
 ///
-/// [scaling a bitmap image]: ../struct.Scale.html#pixels-and-display-points
+/// [scaling a bitmap image]: crate::Scale#pixels-and-display-points
 /// [SVG files]: https://en.wikipedia.org/wiki/Scalable_Vector_Graphics
 pub struct Image {
     image_data: ImageBuf,

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -72,15 +72,7 @@ const LABEL_X_PADDING: f64 = 2.0;
 /// # let _ = SizedBox::<()>::new(important_label);
 /// ```
 ///
-/// [`ArcStr`]: ../type.ArcStr.html
-/// [`Data`]: ../trait.Data.html
-/// [`Env`]: ../struct.Env.html
-/// [`RawLabel`]: struct.RawLabel.html
-/// [`Label::raw`]: #method.raw
-/// [`LabelText`]: enum.LabelText.html
-/// [`LocalizedString`]: ../struct.LocalizedString.html
-/// [`draw_at`]: #method.draw_at
-/// [`Widget`]: ../trait.Widget.html
+/// [`draw_at`]: Label::draw_at
 pub struct Label<T> {
     label: RawLabel<ArcStr>,
     current_text: ArcStr,
@@ -118,10 +110,6 @@ pub enum LineBreaking {
 /// This can be one of three things; either an [`ArcStr`], a [`LocalizedString`],
 /// or a closure with the signature `Fn(&T, &Env) -> impl Into<ArcStr>`, where
 /// `T` is the `Data` at this point in the tree.
-///
-/// [`ArcStr`]: ../type.ArcStr.html
-/// [`LocalizedString`]: ../struct.LocalizedString.html
-/// [`Label`]: struct.Label.html
 #[derive(Clone)]
 pub enum LabelText<T> {
     /// Localized string that will be resolved through `Env`.
@@ -168,7 +156,7 @@ impl<T: TextStorage> RawLabel<T> {
     ///
     /// The argument can be either a `Color` or a [`Key<Color>`].
     ///
-    /// [`Key<Color>`]: ../struct.Key.html
+    /// [`Key<Color>`]: crate::Key
     pub fn with_text_color(mut self, color: impl Into<KeyOrValue<Color>>) -> Self {
         self.set_text_color(color);
         self
@@ -178,7 +166,7 @@ impl<T: TextStorage> RawLabel<T> {
     ///
     /// The argument can be either an `f64` or a [`Key<f64>`].
     ///
-    /// [`Key<f64>`]: ../struct.Key.html
+    /// [`Key<f64>`]: crate::Key
     pub fn with_text_size(mut self, size: impl Into<KeyOrValue<f64>>) -> Self {
         self.set_text_size(size);
         self
@@ -189,25 +177,19 @@ impl<T: TextStorage> RawLabel<T> {
     /// The argument can be a [`FontDescriptor`] or a [`Key<FontDescriptor>`]
     /// that refers to a font defined in the [`Env`].
     ///
-    /// [`Env`]: ../struct.Env.html
-    /// [`FontDescriptor`]: ../struct.FontDescriptor.html
-    /// [`Key<FontDescriptor>`]: ../struct.Key.html
+    /// [`Key<FontDescriptor>`]: crate::Key
     pub fn with_font(mut self, font: impl Into<KeyOrValue<FontDescriptor>>) -> Self {
         self.set_font(font);
         self
     }
 
     /// Builder-style method to set the [`LineBreaking`] behaviour.
-    ///
-    /// [`LineBreaking`]: enum.LineBreaking.html
     pub fn with_line_break_mode(mut self, mode: LineBreaking) -> Self {
         self.set_line_break_mode(mode);
         self
     }
 
     /// Builder-style method to set the [`TextAlignment`].
-    ///
-    /// [`TextAlignment`]: enum.TextAlignment.html
     pub fn with_text_alignment(mut self, alignment: TextAlignment) -> Self {
         self.set_text_alignment(alignment);
         self
@@ -220,8 +202,8 @@ impl<T: TextStorage> RawLabel<T> {
     /// If you change this property, you are responsible for calling
     /// [`request_layout`] to ensure the label is updated.
     ///
-    /// [`request_layout`]: ../struct.EventCtx.html#method.request_layout
-    /// [`Key<Color>`]: ../struct.Key.html
+    /// [`request_layout`]: EventCtx::request_layout
+    /// [`Key<Color>`]: crate::Key
     pub fn set_text_color(&mut self, color: impl Into<KeyOrValue<Color>>) {
         let color = color.into();
         if !self.disabled {
@@ -237,8 +219,8 @@ impl<T: TextStorage> RawLabel<T> {
     /// If you change this property, you are responsible for calling
     /// [`request_layout`] to ensure the label is updated.
     ///
-    /// [`request_layout`]: ../struct.EventCtx.html#method.request_layout
-    /// [`Key<f64>`]: ../struct.Key.html
+    /// [`request_layout`]: EventCtx::request_layout
+    /// [`Key<f64>`]: crate::Key
     pub fn set_text_size(&mut self, size: impl Into<KeyOrValue<f64>>) {
         self.layout.set_text_size(size);
     }
@@ -251,10 +233,8 @@ impl<T: TextStorage> RawLabel<T> {
     /// If you change this property, you are responsible for calling
     /// [`request_layout`] to ensure the label is updated.
     ///
-    /// [`request_layout`]: ../struct.EventCtx.html#method.request_layout
-    /// [`Env`]: ../struct.Env.html
-    /// [`FontDescriptor`]: ../struct.FontDescriptor.html
-    /// [`Key<FontDescriptor>`]: ../struct.Key.html
+    /// [`request_layout`]: EventCtx::request_layout
+    /// [`Key<FontDescriptor>`]: crate::Key
     pub fn set_font(&mut self, font: impl Into<KeyOrValue<FontDescriptor>>) {
         self.layout.set_font(font);
     }
@@ -264,15 +244,12 @@ impl<T: TextStorage> RawLabel<T> {
     /// If you change this property, you are responsible for calling
     /// [`request_layout`] to ensure the label is updated.
     ///
-    /// [`request_layout`]: ../struct.EventCtx.html#method.request_layout
-    /// [`LineBreaking`]: enum.LineBreaking.html
+    /// [`request_layout`]: EventCtx::request_layout
     pub fn set_line_break_mode(&mut self, mode: LineBreaking) {
         self.line_break_mode = mode;
     }
 
     /// Set the [`TextAlignment`] for this layout.
-    ///
-    /// [`TextAlignment`]: enum.TextAlignment.html
     pub fn set_text_alignment(&mut self, alignment: TextAlignment) {
         self.layout.set_text_alignment(alignment);
     }
@@ -349,7 +326,7 @@ impl<T: Data> Label<T> {
     /// let label2: Label<u32> = Label::dynamic(|data, _| format!("total is {}", data));
     /// ```
     ///
-    /// [`new`]: #method.new
+    /// [`new`]: Label::new
     pub fn dynamic(text: impl Fn(&T, &Env) -> String + 'static) -> Self {
         let text: LabelText<T> = text.into();
         Label::new(text)
@@ -368,8 +345,8 @@ impl<T: Data> Label<T> {
     /// is called in order to correctly recompute the text. If you are unsure,
     /// call [`request_update`] explicitly.
     ///
-    /// [`update`]: ../trait.Widget.html#tymethod.update
-    /// [`request_update`]: ../struct.EventCtx.html#method.request_update
+    /// [`update`]: Widget::update
+    /// [`request_update`]: EventCtx::request_update
     pub fn set_text(&mut self, text: impl Into<LabelText<T>>) {
         self.text = text.into();
         self.text_should_be_updated = true;
@@ -379,7 +356,7 @@ impl<T: Data> Label<T> {
     ///
     /// The argument can be either a `Color` or a [`Key<Color>`].
     ///
-    /// [`Key<Color>`]: ../struct.Key.html
+    /// [`Key<Color>`]: crate::Key
     pub fn with_text_color(mut self, color: impl Into<KeyOrValue<Color>>) -> Self {
         self.label.set_text_color(color);
         self
@@ -389,7 +366,7 @@ impl<T: Data> Label<T> {
     ///
     /// The argument can be either an `f64` or a [`Key<f64>`].
     ///
-    /// [`Key<f64>`]: ../struct.Key.html
+    /// [`Key<f64>`]: crate::Key
     pub fn with_text_size(mut self, size: impl Into<KeyOrValue<f64>>) -> Self {
         self.label.set_text_size(size);
         self
@@ -400,25 +377,19 @@ impl<T: Data> Label<T> {
     /// The argument can be a [`FontDescriptor`] or a [`Key<FontDescriptor>`]
     /// that refers to a font defined in the [`Env`].
     ///
-    /// [`Env`]: ../struct.Env.html
-    /// [`FontDescriptor`]: ../struct.FontDescriptor.html
-    /// [`Key<FontDescriptor>`]: ../struct.Key.html
+    /// [`Key<FontDescriptor>`]: crate::Key
     pub fn with_font(mut self, font: impl Into<KeyOrValue<FontDescriptor>>) -> Self {
         self.label.set_font(font);
         self
     }
 
     /// Builder-style method to set the [`LineBreaking`] behaviour.
-    ///
-    /// [`LineBreaking`]: enum.LineBreaking.html
     pub fn with_line_break_mode(mut self, mode: LineBreaking) -> Self {
         self.label.set_line_break_mode(mode);
         self
     }
 
     /// Builder-style method to set the [`TextAlignment`].
-    ///
-    /// [`TextAlignment`]: enum.TextAlignment.html
     pub fn with_text_alignment(mut self, alignment: TextAlignment) -> Self {
         self.label.set_text_alignment(alignment);
         self

--- a/druid/src/widget/lens_wrap.rs
+++ b/druid/src/widget/lens_wrap.rs
@@ -13,10 +13,6 @@
 // limitations under the License.
 
 //! A [`Widget`] that uses a [`Lens`] to change the [`Data`] of its child.
-//!
-//! [`Widget`]: ../trait.Widget.html
-//! [`Lens`]: ../trait.Lens.html
-//! [`Data`]: ../trait.Data.html
 
 use std::marker::PhantomData;
 
@@ -45,8 +41,6 @@ use tracing::{instrument, trace};
 ///
 /// This wrapper takes a [`Lens`] as an argument, which is a specification
 /// of a struct field, or some other way of narrowing the scope.
-///
-/// [`Lens`]: trait.Lens.html
 pub struct LensWrap<T, U, L, W> {
     child: W,
     lens: L,

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -113,26 +113,29 @@ pub use widget_ext::WidgetExt;
 pub use widget_wrapper::WidgetWrapper;
 pub use z_stack::ZStack;
 
-/// The types required to implement a `Widget`.
+/// The types required to implement a [`Widget`].
 ///
 /// # Structs
-/// [`BoxConstraints`](../../struct.BoxConstraints.html)\
-/// [`Env`](../../struct.Env.html)\
-/// [`EventCtx`](../../struct.EventCtx.html)\
-/// [`LayoutCtx`](../../struct.LayoutCtx.html)\
-/// [`LifeCycleCtx`](../../struct.LifeCycleCtx.html)\
-/// [`PaintCtx`](../../struct.PaintCtx.html)\
-/// [`Size`](../../struct.Size.html)\
-/// [`UpdateCtx`](../../struct.UpdateCtx.html)\
-/// [`WidgetId`](../../struct.WidgetId.html)\
+/// [`BoxConstraints`](crate::BoxConstraints)\
+/// [`Env`](crate::Env)\
+/// [`EventCtx`](crate::EventCtx)\
+/// [`LayoutCtx`](crate::LayoutCtx)\
+/// [`LifeCycleCtx`](crate::LifeCycleCtx)\
+/// [`PaintCtx`](crate::PaintCtx)\
+/// [`Size`](crate::Size)\
+/// [`UpdateCtx`](crate::UpdateCtx)\
+/// [`WidgetId`](crate::WidgetId)\
 ///
 /// # Enums
-/// [`Event`](../../enum.Event.html)\
-/// [`LifeCycle`](../../enum.LifeCycle.html)\
+/// [`Event`](crate::Event)\
+/// [`LifeCycle`](crate::LifeCycle)\
 ///
 /// # Traits
-/// [`RenderContext`](../../trait.RenderContext.html)\
-/// [`Widget`](../../trait.Widget.html)
+/// [`Data`](crate::Data)\
+/// [`RenderContext`](crate::RenderContext)\
+/// [`Widget`]
+///
+/// [`Widget`]: crate::Widget
 // NOTE: \ at the end works as a line break, but skip on last line!
 pub mod prelude {
     #[doc(hidden)]

--- a/druid/src/widget/painter.rs
+++ b/druid/src/widget/painter.rs
@@ -72,10 +72,9 @@ use tracing::instrument;
 /// });
 /// ```
 ///
-/// [`paint`]: ../trait.Widget.html#tymethod.paint
-/// [`Data`]: ../trait.Data.html
-/// [`request_paint`]: ../EventCtx.html#method.request_paint
-/// [`Controller`]: trait.Controller.html
+/// [`paint`]: Widget::paint
+/// [`request_paint`]: EventCtx::request_paint
+/// [`Controller`]: super::Controller
 pub struct Painter<T>(Box<dyn FnMut(&mut PaintCtx, &T, &Env)>);
 
 /// Something that can be used as the background for a widget.
@@ -83,9 +82,7 @@ pub struct Painter<T>(Box<dyn FnMut(&mut PaintCtx, &T, &Env)>);
 /// This represents anything that can be painted inside a widgets [`paint`]
 /// method; that is, it may have access to the [`Data`] and the [`Env`].
 ///
-/// [`paint`]: ../trait.Widget.html#tymethod.paint
-/// [`Data`]: ../trait.Data.html
-/// [`Env`]: ../struct.Env.html
+/// [`paint`]: Widget::paint
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub enum BackgroundBrush<T> {
@@ -100,7 +97,7 @@ pub enum BackgroundBrush<T> {
 impl<T> Painter<T> {
     /// Create a new `Painter` with the provided [`paint`] fn.
     ///
-    /// [`paint`]: ../trait.Widget.html#tymethod.paint
+    /// [`paint`]: Widget::paint
     pub fn new(f: impl FnMut(&mut PaintCtx, &T, &Env) + 'static) -> Self {
         Painter(Box::new(f))
     }
@@ -119,8 +116,6 @@ impl<T: Data> BackgroundBrush<T> {
     }
 
     /// Draw this `BackgroundBrush` into a provided [`PaintCtx`].
-    ///
-    /// [`PaintCtx`]: ../struct.PaintCtx.html
     pub fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         let bounds = ctx.size().to_rect();
         match self {

--- a/druid/src/widget/spinner.rs
+++ b/druid/src/widget/spinner.rs
@@ -26,7 +26,7 @@ use druid::{theme, Color, Data, KeyOrValue, Point, Vec2};
 /// To customize the spinner's size, you can place it inside a [`SizedBox`]
 /// that has a fixed width and height.
 ///
-/// [`SizedBox`]: struct.SizedBox.html
+/// [`SizedBox`]: super::SizedBox
 pub struct Spinner {
     t: f64,
     color: KeyOrValue<Color>,
@@ -40,9 +40,9 @@ impl Spinner {
 
     /// Builder-style method for setting the spinner's color.
     ///
-    /// The argument can be either a `Color` or a [`Key<Color>`].
+    /// The argument can be either a [`Color`] or a [`Key<Color>`].
     ///
-    /// [`Key<Color>`]: ../struct.Key.html
+    /// [`Key<Color>`]: crate::Key
     pub fn with_color(mut self, color: impl Into<KeyOrValue<Color>>) -> Self {
         self.color = color.into();
         self
@@ -50,9 +50,9 @@ impl Spinner {
 
     /// Set the spinner's color.
     ///
-    /// The argument can be either a `Color` or a [`Key<Color>`].
+    /// The argument can be either a [`Color`] or a [`Key<Color>`].
     ///
-    /// [`Key<Color>`]: ../struct.Key.html
+    /// [`Key<Color>`]: crate::Key
     pub fn set_color(&mut self, color: impl Into<KeyOrValue<Color>>) {
         self.color = color.into();
     }

--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -23,17 +23,6 @@ use crate::piet::{ImageBuf, ImageFormat, InterpolationMode};
 use crate::widget::prelude::*;
 use crate::{Rect, ScaledArea};
 
-#[allow(dead_code)]
-pub fn new(data: impl Into<Arc<Tree>>) -> Svg {
-    Svg::new(data.into())
-}
-
-#[allow(dead_code)]
-pub fn from_str(s: &str) -> Result<SvgData, <SvgData as std::str::FromStr>::Err> {
-    use std::str::FromStr;
-    SvgData::from_str(s)
-}
-
 /// A widget that renders a SVG
 pub struct Svg {
     tree: Arc<Tree>,
@@ -54,6 +43,7 @@ impl Svg {
         }
     }
 
+    /// Rasterize the SVG into the specified size in pixels.
     fn render(&self, size_px: Size) -> Option<ImageBuf> {
         let fit = usvg::FitTo::Size(size_px.width as u32, size_px.height as u32);
         let mut pixmap =
@@ -133,6 +123,7 @@ pub struct SvgData {
 }
 
 impl SvgData {
+    /// Create a new SVG
     fn new(tree: Arc<Tree>) -> Self {
         Self { tree }
     }

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -53,7 +53,7 @@ const SCROLL_TO_INSETS: Insets = Insets::uniform_xy(40.0, 0.0);
 /// [`Formatter`]. You can create a [`ValueTextBox`] by passing the appropriate
 /// [`Formatter`] to [`TextBox::with_formatter`].
 ///
-/// [`Formatter`]: crate::text::format::Formatter
+/// [`Formatter`]: crate::text::Formatter
 /// [`ValueTextBox`]: super::ValueTextBox
 pub struct TextBox<T> {
     placeholder_text: LabelText<T>,
@@ -226,7 +226,7 @@ impl<T> TextBox<T> {
     ///     .with_text_size(FONT_SIZE)
     ///     .lens(AppState::name);
     /// ```
-    /// [`Key<f64>`]: ../struct.Key.html
+    /// [`Key<f64>`]: crate::Key
     pub fn with_text_size(mut self, size: impl Into<KeyOrValue<f64>>) -> Self {
         self.set_text_size(size);
         self
@@ -264,8 +264,7 @@ impl<T> TextBox<T> {
     ///     .lens(AppState::name);
     /// ```
     ///
-    /// [`TextAlignment`]: enum.TextAlignment.html
-    /// [`multiline`]: #method.multiline
+    /// [`multiline`]: TextBox::multiline
     pub fn with_text_alignment(mut self, alignment: TextAlignment) -> Self {
         self.set_text_alignment(alignment);
         self
@@ -300,9 +299,7 @@ impl<T> TextBox<T> {
     /// ```
     ///
     ///
-    /// [`Env`]: ../struct.Env.html
-    /// [`FontDescriptor`]: ../struct.FontDescriptor.html
-    /// [`Key<FontDescriptor>`]: ../struct.Key.html
+    /// [`Key<FontDescriptor>`]: crate::Key
     pub fn with_font(mut self, font: impl Into<KeyOrValue<FontDescriptor>>) -> Self {
         self.set_font(font);
         self
@@ -332,7 +329,8 @@ impl<T> TextBox<T> {
     ///     .with_text_color(COLOR)
     ///     .lens(AppState::name);
     /// ```
-    /// [`Key<Color>`]: ../struct.Key.html
+    ///
+    /// [`Key<Color>`]: crate::Key
     pub fn with_text_color(mut self, color: impl Into<KeyOrValue<Color>>) -> Self {
         self.set_text_color(color);
         self
@@ -342,7 +340,7 @@ impl<T> TextBox<T> {
     ///
     /// The argument can be either an `f64` or a [`Key<f64>`].
     ///
-    /// [`Key<f64>`]: ../struct.Key.html
+    /// [`Key<f64>`]: crate::Key
     pub fn set_text_size(&mut self, size: impl Into<KeyOrValue<f64>>) {
         if !self.text().can_write() {
             tracing::warn!("set_text_size called with IME lock held.");
@@ -362,9 +360,7 @@ impl<T> TextBox<T> {
     /// The argument can be a [`FontDescriptor`] or a [`Key<FontDescriptor>`]
     /// that refers to a font defined in the [`Env`].
     ///
-    /// [`Env`]: ../struct.Env.html
-    /// [`FontDescriptor`]: ../struct.FontDescriptor.html
-    /// [`Key<FontDescriptor>`]: ../struct.Key.html
+    /// [`Key<FontDescriptor>`]: crate::Key
     pub fn set_font(&mut self, font: impl Into<KeyOrValue<FontDescriptor>>) {
         if !self.text().can_write() {
             tracing::warn!("set_font called with IME lock held.");
@@ -391,8 +387,7 @@ impl<T> TextBox<T> {
     /// This should be considered a bug, but it will not be fixed until proper
     /// BiDi support is implemented.
     ///
-    /// [`TextAlignment`]: enum.TextAlignment.html
-    /// [`multiline`]: #method.multiline
+    /// [`multiline`]: TextBox::multiline
     pub fn set_text_alignment(&mut self, alignment: TextAlignment) {
         if !self.text().can_write() {
             tracing::warn!("set_text_alignment called with IME lock held.");
@@ -408,8 +403,8 @@ impl<T> TextBox<T> {
     /// If you change this property, you are responsible for calling
     /// [`request_layout`] to ensure the label is updated.
     ///
-    /// [`request_layout`]: ../struct.EventCtx.html#method.request_layout
-    /// [`Key<Color>`]: ../struct.Key.html
+    /// [`request_layout`]: EventCtx::request_layout
+    /// [`Key<Color>`]: crate::Key
     pub fn set_text_color(&mut self, color: impl Into<KeyOrValue<Color>>) {
         if !self.text().can_write() {
             tracing::warn!("set_text_color called with IME lock held.");

--- a/druid/src/widget/value_textbox.rs
+++ b/druid/src/widget/value_textbox.rs
@@ -88,9 +88,8 @@ impl TextBox<String> {
     ///
     /// For simple value formatting, you can use the [`ParseFormatter`].
     ///
-    /// [`ValueTextBox`]: ValueTextBox
-    /// [`Formatter`]: crate::text::format::Formatter
-    /// [`ParseFormatter`]: crate::text::format::ParseFormatter
+    /// [`Formatter`]: crate::text::Formatter
+    /// [`ParseFormatter`]: crate::text::ParseFormatter
     pub fn with_formatter<T: Data>(
         self,
         formatter: impl Formatter<T> + 'static,
@@ -102,8 +101,8 @@ impl TextBox<String> {
 impl<T: Data> ValueTextBox<T> {
     /// Create a new `ValueTextBox` from a normal [`TextBox`] and a [`Formatter`].
     ///
-    /// [`TextBox`]: crate::widget::TextBox
-    /// [`Formatter`]: crate::text::format::Formatter
+    /// [`TextBox`]: super::TextBox
+    /// [`Formatter`]: crate::text::Formatter
     pub fn new(mut child: TextBox<String>, formatter: impl Formatter<T> + 'static) -> Self {
         child.text_mut().borrow_mut().send_notification_on_return = true;
         child.text_mut().borrow_mut().send_notification_on_cancel = true;

--- a/druid/src/widget/widget.rs
+++ b/druid/src/widget/widget.rs
@@ -41,13 +41,10 @@ use crate::widget::Axis;
 /// is unique in time. That is: only one widget can exist with a given id at a
 /// given time.
 ///
-/// [`Widget`]: trait.Widget.html
-/// [`EventCtx::submit_command`]: struct.EventCtx.html#method.submit_command
-/// [`Target`]: enum.Target.html
-/// [`WidgetPod`]: struct.WidgetPod.html
-/// [`LifeCycleCtx::widget_id`]: struct.LifeCycleCtx.html#method.widget_id
-/// [`WidgetExt::with_id`]: trait.WidgetExt.html#method.with_id
-/// [`IdentityWrapper`]: widget/struct.IdentityWrapper.html
+/// [`Target`]: crate::Target
+/// [`WidgetPod`]: crate::WidgetPod
+/// [`WidgetExt::with_id`]: super::WidgetExt::with_id
+/// [`IdentityWrapper`]: super::IdentityWrapper
 // this is NonZeroU64 because we regularly store Option<WidgetId>
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct WidgetId(NonZeroU64);
@@ -86,11 +83,9 @@ pub struct WidgetId(NonZeroU64);
 /// `WidgetPod` method on all their children. The `WidgetPod` applies
 /// logic to determine whether to recurse, as needed.
 ///
-/// [`event`]: #tymethod.event
-/// [`update`]: #tymethod.update
-/// [`Data`]: trait.Data.html
-/// [`Env`]: struct.Env.html
-/// [`WidgetPod`]: struct.WidgetPod.html
+/// [`event`]: Widget::event
+/// [`update`]: Widget::update
+/// [`WidgetPod`]: crate::WidgetPod
 pub trait Widget<T> {
     /// Handle an event.
     ///
@@ -99,9 +94,7 @@ pub trait Widget<T> {
     /// requesting things from the [`EventCtx`], mutating the data, or submitting
     /// a [`Command`].
     ///
-    /// [`Event`]: enum.Event.html
-    /// [`EventCtx`]: struct.EventCtx.html
-    /// [`Command`]: struct.Command.html
+    /// [`Command`]: crate::Command
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env);
 
     /// Handle a life cycle notification.
@@ -115,9 +108,7 @@ pub trait Widget<T> {
     /// if a widget needs to mutate data, it can submit a [`Command`] that will
     /// be executed at the next opportunity.
     ///
-    /// [`LifeCycle`]: enum.LifeCycle.html
-    /// [`LifeCycleCtx`]: struct.LifeCycleCtx.html
-    /// [`Command`]: struct.Command.html
+    /// [`Command`]: crate::Command
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env);
 
     /// Update the widget's appearance in response to a change in the app's
@@ -138,15 +129,12 @@ pub trait Widget<T> {
     /// with any keys that are used in your widget, to see if they have changed;
     /// you can then request layout or paint as needed.
     ///
-    /// [`Data`]: trait.Data.html
-    /// [`Env`]: struct.Env.html
-    /// [`UpdateCtx`]: struct.UpdateCtx.html
-    /// [`env_changed`]: struct.UpdateCtx.html#method.env_changed
-    /// [`env_key_changed`]: struct.UpdateCtx.html#method.env_changed
-    /// [`request_paint`]: struct.UpdateCtx.html#method.request_paint
-    /// [`request_layout`]: struct.UpdateCtx.html#method.request_layout
-    /// [`layout`]: #tymethod.layout
-    /// [`paint`]: #tymethod.paint
+    /// [`env_changed`]: UpdateCtx::env_changed
+    /// [`env_key_changed`]: UpdateCtx::env_key_changed
+    /// [`request_paint`]: UpdateCtx::request_paint
+    /// [`request_layout`]: UpdateCtx::request_layout
+    /// [`layout`]: Widget::layout
+    /// [`paint`]: Widget::paint
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env);
 
     /// Compute layout.
@@ -167,8 +155,8 @@ pub trait Widget<T> {
     ///
     /// The layout strategy is strongly inspired by Flutter.
     ///
-    /// [`WidgetPod::layout`]: struct.WidgetPod.html#method.layout
-    /// [`set_origin`]: struct.WidgetPod.html#method.set_origin
+    /// [`WidgetPod::layout`]: crate::WidgetPod::layout
+    /// [`set_origin`]: crate::WidgetPod::set_origin
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size;
 
     /// Paint the widget appearance.
@@ -181,9 +169,6 @@ pub trait Widget<T> {
     /// children, or annotations (for example, scrollbars) by painting
     /// afterwards. In addition, they can apply masks and transforms on
     /// the render context, which is especially useful for scrolling.
-    ///
-    /// [`PaintCtx`]: struct.PaintCtx.html
-    /// [`RenderContext`]: trait.RenderContext.html
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env);
 
     #[doc(hidden)]

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -34,63 +34,46 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     /// a [`Key`] referring to [`Insets`] in the [`Env`].
     ///
     /// [`Key`]: crate::Key
-    /// [`Insets`]: crate::Insets
     fn padding(self, insets: impl Into<KeyOrValue<Insets>>) -> Padding<T, Self> {
         Padding::new(insets, self)
     }
 
     /// Wrap this widget in an [`Align`] widget, configured to center it.
-    ///
-    /// [`Align`]: widget/struct.Align.html
     fn center(self) -> Align<T> {
         Align::centered(self)
     }
 
     /// Wrap this widget in an [`Align`] widget, configured to align left.
-    ///
-    /// [`Align`]: widget/struct.Align.html
     fn align_left(self) -> Align<T> {
         Align::left(self)
     }
 
     /// Wrap this widget in an [`Align`] widget, configured to align right.
-    ///
-    /// [`Align`]: widget/struct.Align.html
     fn align_right(self) -> Align<T> {
         Align::right(self)
     }
 
     /// Wrap this widget in an [`Align`] widget, configured to align vertically.
-    ///
-    /// [`Align`]: widget/struct.Align.html
     fn align_vertical(self, align: UnitPoint) -> Align<T> {
         Align::vertical(align, self)
     }
 
     /// Wrap this widget in an [`Align`] widget, configured to align horizontally.
-    ///
-    /// [`Align`]: widget/struct.Align.html
     fn align_horizontal(self, align: UnitPoint) -> Align<T> {
         Align::horizontal(align, self)
     }
 
     /// Wrap this widget in a [`SizedBox`] with an explicit width.
-    ///
-    /// [`SizedBox`]: widget/struct.SizedBox.html
     fn fix_width(self, width: impl Into<KeyOrValue<f64>>) -> SizedBox<T> {
         SizedBox::new(self).width(width)
     }
 
     /// Wrap this widget in a [`SizedBox`] with an explicit height.
-    ///
-    /// [`SizedBox`]: widget/struct.SizedBox.html
     fn fix_height(self, height: impl Into<KeyOrValue<f64>>) -> SizedBox<T> {
         SizedBox::new(self).height(height)
     }
 
     /// Wrap this widget in an [`SizedBox`] with an explicit width and height
-    ///
-    /// [`SizedBox`]: widget/struct.SizedBox.html
     fn fix_size(
         self,
         width: impl Into<KeyOrValue<f64>>,
@@ -105,9 +88,8 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     /// space. If you only care about expanding in one of width or height, use
     /// [`expand_width`] or [`expand_height`] instead.
     ///
-    /// [`expand_height`]: #method.expand_height
-    /// [`expand_width`]: #method.expand_width
-    /// [`SizedBox`]: widget/struct.SizedBox.html
+    /// [`expand_height`]: WidgetExt::expand_height
+    /// [`expand_width`]: WidgetExt::expand_width
     fn expand(self) -> SizedBox<T> {
         SizedBox::new(self).expand()
     }
@@ -115,8 +97,6 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     /// Wrap this widget in a [`SizedBox`] with an infinite width.
     ///
     /// This will force the child to use all available space on the x-axis.
-    ///
-    /// [`SizedBox`]: widget/struct.SizedBox.html
     fn expand_width(self) -> SizedBox<T> {
         SizedBox::new(self).expand_width()
     }
@@ -124,8 +104,6 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     /// Wrap this widget in a [`SizedBox`] with an infinite width.
     ///
     /// This will force the child to use all available space on the y-axis.
-    ///
-    /// [`SizedBox`]: widget/struct.SizedBox.html
     fn expand_height(self) -> SizedBox<T> {
         SizedBox::new(self).expand_height()
     }
@@ -133,9 +111,6 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     /// Wrap this widget in a [`Container`] with the provided `background`.
     ///
     /// See [`Container::background`] for more information.
-    ///
-    /// [`Container`]: widget/struct.Container.html
-    /// [`Container::background`]: widget/struct.Container.html#method.background
     fn background(self, brush: impl Into<BackgroundBrush<T>>) -> Container<T> {
         Container::new(self).background(brush)
     }
@@ -145,8 +120,7 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     /// Arguments can be either concrete values, or a [`Key`] of the respective
     /// type.
     ///
-    /// [`Container`]: widget/struct.Container.html
-    /// [`Key`]: struct.Key.html
+    /// [`Key`]: crate::Key
     fn border(
         self,
         color: impl Into<KeyOrValue<Color>>,
@@ -157,16 +131,11 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
 
     /// Wrap this widget in a [`EnvScope`] widget, modifying the parent
     /// [`Env`] with the provided closure.
-    ///
-    /// [`EnvScope`]: widget/struct.EnvScope.html
-    /// [`Env`]: struct.Env.html
     fn env_scope(self, f: impl Fn(&mut Env, &T) + 'static) -> EnvScope<T, Self> {
         EnvScope::new(f, self)
     }
 
     /// Wrap this widget with the provided [`Controller`].
-    ///
-    /// [`Controller`]: widget/trait.Controller.html
     fn controller<C: Controller<T, Self>>(self, controller: C) -> ControllerHost<Self, C> {
         ControllerHost::new(self, controller)
     }
@@ -194,8 +163,7 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     /// mouse down, which can be useful for painting based on `ctx.is_active()`
     /// and `ctx.is_hot()`.
     ///
-    /// [`Click`]: widget/struct.Click.html
-    /// [`LifeCycle::HotChanged`]: enum.LifeCycle.html#variant.HotChanged
+    /// [`LifeCycle::HotChanged`]: crate::LifeCycle::HotChanged
     fn on_click(
         self,
         f: impl Fn(&mut EventCtx, &mut T, &Env) + 'static,
@@ -205,7 +173,7 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
 
     /// Draw the [`layout`] `Rect`s of  this widget and its children.
     ///
-    /// [`layout`]: trait.Widget.html#tymethod.layout
+    /// [`layout`]: Widget::layout
     fn debug_paint_layout(self) -> EnvScope<T, Self> {
         EnvScope::new(|env, _| env.set(Env::DEBUG_PAINT, true), self)
     }
@@ -232,7 +200,7 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     /// This does nothing by default, but you can use this variable while
     /// debugging to only print messages from particular instances of a widget.
     ///
-    /// [`DEBUG_WIDGET`]: struct.Env.html#associatedconstant.DEBUG_WIDGET
+    /// [`DEBUG_WIDGET`]: crate::Env::DEBUG_WIDGET
     fn debug_widget(self) -> EnvScope<T, Self> {
         EnvScope::new(|env, _| env.set(Env::DEBUG_WIDGET, true), self)
     }
@@ -259,8 +227,6 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     ///
     /// An id _may_ be reused over time; for instance if you replace one
     /// widget with another, you may reuse the first widget's id.
-    ///
-    /// [`WidgetId`]: struct.WidgetId.html
     fn with_id(self, id: WidgetId) -> IdentityWrapper<Self> {
         IdentityWrapper::wrap(self, id)
     }
@@ -271,8 +237,6 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     }
 
     /// Wrap this widget in a [`Scroll`] widget.
-    ///
-    /// [`Scroll`]: widget/struct.Scroll.html
     fn scroll(self) -> Scroll<T, Self> {
         Scroll::new(self)
     }
@@ -282,9 +246,8 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     /// The provided closure will determine if the widget is disabled.
     /// See [`is_disabled`] or [`set_disabled`] for more info about disabled state.
     ///
-    /// [`is_disabled`]: crate::EventCtx::is_disabled
-    /// [`set_disabled`]: crate::EventCtx::set_disabled
-    /// [`DisabledIf`]: crate::widget::DisabledIf
+    /// [`is_disabled`]: EventCtx::is_disabled
+    /// [`set_disabled`]: EventCtx::set_disabled
     fn disabled_if(self, disabled_if: impl Fn(&T, &Env) -> bool + 'static) -> DisabledIf<T, Self> {
         DisabledIf::new(self, disabled_if)
     }


### PR DESCRIPTION
I went over all the documentation and fixed every broken link I could find. It's not perfect, there are still broken links that are caused by code that is not in this repo (`kurbo`, `piet`, `im`) but obviously those will need to be fixed elsewhere.

The strategy here was to resolve broken links by changing the URL link to a [rustdoc managed symbol based link](https://doc.rust-lang.org/rustdoc/write-documentation/linking-to-items-by-name.html). This method supports the link appearing at different levels of nesting (*which URL links never did*) and also has the benefit of sometimes being automatically detected when broken. Not every link was converted, but the remaining URL links still work.

Another thing to note is that when a symbol is in scope then the link doesn't have to be defined at all.
```rust
/// If the [`Widget`] trait is in scope, then that link will just work.
```