### PR TITLE
Fix `ScrollComponent` not handling `LifeCycle::HotChanged`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@ You can find its changes [documented below](#070---2021-01-01).
 - X11: window focus events ([#1938] by [@Maan2003]
 - Preserve the aspect ratio of a clipped region in an Image ([#2195] by [@barsae])
 - GTK: Hot state now properly resets when the mouse leaves the window via an occluded part. ([#2324] by [@xStrom])
+- Scrollbars no longer remain permanently visible when the mouse leaves the window. ([#2343] by [@xStrom])
 
 ### Visual
 
@@ -892,6 +893,7 @@ Last release without a changelog :(
 [#2331]: https://github.com/linebender/druid/pull/2331
 [#2335]: https://github.com/linebender/druid/pull/2335
 [#2340]: https://github.com/linebender/druid/pull/2340
+[#2343]: https://github.com/linebender/druid/pull/2343
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.7.0...master
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -95,9 +95,11 @@ pub enum Event {
     /// Called when the mouse is moved.
     ///
     /// The `MouseMove` event is propagated to the active widget, if
-    /// there is one, otherwise to hot widgets (see `HotChanged`).
+    /// there is one, otherwise to hot widgets (see [`HotChanged`]).
     /// If a widget loses its hot status due to `MouseMove` then that specific
-    /// `MouseMove` event is also still sent to that widget.
+    /// `MouseMove` event is also still sent to that widget. However a widget
+    /// can lose its hot status even without a `MouseMove` event, so make
+    /// sure to also handle [`HotChanged`] if you care about the hot status.
     ///
     /// The `MouseMove` event is also the primary mechanism for widgets
     /// to set a cursor, for example to an I-bar inside a text widget. A
@@ -105,6 +107,7 @@ pub enum Event {
     /// [`set_cursor`] in the MouseMove handler, as `MouseMove` is only
     /// propagated to active or hot widgets.
     ///
+    /// [`HotChanged`]: LifeCycle::HotChanged
     /// [`set_cursor`]: struct.EventCtx.html#method.set_cursor
     MouseMove(MouseEvent),
     /// Called when the mouse wheel or trackpad is scrolled.
@@ -242,8 +245,8 @@ pub enum InternalEvent {
 ///
 /// Similarly the [`LifeCycle::Size`] method occurs during [`layout`], and
 /// [`LifeCycle::HotChanged`] can occur both during [`event`] (if the mouse
-/// moves over a widget) or during [`layout`], if a widget is resized and
-/// that moves it under the mouse.
+/// moves over a widget) or in response to [`LifeCycle::ViewContextChanged`],
+/// if a widget is moved away from under the mouse.
 ///
 /// [`event`]: crate::Widget::event
 /// [`update`]: crate::Widget::update

--- a/druid/src/scroll_component.rs
+++ b/druid/src/scroll_component.rs
@@ -509,9 +509,18 @@ impl ScrollComponent {
     ///
     /// Make sure to call on every lifecycle event
     pub fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, env: &Env) {
-        if let LifeCycle::Size(_) = event {
-            // Show the scrollbars any time our size changes
-            self.reset_scrollbar_fade(|d| ctx.request_timer(d), env);
+        match event {
+            LifeCycle::Size(_) => {
+                // Show the scrollbars any time our size changes
+                self.reset_scrollbar_fade(|d| ctx.request_timer(d), env);
+            }
+            LifeCycle::HotChanged(false) => {
+                if self.hovered.is_hovered() {
+                    self.hovered = BarHoveredState::None;
+                    self.reset_scrollbar_fade(|d| ctx.request_timer(d), env);
+                }
+            }
+            _ => (),
         }
     }
 }


### PR DESCRIPTION
This PR adds `LifeCycle::HotChanged` handling to `ScrollComponent` which allows it to hide the scroll bars when the widget loses hot state but doesn't receive any `MouseMove` events that would confirm this. This bug was hidden on GTK thanks to #552 but revealed again due to #2324.

The fix can be seen in action with the `scroll_colors` example as seen below:

![before_leave](https://user-images.githubusercontent.com/30666851/74542915-81912480-4f12-11ea-8b39-a085c1283d83.gif)
![after_leave](https://user-images.githubusercontent.com/30666851/74542920-83f37e80-4f12-11ea-89ef-78ab994fb9b5.gif)