### PR TITLE
Update dependencies to latest semver compatible versions.

### DIFF
--- a/druid-derive/Cargo.toml
+++ b/druid-derive/Cargo.toml
@@ -15,9 +15,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 default-target = "x86_64-pc-windows-msvc"
 
 [dependencies]
-syn = "1.0.107"
+syn = "1.0.109"
 quote = "1.0.23"
-proc-macro2 = "1.0.50"
+proc-macro2 = "1.0.51"
 
 [dev-dependencies]
 druid = { version = "0.8.2", path = "../druid" }

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -68,15 +68,15 @@ serde = ["piet-common/serde"]
 piet-common = "0.6.2"
 
 tracing = "0.1.37"
-once_cell = "1.17.0"
-time = "0.3.17"
+once_cell = "1.17.1"
+time = "0.3.20"
 cfg-if = "1.0.0"
 instant = { version = "0.1.12", features = ["wasm-bindgen"] }
-anyhow = "1.0.68"
-keyboard-types = { version = "0.6.2", default_features = false }
+anyhow = "1.0.69"
+keyboard-types = { version = "0.6.2", default-features = false }
 
 # Optional dependencies
-raw-window-handle = { version = "0.5.0", optional = true, default_features = false }
+raw-window-handle = { version = "0.5.0", optional = true, default-features = false }
 
 [target.'cfg(target_os="windows")'.dependencies]
 scopeguard = "1.1.0"
@@ -100,9 +100,9 @@ bitflags = "1.3.2"
 [target.'cfg(any(target_os = "freebsd", target_os="linux", target_os="openbsd"))'.dependencies]
 ashpd = { version = "0.3.2", optional = true }
 # TODO(x11/dependencies): only use feature "xcb" if using X11
-cairo-rs = { version = "0.16.3", default_features = false, features = ["xcb"] }
-cairo-sys-rs = { version = "0.16.3", default_features = false, optional = true }
-futures = { version = "0.3.25", optional = true, features = ["executor"]}
+cairo-rs = { version = "0.16.7", default-features = false, features = ["xcb"] }
+cairo-sys-rs = { version = "0.16.3", default-features = false, optional = true }
+futures = { version = "0.3.26", optional = true, features = ["executor"]}
 gdk-sys = { version = "0.16.0", optional = true }
 # `gtk` gets renamed to `gtk-rs` so that we can use `gtk` as the feature name.
 gtk-rs = { version = "0.16.2", package = "gtk", optional = true }
@@ -119,11 +119,11 @@ log = { version = "0.4.17", optional = true }
 im = { version = "15.1.0", optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
-wasm-bindgen = "0.2.83"
-js-sys = "0.3.60"
+wasm-bindgen = "0.2.84"
+js-sys = "0.3.61"
 
 [target.'cfg(target_arch="wasm32")'.dependencies.web-sys]
-version = "0.3.60"
+version = "0.3.61"
 features = ["Window", "MouseEvent", "CssStyleDeclaration", "WheelEvent", "KeyEvent", "KeyboardEvent", "Navigator"]
 
 [dev-dependencies]
@@ -131,7 +131,7 @@ piet-common = { version = "0.6.2", features = ["png"] }
 static_assertions = "1.1.0"
 test-log = { version = "0.2.11", features = ["trace"], default-features = false }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
-unicode-segmentation = "1.10.0"
+unicode-segmentation = "1.10.1"
 
 [build-dependencies]
 bindgen = { version = "0.61.0", optional = true }

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -60,7 +60,7 @@ fluent-bundle = "0.15.2"
 fluent-langneg = "0.13.0"
 fluent-syntax = "0.11.0"
 unic-langid = "0.9.1"
-unicode-segmentation = "1.10.0"
+unicode-segmentation = "1.10.1"
 xi-unicode = "0.3.0"
 fnv = "1.0.7"
 instant = { version = "0.1.12", features = ["wasm-bindgen"] }
@@ -70,7 +70,7 @@ chrono = { version = "0.4.23", optional = true }
 im = { version = "15.1.0", optional = true }
 resvg = { version = "0.25.0", optional = true } # When updating, make sure it doesn't pin a specific `png` crate, see druid#2345
 usvg =  { version = "0.25.0", optional = true }
-tiny-skia = { version = "0.8.2", optional = true }
+tiny-skia = { version = "0.8.3", optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 tracing-wasm = { version = "0.2.1" }
@@ -78,7 +78,7 @@ console_error_panic_hook = { version = "0.1.7" }
 
 [dev-dependencies]
 float-cmp = { version = "0.9.0", features = ["std"], default-features = false }
-tempfile = "3.3.0"
+tempfile = "3.4.0"
 piet-common = { version = "0.6.2", features = ["png"] }
 pulldown-cmark = { version = "0.8.0", default-features = false }
 test-log = { version = "0.2.11", features = ["trace"], default-features = false }

--- a/druid/examples/hello_web/Cargo.toml
+++ b/druid/examples/hello_web/Cargo.toml
@@ -13,5 +13,5 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 druid = { path="../.." }
 
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 console_error_panic_hook = "0.1.7"

--- a/druid/examples/web/Cargo.toml
+++ b/druid/examples/web/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 druid = { path="../..", features = ["im", "image", "png"] }
 tracing = "0.1.37"
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 console_error_panic_hook = "0.1.7"
 log = "0.4.17"
 instant = { version = "0.1.12", features = ["wasm-bindgen"] }


### PR DESCRIPTION
This PR updates all dependencies to the latest semver compatible versions. This is in preparation for the next Druid release and the rationale for this can be found in [`CONTRIBUTING.md`](https://github.com/linebender/druid/blob/master/CONTRIBUTING.md#dependencies).

Additionally I changed the use of `default_features` in `druid-shell/Cargo.toml` to `default-features` which seems to be the [recommended way](https://doc.rust-lang.org/cargo/reference/features.html#dependency-features) and how our other crates do it.