### PR TITLE
Prepare to release `druid-derive` v0.5.1.

### DIFF
--- a/druid-derive/Cargo.toml
+++ b/druid-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "druid-derive"
-version = "0.5.0"
+version = "0.5.1"
 license = "Apache-2.0"
 authors = ["Druid authors"]
 description = "derive impls for Druid, a Rust UI toolkit."
@@ -16,8 +16,8 @@ default-target = "x86_64-pc-windows-msvc"
 
 [dependencies]
 syn = { version = "1.0.109", features = ["extra-traits"] }
-quote = "1.0.23"
-proc-macro2 = "1.0.51"
+quote = "1.0.26"
+proc-macro2 = "1.0.56"
 
 [dev-dependencies]
 druid = { version = "0.8.3", path = "../druid" }

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -52,7 +52,7 @@ image-all = ["image", "svg", "png", "jpeg", "jpeg_rayon", "gif", "bmp", "ico", "
 
 [dependencies]
 druid-shell = { version = "0.8.3", default-features = false, path = "../druid-shell" }
-druid-derive = { version = "0.5.0", path = "../druid-derive" }
+druid-derive = { version = "0.5.1", path = "../druid-derive" }
 
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.16", features = ["fmt", "ansi"], default-features = false }


### PR DESCRIPTION
With the recent merger of #2375 we have `master` in a good state. But of course the repro steps given in #2373 still produce an error.

```sh
cargo init my_app
cd my_app
cargo add druid
cargo run
```

This can be fixed by releasing v0.5.1 of `druid-derive` which will be picked up by cargo as it is semver compatible.