### PR TITLE
Remove `set_layout_rect` and fix deprecation declarations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ You can find its changes [documented below](#070---2021-01-01).
 ### Removed
 
 - Remove Default impl for `FlexParams` ([#1885] by [@Maan2003])
+- `WidgetPod::set_layout_rect` because it was deprecated and no longer doing what it claimed. ([#2340] by [@xStrom])
 
 ### Fixed
 
@@ -887,6 +888,7 @@ Last release without a changelog :(
 [#2324]: https://github.com/linebender/druid/pull/2324
 [#2331]: https://github.com/linebender/druid/pull/2331
 [#2335]: https://github.com/linebender/druid/pull/2335
+[#2340]: https://github.com/linebender/druid/pull/2340
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid-shell/src/mouse.rs
+++ b/druid-shell/src/mouse.rs
@@ -257,7 +257,10 @@ pub enum Cursor {
     Pointer,
     Crosshair,
 
-    #[deprecated(note = "this will be removed in future because it is not available on windows")]
+    #[deprecated(
+        since = "0.8.0",
+        note = "This will be removed because it is not available on Windows."
+    )]
     OpenHand,
     NotAllowed,
     ResizeLeftRight,

--- a/druid/examples/styled_text.rs
+++ b/druid/examples/styled_text.rs
@@ -17,8 +17,10 @@
 // On Windows platform, don't show a console when opening the app.
 #![windows_subsystem = "windows"]
 
+#[allow(deprecated)]
+use druid::widget::Parse;
 use druid::widget::{
-    Checkbox, CrossAxisAlignment, Flex, Label, LensWrap, MainAxisAlignment, Painter, Parse, Scroll,
+    Checkbox, CrossAxisAlignment, Flex, Label, LensWrap, MainAxisAlignment, Painter, Scroll,
     Stepper, TextBox,
 };
 use druid::{
@@ -126,6 +128,8 @@ fn ui_builder() -> impl Widget<AppData> {
         .with_wraparound(false)
         .lens(AppData::size);
 
+    // TODO: Replace Parse usage with TextBox::with_formatter
+    #[allow(deprecated)]
     let stepper_textbox = LensWrap::new(
         Parse::new(TextBox::new()),
         AppData::size.map(|x| Some(*x), |x, y| *x = y.unwrap_or(24.0)),

--- a/druid/examples/switches.rs
+++ b/druid/examples/switches.rs
@@ -17,8 +17,10 @@
 // On Windows platform, don't show a console when opening the app.
 #![windows_subsystem = "windows"]
 
+#[allow(deprecated)]
+use druid::widget::Parse;
 use druid::widget::{
-    Checkbox, Flex, Label, LensWrap, MainAxisAlignment, Padding, Parse, Stepper, Switch, TextBox,
+    Checkbox, Flex, Label, LensWrap, MainAxisAlignment, Padding, Stepper, Switch, TextBox,
     WidgetExt,
 };
 use druid::{AppLauncher, Data, Lens, LensExt, LocalizedString, Widget, WindowDesc};
@@ -49,6 +51,8 @@ fn build_widget() -> impl Widget<DemoState> {
     );
 
     let mut textbox_row = Flex::row();
+    // TODO: Replace Parse usage with TextBox::with_formatter
+    #[allow(deprecated)]
     let textbox = LensWrap::new(
         Parse::new(TextBox::new()),
         DemoState::stepper_value.map(|x| Some(*x), |x, y| *x = y.unwrap_or(0.0)),

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -177,7 +177,7 @@ impl<T: Data> AppLauncher<T> {
     /// # Panics
     ///
     /// Panics if the logger fails to initialize.
-    #[deprecated(since = "0.7.0", note = "Use log_to_console instead")]
+    #[deprecated(since = "0.8.0", note = "Use log_to_console instead")]
     pub fn use_simple_logger(self) -> Self {
         self.log_to_console()
     }

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -277,21 +277,9 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
         self.state.id
     }
 
-    /// This widget or any of its children has requested layout
+    /// This widget or any of its children have requested layout.
     pub fn layout_requested(&self) -> bool {
         self.state.needs_layout
-    }
-
-    /// Set the layout [`Rect`].
-    ///
-    /// This is soft-deprecated; you should use [`set_origin`] instead for new code.
-    ///
-    /// [`set_origin`]: WidgetPod::set_origin
-    pub fn set_layout_rect(&mut self, ctx: &mut LayoutCtx, layout_rect: Rect) {
-        if layout_rect.size() != self.state.size {
-            warn!("set_layout_rect passed different size than returned by layout method");
-        }
-        self.set_origin(ctx, layout_rect.origin());
     }
 
     /// Set the origin of this widget, in the parent's coordinate space.

--- a/druid/src/menu/mod.rs
+++ b/druid/src/menu/mod.rs
@@ -522,7 +522,7 @@ impl<T: Data> Menu<T> {
     }
 
     #[doc(hidden)]
-    #[deprecated(since = "0.8.0", note = "use entry instead")]
+    #[deprecated(since = "0.8.0", note = "use separator instead")]
     pub fn append_separator(self) -> Self {
         self.separator()
     }

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -88,6 +88,7 @@ pub use list::{List, ListIter};
 pub use maybe::Maybe;
 pub use padding::Padding;
 pub use painter::{BackgroundBrush, Painter};
+#[allow(deprecated)]
 pub use parse::Parse;
 pub use progress_bar::ProgressBar;
 pub use radio::{Radio, RadioGroup};

--- a/druid/src/widget/parse.rs
+++ b/druid/src/widget/parse.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// This whole widget was deprecated in Druid 0.7
+// https://github.com/linebender/druid/pull/1377
+#![allow(deprecated)]
+
 use std::fmt::Display;
 use std::mem;
 use std::str::FromStr;
@@ -22,6 +26,7 @@ use crate::widget::prelude::*;
 use crate::Data;
 
 /// Converts a `Widget<String>` to a `Widget<Option<T>>`, mapping parse errors to None
+#[deprecated(since = "0.7.0", note = "Use the Formatter trait instead")]
 pub struct Parse<T> {
     widget: T,
     state: String,

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -15,9 +15,11 @@
 //! Convenience methods for widgets.
 
 use super::invalidation::DebugInvalidation;
+#[allow(deprecated)]
+use super::Parse;
 use super::{
     Added, Align, BackgroundBrush, Click, Container, Controller, ControllerHost, EnvScope,
-    IdentityWrapper, LensWrap, Padding, Parse, SizedBox, WidgetId,
+    IdentityWrapper, LensWrap, Padding, SizedBox, WidgetId,
 };
 use crate::widget::{DisabledIf, Scroll};
 use crate::{
@@ -242,6 +244,7 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
 
     /// Parse a `Widget<String>`'s contents
     #[deprecated(since = "0.7.0", note = "Use TextBox::with_formatter instead")]
+    #[allow(deprecated)]
     fn parse(self) -> Parse<Self>
     where
         Self: Widget<String>,


### PR DESCRIPTION
`WidgetPod::set_layout_rect` has been *soft-deprecated* since #1289. Then #2149 changed its signature. I considered changing its signature back to the previous one and giving it a proper deprecation declaration. However looking at the code, it doesn't even set the widget's layout rect. So at this point the method has outlived its usefulness and should be removed.

`use_simple_logger` deprecation declaration was incorrectly claiming version 0.7, so I changed it to 0.8.

The `Parse` widget was deprecated way back in #1377 and even declared so in the changelog. However the struct never got a proper declaration. Better late than never.