### PR TITLE
Add type_name to panic error messages in WidgetPod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ You can find its changes [documented below](#083---2023-02-28).
 
 ### Added
 
+- Type name is now included in panic error messages in WidgetPod ([#2376] by [@matthewgapp])
+
 ### Changed
 
 ### Deprecated
@@ -141,7 +143,7 @@ Later support was widened in [#2254] by [@PolyMeilex].
 - `ClipBox::unmanaged` constructor for when you are using `ClipBox` in the widget tree directly. ([#2141] by [@xarvic])
 - Scroll-to-view support for `ClipBox` and `Tabs`. ([#2141] by [@xarvic])
 - `with_tab_index`, `set_tab_index`, and `tab_index` methods to `Tabs` to control the index. ([#2082] by [@rjwittams]
-- `state` and `state_mut` methods to `Scope` to get references to the inner state.  ([#2082] by [@rjwittams]
+- `state` and `state_mut` methods to `Scope` to get references to the inner state. ([#2082] by [@rjwittams]
 - `Slider::with_step` method for stepping functionality. ([#1875] by [@raymanfx])
 - `RangeSlider` and `Annotated` widgets, which are both variations on `Slider`. ([#1979] by [@xarvic])
 - `Checkbox::from_label` constructor. ([#2111] by [@maurerdietmar])
@@ -296,7 +298,7 @@ Later support was widened in [#2254] by [@PolyMeilex].
 
 - Rewrote multiple chapters of the Druid book. ([#2301] by [@PoignardAzur])
 - Rewrote the lens chapter of the Druid book. ([#1444] by [@derekdreery])
-- Fixed example code in the *Get started with Druid* chapter of the book. ([#1698] by [@ccqpein])
+- Fixed example code in the _Get started with Druid_ chapter of the book. ([#1698] by [@ccqpein])
 - Added more detailed explanation of `Target::Auto`. ([#1761] by [@arthmis])
 - Added code examples to `TextBox` docs. ([#2284] by [@ThomasMcandrew])
 - Added a link to the [druid_widget_nursery](https://github.com/linebender/druid-widget-nursery) to `README.md`. ([#1754] by [@xarvic])
@@ -353,7 +355,7 @@ Later support was widened in [#2254] by [@PolyMeilex].
 
 - Text improvements: `TextLayout` type ([#1182]) and rich text support ([#1245]).
 - The `Formatter` trait provides more flexible handling of conversions between
-values and their textual representations. ([#1377])
+  values and their textual representations. ([#1377])
 
 ### Added
 
@@ -671,10 +673,15 @@ This means that Druid no longer requires Cairo on macOS and uses Core Graphics i
 Last release without a changelog :(
 
 ## [0.4.0] - 2019-12-28
+
 ## [0.3.2] - 2019-11-05
+
 ## [0.3.1] - 2019-11-04
+
 ## 0.3.0 - 2019-11-02
+
 ## 0.1.1 - 2018-11-02
+
 ## 0.1.0 - 2018-11-02
 
 [@futurepaul]: https://github.com/futurepaul
@@ -787,7 +794,6 @@ Last release without a changelog :(
 [@newcomb-luke]: https://github.com/newcomb-luke
 [@AtomicGamer9523]: https://github.com/AtomicGamer9523
 [@Insprill]: https://github.com/Insprill
-
 [#599]: https://github.com/linebender/druid/pull/599
 [#611]: https://github.com/linebender/druid/pull/611
 [#695]: https://github.com/linebender/druid/pull/695
@@ -1233,7 +1239,6 @@ Last release without a changelog :(
 [#2356]: https://github.com/linebender/druid/pull/2356
 [#2375]: https://github.com/linebender/druid/pull/2375
 [#2378]: https://github.com/linebender/druid/pull/2378
-
 [Unreleased]: https://github.com/linebender/druid/compare/v0.8.3...master
 [0.8.3]: https://github.com/linebender/druid/compare/v0.8.2...v0.8.3
 [0.8.2]: https://github.com/linebender/druid/compare/v0.8.1...v0.8.2

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -475,7 +475,8 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
 
         if !self.is_initialized() {
             debug_panic!(
-                "{:?}: paint method called before receiving WidgetAdded.",
+                "{:?} with widget id {:?}: paint method called before receiving WidgetAdded.",
+                self.inner.type_name(),
                 ctx.widget_id()
             );
             return;
@@ -549,7 +550,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
     ) -> Size {
         if !self.is_initialized() {
             debug_panic!(
-                "{:?} with widget id: {:?}: layout method called before receiving WidgetAdded.",
+                "{:?} with widget id {:?}: layout method called before receiving WidgetAdded.",
                 self.inner.type_name(),
                 ctx.widget_id()
             );
@@ -609,7 +610,8 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
     pub fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if !self.is_initialized() {
             debug_panic!(
-                "{:?}: event method called before receiving WidgetAdded.",
+                "{:?} with widget id {:?}: event method called before receiving WidgetAdded.",
+                self.inner.type_name(),
                 ctx.widget_id()
             );
             return;
@@ -618,8 +620,9 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         // log if we seem not to be laid out when we should be
         if self.state.is_expecting_set_origin_call && !event.should_propagate_to_hidden() {
             warn!(
-                "{:?} received an event ({:?}) without having been laid out. \
+                "{:?} with widget id {:?} received an event ({:?}) without having been laid out. \
                 This likely indicates a missed call to set_origin.",
+                self.inner.type_name(),
                 ctx.widget_id(),
                 event,
             );
@@ -1151,7 +1154,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                 (Some(_), None) => self.env = Some(env.clone()),
                 (None, _) => {
                     debug_panic!(
-                        "{:?} with widget id: {:?} is receiving an update without having first received WidgetAdded.",
+                        "{:?} with widget id {:?} is receiving an update without having first received WidgetAdded.",
                         self.inner.type_name(),
                         self.id()
                     );

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -549,7 +549,8 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
     ) -> Size {
         if !self.is_initialized() {
             debug_panic!(
-                "{:?}: layout method called before receiving WidgetAdded.",
+                "{:?} with widget id: {:?}: layout method called before receiving WidgetAdded.",
+                self.inner.type_name(),
                 ctx.widget_id()
             );
             return Size::ZERO;
@@ -1015,7 +1016,8 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             }
             _ if !self.is_initialized() => {
                 debug_panic!(
-                    "{:?}: received LifeCycle::{:?} before WidgetAdded.",
+                    "{:?} with widget id {:?}: received LifeCycle::{:?} before WidgetAdded.",
+                    self.inner.type_name(),
                     self.id(),
                     event
                 );
@@ -1149,7 +1151,8 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                 (Some(_), None) => self.env = Some(env.clone()),
                 (None, _) => {
                     debug_panic!(
-                        "{:?} is receiving an update without having first received WidgetAdded.",
+                        "{:?} with widget id: {:?} is receiving an update without having first received WidgetAdded.",
+                        self.inner.type_name(),
                         self.id()
                     );
                     return;


### PR DESCRIPTION
Hey, just started tinkering with Druid and think that it could work well for my current project. Although it's "discontinued", I'd like to start contributing to soften some of the rough edges while Xilem gets off the ground. 

This PR introduces a super small change, adding the typename to the panic messages. I ran into this while running down a another bug in my app. I couldn't make heads or tails about which component was causing issues because WidgetPod is used under the hood in so many places. I think adding information. about which type is experiencing the panic will be helpful to others, too. 