### PR TITLE
Update Piet to v0.6.1.

### DIFF
--- a/druid-derive/Cargo.toml
+++ b/druid-derive/Cargo.toml
@@ -17,7 +17,7 @@ default-target = "x86_64-pc-windows-msvc"
 [dependencies]
 syn = "1.0.107"
 quote = "1.0.23"
-proc-macro2 = "1.0.49"
+proc-macro2 = "1.0.50"
 
 [dev-dependencies]
 druid = { version = "0.7.0", path = "../druid" }

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -63,7 +63,7 @@ serde = ["kurbo/serde"]
 [dependencies]
 # NOTE: When changing the piet or kurbo versions, ensure that
 #       the kurbo version included in piet is compatible with the kurbo version specified here.
-piet-common = "0.6.0"
+piet-common = "0.6.1"
 kurbo = "0.9.0"
 
 tracing = "0.1.37"
@@ -127,7 +127,7 @@ version = "0.3.60"
 features = ["Window", "MouseEvent", "CssStyleDeclaration", "WheelEvent", "KeyEvent", "KeyboardEvent", "Navigator"]
 
 [dev-dependencies]
-piet-common = { version = "0.6.0", features = ["png"] }
+piet-common = { version = "0.6.1", features = ["png"] }
 static_assertions = "1.1.0"
 test-log = { version = "0.2.11", features = ["trace"], default-features = false }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -71,7 +71,7 @@ instant = { version = "0.1.12", features = ["wasm-bindgen"] }
 # Optional dependencies
 chrono = { version = "0.4.23", optional = true }
 im = { version = "15.1.0", optional = true }
-resvg = { version = "0.25.0", optional = true }
+resvg = { version = "0.25.0", optional = true } # When updating, make sure it doesn't pin a specific `png` crate, see druid#2345
 usvg =  { version = "0.25.0", optional = true }
 tiny-skia = { version = "0.8.2", optional = true }
 

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -71,8 +71,8 @@ instant = { version = "0.1.12", features = ["wasm-bindgen"] }
 # Optional dependencies
 chrono = { version = "0.4.23", optional = true }
 im = { version = "15.1.0", optional = true }
-resvg = { version = "0.28.0", optional = true }
-usvg =  { version = "0.28.0", optional = true }
+resvg = { version = "0.25.0", optional = true }
+usvg =  { version = "0.25.0", optional = true }
 tiny-skia = { version = "0.8.2", optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
@@ -82,7 +82,7 @@ console_error_panic_hook = { version = "0.1.7" }
 [dev-dependencies]
 float-cmp = { version = "0.9.0", features = ["std"], default-features = false }
 tempfile = "3.3.0"
-piet-common = { version = "0.6.0", features = ["png"] }
+piet-common = { version = "0.6.1", features = ["png"] }
 pulldown-cmark = { version = "0.8.0", default-features = false }
 test-log = { version = "0.2.11", features = ["trace"], default-features = false }
 # test-env-log needs it

--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -152,7 +152,7 @@ impl std::str::FromStr for SvgData {
             ..usvg::Options::default()
         };
 
-        match Tree::from_str(svg_str, &re_opt) {
+        match Tree::from_str(svg_str, &re_opt.to_ref()) {
             Ok(tree) => Ok(SvgData::new(Arc::new(tree))),
             Err(err) => Err(err.into()),
         }


### PR DESCRIPTION
Piet v0.6.1 comes with lots of documentation fixes, which is good for us because we embed it in the Druid docs.

Interestingly this revealed a bad actor in our dependency graph. The `resvg` crate pins `png` to `=0.17.6`. The way cargo works, this means that no other crate that Druid uses, or even any project that uses Druid can use any other semver compatible `png` version.

```
error: failed to select a version for `png`.
    ... required by package `piet-common v0.6.1`
    ... which satisfies dependency `piet-common = "^0.6.1"` of package `druid v0.7.0`
    ... which satisfies path dependency `druid` (locked to 0.7.0) of package `book_examples v0.1.0`
versions that meet the requirements `^0.17.7` are: 0.17.7

all possible versions conflict with previously selected packages.

  previously selected package `png v0.17.6`
    ... which satisfies dependency `png = "=0.17.6"` of package `resvg v0.28.0`
    ... which satisfies dependency `resvg = "^0.28.0"` of package `druid v0.7.0`
    ... which satisfies path dependency `druid` (locked to 0.7.0) of package `book_examples v0.1.0`

failed to select a version for `png` which could resolve this conflict
```

Thus I think the solution here is to revert back to `resvg` v0.25 which is just a few months older, but has a much saner `png` dependency of `^0.17`. This issue has been brought to the attention of `resvg` in [resvg#571](https://github.com/RazrFalcon/resvg/issues/571) where they confirm their intention to change this in the future. For now I don't think we should propagate that pin to all projects depending on Druid. No bug fixes to `png` (e.g. v0.17.8) would reach apps using `druid` that way.