### PR TITLE
Prepare for releasing v0.8.3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,13 @@
 # Changelog
 
-The latest published Druid release is [0.8.2](#082---2023-01-27) which was released on 2023-01-27.
-You can find its changes [documented below](#082---2023-01-27).
+The latest published Druid release is [0.8.3](#083---2023-03-01) which was released on 2023-03-01.
+You can find its changes [documented below](#083---2023-03-01).
 
 ## [Unreleased]
 
 ### Highlights
 
 ### Added
-
-- Input Region and Always On Top support. ([#2328] by [@jaredoconnell])
-- `foreground`, `set_foreground`, and `clear_foreground` methods to `Container` and `WidgetExt::foreground` method for convenience. ([#2346] by [@giannissc])
-- `WindowHandle::hide` method to hide a window. ([#2191] by [@newcomb-luke])
 
 ### Changed
 
@@ -21,9 +17,27 @@ You can find its changes [documented below](#082---2023-01-27).
 
 ### Fixed
 
-- `AddTab` is now properly exported from the `widget` module. ([#2351] by [@cbondurant])
-
 ### Visual
+
+### Docs
+
+### Examples
+
+### Maintenance
+
+### Outside News
+
+## [0.8.3] - 2023-03-01
+
+### Added
+
+- Input Region and Always On Top support. ([#2328] by [@jaredoconnell])
+- `foreground`, `set_foreground`, and `clear_foreground` methods to `Container` and `WidgetExt::foreground` method for convenience. ([#2346] by [@giannissc])
+- `WindowHandle::hide` method to hide a window. ([#2191] by [@newcomb-luke])
+
+### Fixed
+
+- `AddTab` is now properly exported from the `widget` module. ([#2351] by [@cbondurant])
 
 ### Docs
 
@@ -32,13 +46,9 @@ You can find its changes [documented below](#082---2023-01-27).
 - Fixed `rustdoc` example scraping configuration. ([#2353] by [@xStrom])
 - Added info about git symlinks to `CONTRIBUTING.md`. ([#2349] by [@xStrom])
 
-### Examples
-
 ### Maintenance
 
 - Synchronized `kurbo` and `image` imports with `piet-common`. ([#2352] by [@xStrom])
-
-### Outside News
 
 ## [0.8.2] - 2023-01-27
 
@@ -1217,7 +1227,8 @@ Last release without a changelog :(
 [#2353]: https://github.com/linebender/druid/pull/2353
 [#2356]: https://github.com/linebender/druid/pull/2356
 
-[Unreleased]: https://github.com/linebender/druid/compare/v0.8.2...master
+[Unreleased]: https://github.com/linebender/druid/compare/v0.8.3...master
+[0.8.3]: https://github.com/linebender/druid/compare/v0.8.2...v0.8.3
 [0.8.2]: https://github.com/linebender/druid/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/linebender/druid/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/linebender/druid/compare/v0.7.0...v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-The latest published Druid release is [0.8.3](#083---2023-03-01) which was released on 2023-03-01.
-You can find its changes [documented below](#083---2023-03-01).
+The latest published Druid release is [0.8.3](#083---2023-02-28) which was released on 2023-02-28.
+You can find its changes [documented below](#083---2023-02-28).
 
 ## [Unreleased]
 
@@ -27,7 +27,7 @@ You can find its changes [documented below](#083---2023-03-01).
 
 ### Outside News
 
-## [0.8.3] - 2023-03-01
+## [0.8.3] - 2023-02-28
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ a lone dependency (it re-exports all the parts of `druid-shell`, `piet`, and `ku
 that you'll need):
 
 ```toml
-druid = "0.8.2"
+druid = "0.8.3"
 ```
 
 Since Druid is currently in fast-evolving state, you might prefer to drink from
@@ -322,14 +322,14 @@ active and friendly community. See the AUTHORS file for more.
 [Zulip chat instance]: https://xi.zulipchat.com
 [non-`druid` examples]: /druid-shell/examples/shello.rs
 [crates.io]: https://crates.io/crates/druid
-[EventCtx]: https://docs.rs/druid/0.8.2/druid/struct.EventCtx.html
-[LifeCycleCtx]: https://docs.rs/druid/0.8.2/druid/struct.LifeCycleCtx.html
-[LayoutCtx]: https://docs.rs/druid/0.8.2/druid/struct.LayoutCtx.html
-[PaintCtx]: https://docs.rs/druid/0.8.2/druid/struct.PaintCtx.html
-[UpdateCtx]: https://docs.rs/druid/0.8.2/druid/struct.UpdateCtx.html
-[Widget trait]: https://docs.rs/druid/0.8.2/druid/trait.Widget.html
-[Data trait]: https://docs.rs/druid/0.8.2/druid/trait.Data.html
-[Lens datatype]: https://docs.rs/druid/0.8.2/druid/trait.Lens.html
+[EventCtx]: https://docs.rs/druid/0.8.3/druid/struct.EventCtx.html
+[LifeCycleCtx]: https://docs.rs/druid/0.8.3/druid/struct.LifeCycleCtx.html
+[LayoutCtx]: https://docs.rs/druid/0.8.3/druid/struct.LayoutCtx.html
+[PaintCtx]: https://docs.rs/druid/0.8.3/druid/struct.PaintCtx.html
+[UpdateCtx]: https://docs.rs/druid/0.8.3/druid/struct.UpdateCtx.html
+[Widget trait]: https://docs.rs/druid/0.8.3/druid/trait.Widget.html
+[Data trait]: https://docs.rs/druid/0.8.3/druid/trait.Data.html
+[Lens datatype]: https://docs.rs/druid/0.8.3/druid/trait.Lens.html
 [Druid book]: https://linebender.org/druid/
 [Iced]: https://github.com/hecrj/iced
 [Conrod]: https://github.com/PistonDevelopers/conrod

--- a/docs/src/08_widgets_in_depth.md
+++ b/docs/src/08_widgets_in_depth.md
@@ -66,10 +66,10 @@ textbox fire some action (say doing a search) 300ms after the last keypress:
 {{#include ../book_examples/src/custom_widgets_md.rs:annoying_textbox}}
 ```
 
-[`Controller`]: https://docs.rs/druid/0.8.2/druid/widget/trait.Controller.html
+[`Controller`]: https://docs.rs/druid/0.8.3/druid/widget/trait.Controller.html
 [`Widget`]: ./widget.md
-[`Painter`]: https://docs.rs/druid/0.8.2/druid/widget/struct.Painter.html
-[`SizedBox`]: https://docs.rs/druid/0.8.2/druid/widget/struct.SizedBox.html
-[`Container`]: https://docs.rs/druid/0.8.2/druid/widget/struct.Container.html
-[`WidgetExt`]: https://docs.rs/druid/0.8.2/druid/trait.WidgetExt.html
-[`background`]: https://docs.rs/druid/0.8.2/druid/trait.WidgetExt.html#background
+[`Painter`]: https://docs.rs/druid/0.8.3/druid/widget/struct.Painter.html
+[`SizedBox`]: https://docs.rs/druid/0.8.3/druid/widget/struct.SizedBox.html
+[`Container`]: https://docs.rs/druid/0.8.3/druid/widget/struct.Container.html
+[`WidgetExt`]: https://docs.rs/druid/0.8.3/druid/trait.WidgetExt.html
+[`background`]: https://docs.rs/druid/0.8.3/druid/trait.WidgetExt.html#background

--- a/druid-derive/Cargo.toml
+++ b/druid-derive/Cargo.toml
@@ -20,7 +20,7 @@ quote = "1.0.23"
 proc-macro2 = "1.0.51"
 
 [dev-dependencies]
-druid = { version = "0.8.2", path = "../druid" }
+druid = { version = "0.8.3", path = "../druid" }
 trybuild = "1.0"
 
 float-cmp = { version = "0.9.0", features = ["std"], default-features = false }

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "druid-shell"
-version = "0.8.0"
+version = "0.8.3"
 license = "Apache-2.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Platform abstracting application shell used for Druid toolkit."

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "druid"
-version = "0.8.2"
+version = "0.8.3"
 license = "Apache-2.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Data-oriented Rust UI design toolkit."
@@ -51,7 +51,7 @@ hdr = ["druid-shell/hdr"]
 image-all = ["image", "svg", "png", "jpeg", "jpeg_rayon", "gif", "bmp", "ico", "tiff", "webp", "pnm", "dds", "tga", "farbfeld", "dxt", "hdr"]
 
 [dependencies]
-druid-shell = { version = "0.8.0", default-features = false, path = "../druid-shell" }
+druid-shell = { version = "0.8.3", default-features = false, path = "../druid-shell" }
 druid-derive = { version = "0.5.0", path = "../druid-derive" }
 
 tracing = { version = "0.1.37" }

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -125,7 +125,7 @@
 //! Features can be added with `cargo`. For example, in your `Cargo.toml`:
 //! ```no_compile
 //! [dependencies.druid]
-//! version = "0.8.2"
+//! version = "0.8.3"
 //! features = ["im", "svg", "image"]
 //! ```
 //!
@@ -136,7 +136,7 @@
 //! crate.
 //!
 //! [`druid-shell`]: druid_shell
-//! [`druid/examples`]: https://github.com/linebender/druid/tree/v0.8.2/druid/examples
+//! [`druid/examples`]: https://github.com/linebender/druid/tree/v0.8.3/druid/examples
 //! [Druid book]: https://linebender.org/druid/
 //! [`im` crate]: https://crates.io/crates/im
 //! [`im` module]: im/index.html

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -568,7 +568,7 @@ impl<T: Data> Flex<T> {
                 flex: params.flex,
             }
         } else {
-            tracing::warn!("Flex value should be > 0.0. To add a non-flex child use the add_child or with_child methods.\nSee the docs for more information: https://docs.rs/druid/0.8.2/druid/widget/struct.Flex.html");
+            tracing::warn!("Flex value should be > 0.0. To add a non-flex child use the add_child or with_child methods.\nSee the docs for more information: https://docs.rs/druid/0.8.3/druid/widget/struct.Flex.html");
             Child::Fixed {
                 widget: WidgetPod::new(Box::new(child)),
                 alignment: None,


### PR DESCRIPTION
A month has passed since v0.8 was released and it contained a significant issue with the mismatch of `image` crate that was fixed in #2352. Thus it is time for another minor release - v0.8.3.

This PR gets us ready for publishing:
* Finalized the changelog.
* Updated all the relevant links.
* Bumped `druid` and `druid-shell` to `0.8.3`.