### PR TITLE
Synchronize `kurbo` and `image` imports with `piet-common`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ You can find its changes [documented below](#082---2023-01-27).
 
 ### Maintenance
 
+- Synchronized `kurbo` and `image` imports with `piet-common`. ([#2352] by [@xStrom])
+
 ### Outside News
 
 ## [0.8.2] - 2023-01-27
@@ -1192,6 +1194,7 @@ Last release without a changelog :(
 [#2345]: https://github.com/linebender/druid/pull/2345
 [#2347]: https://github.com/linebender/druid/pull/2347
 [#2348]: https://github.com/linebender/druid/pull/2348
+[#2352]: https://github.com/linebender/druid/pull/2352
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.8.2...master
 [0.8.2]: https://github.com/linebender/druid/compare/v0.8.1...v0.8.2

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -44,6 +44,7 @@ raw-win-handle = ["raw-window-handle"]
 
 # passing on all the image features. AVIF is not supported because it does not
 # support decoding, and that's all we use `Image` for.
+image = ["piet-common/image"]
 image_png = ["piet-common/image_png"]
 jpeg = ["piet-common/jpeg"]
 jpeg_rayon = ["piet-common/jpeg_rayon"]
@@ -61,7 +62,7 @@ hdr = ["piet-common/hdr"]
 serde = ["piet-common/serde"]
 
 [dependencies]
-piet-common = "0.6.1"
+piet-common = "0.6.2"
 
 tracing = "0.1.37"
 once_cell = "1.17.0"
@@ -72,7 +73,6 @@ anyhow = "1.0.68"
 keyboard-types = { version = "0.6.2", default_features = false }
 
 # Optional dependencies
-image = { version = "0.23.12", optional = true, default_features = false }
 raw-window-handle = { version = "0.5.0", optional = true, default_features = false }
 
 [target.'cfg(target_os="windows")'.dependencies]
@@ -124,7 +124,7 @@ version = "0.3.60"
 features = ["Window", "MouseEvent", "CssStyleDeclaration", "WheelEvent", "KeyEvent", "KeyboardEvent", "Navigator"]
 
 [dev-dependencies]
-piet-common = { version = "0.6.1", features = ["png"] }
+piet-common = { version = "0.6.2", features = ["png"] }
 static_assertions = "1.1.0"
 test-log = { version = "0.2.11", features = ["trace"], default-features = false }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -58,13 +58,10 @@ tga = ["piet-common/tga"]
 farbfeld = ["piet-common/farbfeld"]
 dxt = ["piet-common/dxt"]
 hdr = ["piet-common/hdr"]
-serde = ["kurbo/serde"]
+serde = ["piet-common/serde"]
 
 [dependencies]
-# NOTE: When changing the piet or kurbo versions, ensure that
-#       the kurbo version included in piet is compatible with the kurbo version specified here.
 piet-common = "0.6.1"
-kurbo = "0.9.0"
 
 tracing = "0.1.37"
 once_cell = "1.17.0"

--- a/druid-shell/src/backend/gtk/screen.rs
+++ b/druid-shell/src/backend/gtk/screen.rs
@@ -14,9 +14,9 @@
 
 //! GTK Monitors and Screen information.
 
+use crate::kurbo::{Point, Rect, Size};
 use crate::screen::Monitor;
 use gtk::gdk::{Display, DisplayManager, Rectangle};
-use kurbo::{Point, Rect, Size};
 
 fn translate_gdk_rectangle(r: Rectangle) -> Rect {
     Rect::from_origin_size(

--- a/druid-shell/src/backend/mac/screen.rs
+++ b/druid-shell/src/backend/mac/screen.rs
@@ -72,8 +72,8 @@ fn transform_coords(monitors_build: Vec<(Rect, Rect)>, max_y: f64) -> Vec<Monito
 #[cfg(test)]
 mod test {
     use crate::backend::mac::screen::transform_coords;
+    use crate::kurbo::Rect;
     use crate::Monitor;
-    use kurbo::Rect;
     use test_log::test;
 
     fn pair(rect: Rect) -> (Rect, Rect) {

--- a/druid-shell/src/backend/wayland/screen.rs
+++ b/druid-shell/src/backend/wayland/screen.rs
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 //! wayland Monitors and Screen information.
+
+use crate::kurbo::Rect;
+
 use crate::screen::Monitor;
 
 use super::error;
@@ -23,7 +26,7 @@ fn _get_monitors() -> Result<Vec<Monitor>, error::Error> {
     let monitors: Vec<Monitor> = metas
         .iter()
         .map(|m| {
-            let rect = kurbo::Rect::from_origin_size(
+            let rect = Rect::from_origin_size(
                 (m.position.x as f64, m.position.y as f64),
                 (m.logical.width as f64, m.logical.height as f64),
             );

--- a/druid-shell/src/backend/wayland/surfaces/buffers.rs
+++ b/druid-shell/src/backend/wayland/surfaces/buffers.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use kurbo::{Rect, Size};
+use crate::kurbo::{Rect, Size};
 use nix::{
     errno::Errno,
     fcntl::OFlag,

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -45,8 +45,7 @@
 extern crate gtk_rs as gtk;
 
 #[cfg(feature = "image")]
-pub use image;
-
+pub use piet::image_crate as image;
 pub use piet::kurbo;
 pub use piet_common as piet;
 

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -44,11 +44,10 @@
 ))]
 extern crate gtk_rs as gtk;
 
-// Reexport the version of `image` we are using.
 #[cfg(feature = "image")]
 pub use image;
 
-pub use kurbo;
+pub use piet::kurbo;
 pub use piet_common as piet;
 
 // Reexport the version of `raw_window_handle` we are using.

--- a/druid-shell/src/region.rs
+++ b/druid-shell/src/region.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use kurbo::{BezPath, Rect, Shape, Vec2};
+use crate::kurbo::{BezPath, Rect, Shape, Vec2};
 
 /// A union of rectangles, useful for describing an area that needs to be repainted.
 #[derive(Clone, Debug)]

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -85,7 +85,7 @@ console_error_panic_hook = { version = "0.1.7" }
 [dev-dependencies]
 float-cmp = { version = "0.9.0", features = ["std"], default-features = false }
 tempfile = "3.3.0"
-piet-common = { version = "0.6.1", features = ["png"] }
+piet-common = { version = "0.6.2", features = ["png"] }
 pulldown-cmark = { version = "0.8.0", default-features = false }
 test-log = { version = "0.2.11", features = ["trace"], default-features = false }
 # test-env-log needs it


### PR DESCRIPTION
Druid v0.8 ended up shipping with a different major version of `image` than Piet, which causes severe issues due to their incompatibility, as pointed out by @jpochyla. The ultimate solution to this is to import the `image` and `kurbo` crates from `piet-common` so that they remain synchronized.