### PR TITLE
Fix Window light theme detection being backwards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ You can find its changes [documented below](#083---2023-02-28).
 ### Fixed
 
 - `syn` feature `extra-traits` is now always enabled. ([#2375] by [@AtomicGamer9523])
+- Title bar color was opposite of the system theme on Windows. ([#2378] by [@Insprill])
 
 ### Visual
 
@@ -785,6 +786,7 @@ Last release without a changelog :(
 [@giannissc]: https://github.com/giannissc
 [@newcomb-luke]: https://github.com/newcomb-luke
 [@AtomicGamer9523]: https://github.com/AtomicGamer9523
+[@Insprill]: https://github.com/Insprill
 
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611
@@ -1230,6 +1232,7 @@ Last release without a changelog :(
 [#2353]: https://github.com/linebender/druid/pull/2353
 [#2356]: https://github.com/linebender/druid/pull/2356
 [#2375]: https://github.com/linebender/druid/pull/2375
+[#2378]: https://github.com/linebender/druid/pull/2378
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.8.3...master
 [0.8.3]: https://github.com/linebender/druid/compare/v0.8.2...v0.8.3

--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -1749,7 +1749,7 @@ impl WindowBuilder {
             // Dark mode support
             // https://docs.microsoft.com/en-us/windows/apps/desktop/modernize/apply-windows-themes
             const DWMWA_USE_IMMERSIVE_DARK_MODE: u32 = 20;
-            let value = should_use_light_theme() as BOOL;
+            let value = should_use_dark_theme() as BOOL;
             let value_ptr = &value as *const _ as *const c_void;
             DwmSetWindowAttribute(
                 hwnd,
@@ -1780,7 +1780,7 @@ fn calculate_window_pos(parent_pos_dp: Option<Point>, pos_dp: Point, scale: Scal
 
 /// Attempt to read the registry and see if the system is set to a dark or
 /// light theme.
-pub fn should_use_light_theme() -> bool {
+pub fn should_use_dark_theme() -> bool {
     let mut data: [u8; 4] = [0; 4];
     let mut cb_data: u32 = data.len() as u32;
     let res = unsafe {

--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -1799,7 +1799,7 @@ pub fn should_use_light_theme() -> bool {
 
     // ERROR_SUCCESS
     if res == 0 {
-        i32::from_le_bytes(data) == 1
+        i32::from_le_bytes(data) == 0
     } else {
         true // Default to light theme.
     }

--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -1801,7 +1801,7 @@ pub fn should_use_dark_theme() -> bool {
     if res == 0 {
         i32::from_le_bytes(data) == 0
     } else {
-        true // Default to light theme.
+        false // Default to light theme.
     }
 }
 


### PR DESCRIPTION
In the Windows backend, when dark mode was enabled, `should_use_light_theme` would return true, and vice-versa. This caused the title bar's color to be the opposite of the system theme. This fixes that behavior so the title bar matches the system theme.