### PR TITLE
Fix `rustdoc` example scraping configuration.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: install libx11-dev
+      - name: install linux dependencies
         run: |
           sudo apt update
-          sudo apt install libx11-dev libpango1.0-dev libxkbcommon-dev libxkbcommon-x11-dev
+          sudo apt install libpango1.0-dev libxkbcommon-dev libxkbcommon-x11-dev
         if: contains(matrix.os, 'ubuntu')
 
       - name: install stable toolchain
@@ -56,13 +56,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --manifest-path=druid-shell/Cargo.toml --all-targets --features=x11,raw-win-handle --no-default-features -- -D warnings
+          args: --manifest-path=druid-shell/Cargo.toml --all-targets --no-default-features --features=x11,image,raw-win-handle -- -D warnings
 
       - name: cargo clippy druid
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --manifest-path=druid/Cargo.toml --all-targets  --no-default-features --features=svg,image,im,x11,raw-win-handle -- -D warnings
+          args: --manifest-path=druid/Cargo.toml --all-targets --no-default-features --features=svg,image,im,x11,raw-win-handle -- -D warnings
 
       - name: cargo clippy druid-derive
         uses: actions-rs/cargo@v1
@@ -84,7 +84,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path=druid-shell/Cargo.toml --no-default-features --features=x11
+          args: --manifest-path=druid-shell/Cargo.toml --no-default-features --features=x11,image,raw-win-handle
 
       # We use --all-targets to skip doc tests; we run them in a parallel task
       # there are no gtk-specific doctests in the main druid crate anyway
@@ -135,13 +135,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --manifest-path=druid-shell/Cargo.toml --all-targets --features=wayland,raw-win-handle --no-default-features -- -D warnings
+          args: --manifest-path=druid-shell/Cargo.toml --all-targets --no-default-features --features=wayland,image,raw-win-handle -- -D warnings
 
       - name: cargo test druid-shell
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path=druid-shell/Cargo.toml --features wayland --no-default-features
+          args: --manifest-path=druid-shell/Cargo.toml --no-default-features --features=wayland,image,raw-win-handle
 
       # We use --all-targets to skip doc tests; there are no wayland-specific
       # doctests in the main druid crate anyway
@@ -149,7 +149,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path=druid/Cargo.toml --all-targets --features=svg,image,im --features wayland --no-default-features
+          args: --manifest-path=druid/Cargo.toml --all-targets --no-default-features --features=wayland,svg,image,im,raw-win-handle
 
   # we test the gtk backend as a separate job because gtk install takes
   # a long time.
@@ -179,13 +179,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --manifest-path=druid-shell/Cargo.toml --all-targets --features=raw-win-handle -- -D warnings
+          args: --manifest-path=druid-shell/Cargo.toml --all-targets --features=image,raw-win-handle -- -D warnings
 
       - name: cargo test druid-shell
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path=druid-shell/Cargo.toml
+          args: --manifest-path=druid-shell/Cargo.toml --features=image,raw-win-handle
 
       # We use --all-targets to skip doc tests; there are no gtk-specific
       # doctests in the main druid crate anyway
@@ -230,7 +230,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path=druid-shell/Cargo.toml --no-run --target wasm32-unknown-unknown
+          args: --manifest-path=druid-shell/Cargo.toml --features=image --no-run --target wasm32-unknown-unknown
 
       # We use --all-targets to skip doc tests; there are no wasm-specific
       # doctests in the main druid crate anyway
@@ -275,7 +275,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path=druid/Cargo.toml --doc --no-default-features --features=svg,image,im
+          args: --manifest-path=druid/Cargo.toml --doc --no-default-features --features=svg,image,im,raw-win-handle
 
   # This tests the future rust compiler to catch errors ahead of time without
   # breaking CI
@@ -304,7 +304,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --manifest-path=druid-shell/Cargo.toml --all-targets --features=raw-win-handle -- -D warnings
+          args: --manifest-path=druid-shell/Cargo.toml --all-targets --features=image,raw-win-handle -- -D warnings
         continue-on-error: true
 
       - name: cargo clippy druid
