### PR TITLE
Change the default behavior of the ValueTextBox.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ You can find its changes [documented below](#083---2023-02-28).
 
 ### Outside News
 
+## [0.8.4] - 2023-05-26
+
+### Changed
+- set ValueTextBox to update value while editing by default. ([#7354d48] by [@jeremiahroise])
+
+### Docs
+- docs for function update_value_while_editing now mentions that is is true by default. ([#11ccafd] by [@jeremiahroise])
+
 ## [0.8.3] - 2023-02-28
 
 ### Added

--- a/druid/src/widget/value_textbox.rs
+++ b/druid/src/widget/value_textbox.rs
@@ -114,7 +114,7 @@ impl<T: Data> ValueTextBox<T> {
             is_editing: false,
             last_known_data: None,
             validate_while_editing: true,
-            update_data_while_editing: false,
+            update_data_while_editing: true,
             old_buffer: String::new(),
             buffer: String::new(),
             force_selection: None,

--- a/druid/src/widget/value_textbox.rs
+++ b/druid/src/widget/value_textbox.rs
@@ -142,7 +142,7 @@ impl<T: Data> ValueTextBox<T> {
     /// Builder-style method to set whether or not this text box updates the
     /// incoming data during editing.
     ///
-    /// If `false` (the default) the data is only updated when editing completes.
+    /// If `true` (the default) the data is updated while editing.
     pub fn update_data_while_editing(mut self, flag: bool) -> Self {
         self.update_data_while_editing = flag;
         self


### PR DESCRIPTION
 I think it would be far more intuitive if this was true by default because it would function more like a normal TextBox.

I was working on adding auto complete to a project of mine, and it was working great until I tried to add it to a ValueTextBox, I spent hours trying to figure out what was wrong with my Formmatter impl because I assumed there was some type of event or command that I should have passed on. Long story short eventually I found the update_value_while_editing function and was able to fix my problem.

thanks for your time and listening to my rant.