### PR TITLE
Fix crates.io `README.md` selection and prep v0.8.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-The latest published Druid release is [0.8.0](#080---2023-01-27) which was released on 2023-01-27.
-You can find its changes [documented below](#080---2023-01-27).
+The latest published Druid release is [0.8.1](#081---2023-01-27) which was released on 2023-01-27.
+You can find its changes [documented below](#081---2023-01-27).
 
 ## [Unreleased]
 
@@ -26,6 +26,12 @@ You can find its changes [documented below](#080---2023-01-27).
 ### Maintenance
 
 ### Outside News
+
+## [0.8.1] - 2023-01-27
+
+### Docs
+
+- Fixed `README.md` selection for crates.io. ([#2347] by [@xStrom])
 
 ## [0.8.0] - 2023-01-27
 
@@ -1178,8 +1184,10 @@ Last release without a changelog :(
 [#2340]: https://github.com/linebender/druid/pull/2340
 [#2343]: https://github.com/linebender/druid/pull/2343
 [#2345]: https://github.com/linebender/druid/pull/2345
+[#2347]: https://github.com/linebender/druid/pull/2347
 
-[Unreleased]: https://github.com/linebender/druid/compare/v0.8.0...master
+[Unreleased]: https://github.com/linebender/druid/compare/v0.8.1...master
+[0.8.1]: https://github.com/linebender/druid/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/linebender/druid/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/linebender/druid/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/linebender/druid/compare/v0.5.0...v0.6.0

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ a lone dependency (it re-exports all the parts of `druid-shell`, `piet`, and `ku
 that you'll need):
 
 ```toml
-druid = "0.8.0"
+druid = "0.8.1"
 ```
 
 Since Druid is currently in fast-evolving state, you might prefer to drink from
@@ -322,14 +322,14 @@ active and friendly community. See the AUTHORS file for more.
 [Zulip chat instance]: https://xi.zulipchat.com
 [non-`druid` examples]: /druid-shell/examples/shello.rs
 [crates.io]: https://crates.io/crates/druid
-[EventCtx]: https://docs.rs/druid/0.8.0/druid/struct.EventCtx.html
-[LifeCycleCtx]: https://docs.rs/druid/0.8.0/druid/struct.LifeCycleCtx.html
-[LayoutCtx]: https://docs.rs/druid/0.8.0/druid/struct.LayoutCtx.html
-[PaintCtx]: https://docs.rs/druid/0.8.0/druid/struct.PaintCtx.html
-[UpdateCtx]: https://docs.rs/druid/0.8.0/druid/struct.UpdateCtx.html
-[Widget trait]: https://docs.rs/druid/0.8.0/druid/trait.Widget.html
-[Data trait]: https://docs.rs/druid/0.8.0/druid/trait.Data.html
-[Lens datatype]: https://docs.rs/druid/0.8.0/druid/trait.Lens.html
+[EventCtx]: https://docs.rs/druid/0.8.1/druid/struct.EventCtx.html
+[LifeCycleCtx]: https://docs.rs/druid/0.8.1/druid/struct.LifeCycleCtx.html
+[LayoutCtx]: https://docs.rs/druid/0.8.1/druid/struct.LayoutCtx.html
+[PaintCtx]: https://docs.rs/druid/0.8.1/druid/struct.PaintCtx.html
+[UpdateCtx]: https://docs.rs/druid/0.8.1/druid/struct.UpdateCtx.html
+[Widget trait]: https://docs.rs/druid/0.8.1/druid/trait.Widget.html
+[Data trait]: https://docs.rs/druid/0.8.1/druid/trait.Data.html
+[Lens datatype]: https://docs.rs/druid/0.8.1/druid/trait.Lens.html
 [Druid book]: https://linebender.org/druid/
 [Iced]: https://github.com/hecrj/iced
 [Conrod]: https://github.com/PistonDevelopers/conrod

--- a/docs/src/08_widgets_in_depth.md
+++ b/docs/src/08_widgets_in_depth.md
@@ -66,10 +66,10 @@ textbox fire some action (say doing a search) 300ms after the last keypress:
 {{#include ../book_examples/src/custom_widgets_md.rs:annoying_textbox}}
 ```
 
-[`Controller`]: https://docs.rs/druid/0.8.0/druid/widget/trait.Controller.html
+[`Controller`]: https://docs.rs/druid/0.8.1/druid/widget/trait.Controller.html
 [`Widget`]: ./widget.md
-[`Painter`]: https://docs.rs/druid/0.8.0/druid/widget/struct.Painter.html
-[`SizedBox`]: https://docs.rs/druid/0.8.0/druid/widget/struct.SizedBox.html
-[`Container`]: https://docs.rs/druid/0.8.0/druid/widget/struct.Container.html
-[`WidgetExt`]: https://docs.rs/druid/0.8.0/druid/trait.WidgetExt.html
-[`background`]: https://docs.rs/druid/0.8.0/druid/trait.WidgetExt.html#background
+[`Painter`]: https://docs.rs/druid/0.8.1/druid/widget/struct.Painter.html
+[`SizedBox`]: https://docs.rs/druid/0.8.1/druid/widget/struct.SizedBox.html
+[`Container`]: https://docs.rs/druid/0.8.1/druid/widget/struct.Container.html
+[`WidgetExt`]: https://docs.rs/druid/0.8.1/druid/trait.WidgetExt.html
+[`background`]: https://docs.rs/druid/0.8.1/druid/trait.WidgetExt.html#background

--- a/druid-derive/Cargo.toml
+++ b/druid-derive/Cargo.toml
@@ -20,7 +20,7 @@ quote = "1.0.23"
 proc-macro2 = "1.0.50"
 
 [dev-dependencies]
-druid = { version = "0.8.0", path = "../druid" }
+druid = { version = "0.8.1", path = "../druid" }
 trybuild = "1.0"
 
 float-cmp = { version = "0.9.0", features = ["std"], default-features = false }

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "druid"
-version = "0.8.0"
+version = "0.8.1"
 license = "Apache-2.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Data-oriented Rust UI design toolkit."
 repository = "https://github.com/linebender/druid"
 categories = ["gui"]
-readme = "README.md"
+readme = "../README.md"
 keywords = ["gui", "ui", "toolkit"]
 edition = "2021"
 

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -125,7 +125,7 @@
 //! Features can be added with `cargo`. For example, in your `Cargo.toml`:
 //! ```no_compile
 //! [dependencies.druid]
-//! version = "0.8.0"
+//! version = "0.8.1"
 //! features = ["im", "svg", "image"]
 //! ```
 //!
@@ -142,7 +142,7 @@
 //! [`Event`]: enum.Event.html
 //! [`druid-shell`]: druid_shell
 //! [`piet`]: piet
-//! [`druid/examples`]: https://github.com/linebender/druid/tree/v0.8.0/druid/examples
+//! [`druid/examples`]: https://github.com/linebender/druid/tree/v0.8.1/druid/examples
 //! [Druid book]: https://linebender.org/druid/
 //! [`im` crate]: https://crates.io/crates/im
 //! [`im` module]: im/index.html

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -568,7 +568,7 @@ impl<T: Data> Flex<T> {
                 flex: params.flex,
             }
         } else {
-            tracing::warn!("Flex value should be > 0.0. To add a non-flex child use the add_child or with_child methods.\nSee the docs for more information: https://docs.rs/druid/0.8.0/druid/widget/struct.Flex.html");
+            tracing::warn!("Flex value should be > 0.0. To add a non-flex child use the add_child or with_child methods.\nSee the docs for more information: https://docs.rs/druid/0.8.1/druid/widget/struct.Flex.html");
             Child::Fixed {
                 widget: WidgetPod::new(Box::new(child)),
                 alignment: None,


### PR DESCRIPTION
Okay this is annoying, but I have to do a quick follow-up v0.8.1 release. The v0.8.0 release has a broken readme on crates.io as can be seen [here](https://crates.io/crates/druid/0.8.0). I'm not sure if cargo has changed or how this happened, but I changed `Cargo.toml` to have `readme = "../README.md"` instead and now it works. 🤷

Only the `druid` crate will get a v0.8.1. The others are fine.