@@ -319,7 +319,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path=druid-shell/Cargo.toml --no-default-features --features=x11
+          args: --manifest-path=druid-shell/Cargo.toml --no-default-features --features=x11,image
         continue-on-error: true
 
       # We use --all-targets to skip doc tests, which are run in doctest-stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,7 +364,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path=druid/Cargo.toml --doc --features=svg,image,im
+          args: --manifest-path=druid/Cargo.toml --doc --features=svg,image,im,raw-win-handle
 
 
   check-docs:
@@ -376,16 +376,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: install libgtk-dev
+      - name: install linux dependencies
         run: |
           sudo apt update
-          sudo apt install libgtk-3-dev libxkbcommon-dev libxkbcommon-x11-dev
+          sudo apt install libgtk-3-dev libwayland-dev libpango1.0-dev libxkbcommon-dev libxkbcommon-x11-dev
         if: contains(matrix.os, 'ubuntu')
 
-      - name: install stable toolchain
+      - name: install nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           profile: minimal
           override: true
 
@@ -397,13 +397,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --manifest-path=druid-shell/Cargo.toml --no-deps --document-private-items
+          args: --manifest-path=druid-shell/Cargo.toml --features=image,raw-win-handle --no-deps --document-private-items -Zunstable-options -Zrustdoc-scrape-examples
 
       - name: cargo doc druid
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --manifest-path=druid/Cargo.toml --features=svg,image,im --no-deps --document-private-items
+          args: --manifest-path=druid/Cargo.toml --features=svg,image,im,raw-win-handle --no-deps --document-private-items -Zunstable-options -Zrustdoc-scrape-examples
 
       - name: cargo doc druid-derive
         uses: actions-rs/cargo@v1
@@ -422,7 +422,15 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --manifest-path=druid-shell/Cargo.toml --features=x11 --no-deps --document-private-items
+          args: --manifest-path=druid-shell/Cargo.toml --no-default-features --features=x11,image,raw-win-handle --no-deps --document-private-items
+        if: contains(matrix.os, 'ubuntu')
+
+      # On Linux also attempt docs for Wayland.
+      - name: cargo doc druid-shell (Wayland)
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --manifest-path=druid-shell/Cargo.toml --no-default-features --features=wayland,image,raw-win-handle --no-deps --document-private-items
         if: contains(matrix.os, 'ubuntu')
 
   mdbook-build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,7 +422,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --manifest-path=druid-shell/Cargo.toml --no-default-features --features=x11,image,raw-win-handle --no-deps --document-private-items
+          args: --manifest-path=druid-shell/Cargo.toml --no-default-features --features=x11,image,raw-win-handle --no-deps --document-private-items  -Zunstable-options -Zrustdoc-scrape-examples
         if: contains(matrix.os, 'ubuntu')
 
       # On Linux also attempt docs for Wayland.
