### PR TITLE
Add new `WindowsMoveResize` event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You can find its changes [documented below](#082---2023-01-27).
 
 - `foreground`, `set_foreground`, and `clear_foreground` methods to `Container` and `WidgetExt::foreground` method for convenience. ([#2346] by [@giannissc])
 - `WindowHandle::hide` method to hide a window. ([#2191] by [@newcomb-luke])
+- added new event variant `Event::WindowMoveResize` that can be used to detect when window resize/move started or finished (currently only Implemented for windows) ([#2360] by [@YouKnow-sys])
 
 ### Changed
 
@@ -770,6 +771,7 @@ Last release without a changelog :(
 [@ratmice]: https://github.com/ratmice
 [@giannissc]: https://github.com/giannissc
 [@newcomb-luke]: https://github.com/newcomb-luke
+[@YouKnow-sys]: https://github.com/YouKnow-sys
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611
@@ -1213,6 +1215,7 @@ Last release without a changelog :(
 [#2352]: https://github.com/linebender/druid/pull/2352
 [#2353]: https://github.com/linebender/druid/pull/2353
 [#2356]: https://github.com/linebender/druid/pull/2356
+[#2360]: https://github.com/linebender/druid/pull/2360
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.8.2...master
 [0.8.2]: https://github.com/linebender/druid/compare/v0.8.1...v0.8.2

--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -992,6 +992,14 @@ impl WndProc for MyWndProc {
                 })
                 .map(|_| 0)
             },
+            WM_ENTERSIZEMOVE => {
+                self.with_wnd_state(|s| s.handler.move_resize(true));
+                Some(0)
+            }
+            WM_EXITSIZEMOVE => {
+                self.with_wnd_state(|s| s.handler.move_resize(false));
+                Some(0)
+            }
             WM_COMMAND => {
                 self.with_wnd_state(|s| s.handler.command(LOWORD(wparam as u32) as u32));
                 Some(0)

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -545,6 +545,13 @@ pub trait WinHandler {
     #[allow(unused_variables)]
     fn size(&mut self, size: Size) {}
 
+    /// Called when window start or finished moving/resizing.
+    ///
+    /// If the `begin` value is `true` it mean the windows started moving/resizing
+    /// and if the value is `false` it mean the moving/resizing finished.
+    #[allow(unused_variables)]
+    fn move_resize(&mut self, begin: bool) {}
+
     /// Called when the [scale](crate::Scale) of the window has changed.
     ///
     /// This is always called before the accompanying [`size`](WinHandler::size).

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -697,6 +697,10 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                 self.state.needs_layout = true;
                 ctx.is_root
             }
+            Event::WindowMoveResize(_) => {
+                self.state.needs_layout = true;
+                ctx.is_root
+            }
             Event::MouseDown(mouse_event) => {
                 self.set_hot_state(
                     ctx.state,

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -88,6 +88,13 @@ pub enum Event {
     /// in the WindowPod, but after that it might be considered better
     /// to just handle it in `layout`.
     WindowSize(Size),
+    /// Called on beginning or end of windows move or resize event.
+    ///
+    /// `true`: move/resize began\
+    /// `false`: move/resize finished
+    ///
+    /// Currently only Implemented for `Windows`
+    WindowMoveResize(bool),
     /// Called when a mouse button is pressed.
     MouseDown(MouseEvent),
     /// Called when a mouse button is released.
@@ -425,6 +432,7 @@ impl Event {
             | Event::WindowDisconnected
             | Event::WindowScale(_)
             | Event::WindowSize(_)
+            | Event::WindowMoveResize(_)
             | Event::Timer(_)
             | Event::AnimFrame(_)
             | Event::Command(_)

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -965,6 +965,11 @@ impl<T: Data> WinHandler for DruidHandler<T> {
         self.app_state.do_window_event(event, self.window_id);
     }
 
+    fn move_resize(&mut self, begin: bool) {
+        let event = Event::WindowMoveResize(begin);
+        self.app_state.do_window_event(event, self.window_id);
+    }
+
     fn scale(&mut self, scale: Scale) {
         let event = Event::WindowScale(scale);
         self.app_state.do_window_event(event, self.window_id);


### PR DESCRIPTION
This PR add a new event variant name `WindowsMoveResize` to the `druid::event::Event`
this event can be used to check when a window resize/move event started or finished.
currently it only Implemented for windows platform.
what it do in more detail is when ever user start Resizing or Moving there window the `WindowsMoveResize` will be sent (just one time for start or end).
it can be helpful when we want to do some action based on the current state of the window (like doing something just when windows isn't moving/resizing or the other way around).
my use case for this was I wanted to apply acrylic blur to my window just when window isn't moving (because as you may know acrylic blur can make window quite heavy when moving or resizing)
with this new event I can change to normal blur when windows is moving or resizing and change back to acrylic at the end. (we can see something like this in action in other Gui frameworks like FluentWPF)