### PR TITLE
Fix doc visibility issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ You can find its changes [documented below](#082---2023-01-27).
 
 ### Docs
 
+- `Widget`, `WidgetExt`, `WidgetId`, `Lens` and `LensExt` docs are visible again. ([#2356] by [@xStrom])
+- Deprecated items are now hidden. ([#2356] by [@xStrom])
 - Fixed `rustdoc` example scraping configuration. ([#2353] by [@xStrom])
 - Added info about git symlinks to `CONTRIBUTING.md`. ([#2349] by [@xStrom])
 
@@ -1207,6 +1209,7 @@ Last release without a changelog :(
 [#2351]: https://github.com/linebender/druid/pull/2351
 [#2352]: https://github.com/linebender/druid/pull/2352
 [#2353]: https://github.com/linebender/druid/pull/2353
+[#2356]: https://github.com/linebender/druid/pull/2356
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.8.2...master
 [0.8.2]: https://github.com/linebender/druid/compare/v0.8.1...v0.8.2

--- a/druid-shell/src/mouse.rs
+++ b/druid-shell/src/mouse.rs
@@ -255,6 +255,7 @@ pub enum Cursor {
     Pointer,
     Crosshair,
 
+    #[doc(hidden)]
     #[deprecated(
         since = "0.8.0",
         note = "This will be removed because it is not available on Windows."

--- a/druid-shell/src/region.rs
+++ b/druid-shell/src/region.rs
@@ -59,6 +59,7 @@ impl Region {
         }
     }
 
+    #[doc(hidden)]
     #[deprecated(since = "0.7.0", note = "Use bounding_box() instead")]
     // this existed on the previous Region type, and I've bumped into it
     // a couple times while updating

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -172,6 +172,7 @@ impl<T: Data> AppLauncher<T> {
     /// # Panics
     ///
     /// Panics if the logger fails to initialize.
+    #[doc(hidden)]
     #[deprecated(since = "0.8.0", note = "Use log_to_console instead")]
     pub fn use_simple_logger(self) -> Self {
         self.log_to_console()

--- a/druid/src/lens/mod.rs
+++ b/druid/src/lens/mod.rs
@@ -52,6 +52,6 @@
 #[allow(clippy::module_inception)]
 #[macro_use]
 mod lens;
-pub use lens::{Constant, Deref, Field, Identity, InArc, Index, Map, Ref, Then, Unit};
-#[doc(hidden)]
-pub use lens::{Lens, LensExt};
+pub use lens::{
+    Constant, Deref, Field, Identity, InArc, Index, Lens, LensExt, Map, Ref, Then, Unit,
+};

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -135,13 +135,7 @@
 //! the console to be shown, use `#![windows_subsystem = "windows"]` at the beginning of your
 //! crate.
 //!
-//! [`Widget`]: trait.Widget.html
-//! [`Data`]: trait.Data.html
-//! [`Lens`]: trait.Lens.html
-//! [`widget`]: ./widget/index.html
-//! [`Event`]: enum.Event.html
 //! [`druid-shell`]: druid_shell
-//! [`piet`]: piet
 //! [`druid/examples`]: https://github.com/linebender/druid/tree/v0.8.2/druid/examples
 //! [Druid book]: https://linebender.org/druid/
 //! [`im` crate]: https://crates.io/crates/im
@@ -231,13 +225,15 @@ pub use app_delegate::{AppDelegate, DelegateCtx};
 pub use box_constraints::BoxConstraints;
 pub use command::{sys as commands, Command, Notification, Selector, SingleUse, Target};
 pub use contexts::{EventCtx, LayoutCtx, LifeCycleCtx, PaintCtx, UpdateCtx};
-pub use data::Data;
+pub use data::*; // Wildcard because rustdoc has trouble inlining docs of two things called Data
 pub use dialog::FileDialogOptions;
+#[doc(inline)]
 pub use env::{Env, Key, KeyOrValue, Value, ValueType, ValueTypeError};
 pub use event::{Event, InternalEvent, InternalLifeCycle, LifeCycle, ViewContext};
 pub use ext_event::{ExtEventError, ExtEventSink};
 pub use lens::{Lens, LensExt};
 pub use localization::LocalizedString;
+#[doc(inline)]
 pub use menu::{sys as platform_menus, Menu, MenuItem};
 pub use mouse::MouseEvent;
 pub use util::Handled;
@@ -248,8 +244,10 @@ pub use window::{Window, WindowId};
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) use event::{DebugStateCell, StateCell, StateCheckFn};
 
+#[doc(hidden)]
 #[deprecated(since = "0.8.0", note = "import from druid::text module instead")]
 pub use piet::{FontFamily, FontStyle, FontWeight, TextAlignment};
+#[doc(hidden)]
 #[deprecated(since = "0.8.0", note = "import from druid::text module instead")]
 pub use text::{ArcStr, FontDescriptor, TextLayout};
 
@@ -261,9 +259,11 @@ pub use text::{ArcStr, FontDescriptor, TextLayout};
 /// alias is provided to make that transition easy, but in any case make
 /// an explicit choice whether to use meaning or physical location and
 /// use the appropriate type.
+#[doc(hidden)]
 #[deprecated(since = "0.7.0", note = "Use KbKey instead")]
 pub type KeyCode = KbKey;
 
+#[doc(hidden)]
 #[deprecated(since = "0.7.0", note = "Use Modifiers instead")]
 /// See [`Modifiers`](struct.Modifiers.html).
 pub type KeyModifiers = Modifiers;

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -25,6 +25,7 @@ use crate::{Env, FontDescriptor, FontFamily, FontStyle, FontWeight, Insets, Key}
 pub const WINDOW_BACKGROUND_COLOR: Key<Color> =
     Key::new("org.linebender.druid.theme.window_background_color");
 
+#[doc(hidden)]
 #[deprecated(since = "0.8.0", note = "renamed to TEXT_COLOR")]
 pub const LABEL_COLOR: Key<Color> = TEXT_COLOR;
 pub const TEXT_COLOR: Key<Color> = Key::new("org.linebender.druid.theme.label_color");
@@ -56,6 +57,7 @@ pub const BUTTON_BORDER_WIDTH: Key<f64> =
     Key::new("org.linebender.druid.theme.button_border_width");
 pub const BORDER_DARK: Key<Color> = Key::new("org.linebender.druid.theme.border_dark");
 pub const BORDER_LIGHT: Key<Color> = Key::new("org.linebender.druid.theme.border_light");
+#[doc(hidden)]
 #[deprecated(since = "0.8.0", note = "use SELECTED_TEXT_BACKGROUND_COLOR instead")]
 pub const SELECTION_COLOR: Key<Color> = SELECTED_TEXT_BACKGROUND_COLOR;
 pub const SELECTED_TEXT_BACKGROUND_COLOR: Key<Color> =

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -106,41 +106,19 @@ pub use tabs::{AddTab, TabInfo, Tabs, TabsEdge, TabsPolicy, TabsState, TabsTrans
 pub use textbox::TextBox;
 pub use value_textbox::{TextBoxEvent, ValidationDelegate, ValueTextBox};
 pub use view_switcher::ViewSwitcher;
-#[doc(hidden)]
 pub use widget::{Widget, WidgetId};
-#[doc(hidden)]
 pub use widget_ext::WidgetExt;
 pub use widget_wrapper::WidgetWrapper;
 pub use z_stack::ZStack;
 
 /// The types required to implement a [`Widget`].
-///
-/// # Structs
-/// [`BoxConstraints`](crate::BoxConstraints)\
-/// [`Env`](crate::Env)\
-/// [`EventCtx`](crate::EventCtx)\
-/// [`LayoutCtx`](crate::LayoutCtx)\
-/// [`LifeCycleCtx`](crate::LifeCycleCtx)\
-/// [`PaintCtx`](crate::PaintCtx)\
-/// [`Size`](crate::Size)\
-/// [`UpdateCtx`](crate::UpdateCtx)\
-/// [`WidgetId`](crate::WidgetId)\
-///
-/// # Enums
-/// [`Event`](crate::Event)\
-/// [`LifeCycle`](crate::LifeCycle)\
-///
-/// # Traits
-/// [`Data`](crate::Data)\
-/// [`RenderContext`](crate::RenderContext)\
-/// [`Widget`]
-///
-/// [`Widget`]: crate::Widget
-// NOTE: \ at the end works as a line break, but skip on last line!
 pub mod prelude {
-    #[doc(hidden)]
+    // Wildcard because rustdoc has trouble inlining docs of two things called Data
+    pub use crate::data::*;
+
+    #[doc(inline)]
     pub use crate::{
-        BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
+        BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
         RenderContext, Size, UpdateCtx, Widget, WidgetId,
     };
 }

--- a/druid/src/widget/parse.rs
+++ b/druid/src/widget/parse.rs
@@ -26,6 +26,7 @@ use crate::widget::prelude::*;
 use crate::Data;
 
 /// Converts a `Widget<String>` to a `Widget<Option<T>>`, mapping parse errors to None
+#[doc(hidden)]
 #[deprecated(since = "0.7.0", note = "Use the Formatter trait instead")]
 pub struct Parse<T> {
     widget: T,

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -218,6 +218,7 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     }
 
     /// Parse a `Widget<String>`'s contents
+    #[doc(hidden)]
     #[deprecated(since = "0.7.0", note = "Use TextBox::with_formatter instead")]
     #[allow(deprecated)]
     fn parse(self) -> Parse<Self>


### PR DESCRIPTION
@cbondurant reported in #2355 that the docs for `Widget` and `LensExt` are missing. Indeed that is the case, as is for `Lens`, `WidgetId`, and `WidgetExt`. I think I checked these just a month ago, and regardless I'm confident that these used to work way earlier, with no code/attribute changes since then.

My best guess is that `rustdoc` changed how `#[doc(hidden)]` is inherited. The way we use this attribute is to hide the docs in the `widget` module but then show them in the re-exported root module. This no longer works and the docs are hidden in the root too. Interestingly the reverse is still possible, we could hide the docs in the root but have them show up in the `widget` module.

In this PR I decided to just have the docs visible in both the `widget` module and the root module. We're only talking a few traits here and they're quite fundamental.

Additionally, I made two adjacent changes.
1. I hid the docs for all deprecated items. We already did this for a bunch, now it is consistent.
2. I made sure that all re-exported Druid items (e.g. `Env`) show up as inline docs, not as re-exports.

Fixes #2355