@@ -430,7 +430,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --manifest-path=druid-shell/Cargo.toml --no-default-features --features=wayland,image,raw-win-handle --no-deps --document-private-items
+          args: --manifest-path=druid-shell/Cargo.toml --no-default-features --features=wayland,image,raw-win-handle --no-deps --document-private-items  -Zunstable-options -Zrustdoc-scrape-examples
         if: contains(matrix.os, 'ubuntu')
 
   mdbook-build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ You can find its changes [documented below](#082---2023-01-27).
 
 ### Docs
 
+- Fixed `rustdoc` example scraping configuration. ([#2353] by [@xStrom])
 - Added info about git symlinks to `CONTRIBUTING.md`. ([#2349] by [@xStrom])
 
 ### Examples
@@ -1205,6 +1206,7 @@ Last release without a changelog :(
 [#2349]: https://github.com/linebender/druid/pull/2349
 [#2351]: https://github.com/linebender/druid/pull/2351
 [#2352]: https://github.com/linebender/druid/pull/2352
+[#2353]: https://github.com/linebender/druid/pull/2353
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.8.2...master
 [0.8.2]: https://github.com/linebender/druid/compare/v0.8.1...v0.8.2

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -10,8 +10,11 @@ categories = ["os::macos-apis", "os::windows-apis", "gui"]
 edition = "2021"
 
 [package.metadata.docs.rs]
+features = ["raw-win-handle", "image"]
 rustdoc-args = ["--cfg", "docsrs"]
 default-target = "x86_64-pc-windows-msvc"
+# rustdoc-scrape-examples tracking issue https://github.com/rust-lang/rust/issues/88791
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
 [features]
 default = ["gtk"]
@@ -133,3 +136,9 @@ unicode-segmentation = "1.10.0"
 [build-dependencies]
 bindgen = { version = "0.61.0", optional = true }
 pkg-config = { version = "0.3.26", optional = true }
+
+[[example]]
+name = "shello"
+# This actually enables scraping for all examples, not just `shello`.
+# However it is possible to add another [[example]] entry to disable it for a specific example.
+doc-scrape-examples = true

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -11,17 +11,11 @@ keywords = ["gui", "ui", "toolkit"]
 edition = "2021"
 
 [package.metadata.docs.rs]
-# The "svg" and "image" features have doc clashes that cause undefined output in docs.
-# See https://github.com/rust-lang/cargo/issues/6313 for more information.
-# Once cargo doc becomes smart enough to handle multiple versions of the same crate,
-# the "svg" and "image" features should be enabled for the docs.rs output.
-features = ["im"]
+features = ["raw-win-handle", "im", "svg", "image"]
 rustdoc-args = ["--cfg", "docsrs"]
 default-target = "x86_64-pc-windows-msvc"
-# TODO: Enable this again after figuring out how the flags have changed.
-#       Also be sure to add nightly compiler docs building to CI
-#       to catch any changes to the flags early.
-#cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples=examples"]
+# rustdoc-scrape-examples tracking issue https://github.com/rust-lang/rust/issues/88791
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
 [features]
 default = ["gtk"]
@@ -93,6 +87,12 @@ tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 
 [target.'cfg(not(target_arch="wasm32"))'.dev-dependencies]
 open = "1.7.1"
+
+[[example]]
+name = "hello"
+# This actually enables scraping for all examples, not just `hello`.
+# However it is possible to add another [[example]] entry to disable it for a specific example.
+doc-scrape-examples = true
 
 [[example]]
 name = "cursor"


### PR DESCRIPTION
[Docs.rs failed to build Druid v0.8.0 docs](https://docs.rs/crate/druid/0.8.0) because we were specifying a stale unstable nightly rustdoc option in our `Cargo.toml`.

I temporarily disabled this option in #2348.

This PR here brings back example scraping. Unfortunately the [rustdoc book is also stale](https://doc.rust-lang.org/rustdoc/scraped-examples.html#how-to-use-this-feature) so I had to go [deep into the tracking issue](https://github.com/rust-lang/rust/issues/88791#issuecomment-1028240911) to figure out how it changed. The feature can now be disabled on a per example basis, but I enabled it for all of them like was intended before.

I also enabled all the features for docs.rs builds. We used to disable `svg` and `image` due to duplicate artifacts. The duplicate artifacts tracking issue is still open, however `rustdoc` no longer seems to complain for our builds. Perhaps the code changed or the issue is more limited now? Not sure, but I think we can keep the features enabled for now.

I tested this on my own machine with the nightly toolchain and everything seems to work fine.

Critically, I also updated our CI tests. The docs are now built with the nightly toolchain, as that matches docs.rs. I also updated the flags to be a closer match to what docs.rs is configured to use. This way we can hopefully prevent another event where a published build fails on docs.rs. On top of that I made sure we enable our various features in all sorts of CI tests and removed `libx11-dev` as a seemingly stale Linux dependency.