### PR TITLE
partially "reverting" PR #1617 to fix invalid rectangle paint issue which is causing visual artifacts almost anywhere an input field is used. 

### DIFF
--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -445,15 +445,14 @@ impl<T: Data> Window<T> {
             self.layout(queue, data, env);
         }
 
+        let reset_color = if self.transparent {
+            Color::TRANSPARENT
+        } else {
+            env.get(crate::theme::WINDOW_BACKGROUND_COLOR)
+        };
+
         for &r in invalid.rects() {
-            piet.clear(
-                Some(r),
-                if self.transparent {
-                    Color::TRANSPARENT
-                } else {
-                    env.get(crate::theme::WINDOW_BACKGROUND_COLOR)
-                },
-            );
+            piet.fill(r, &reset_color);
         }
         self.paint(piet, invalid, queue, data, env);
     }


### PR DESCRIPTION
This PR fills invalid rects with a reset color instead of filling them to fix https://github.com/linebender/druid/issues/2367 which is is easily reproducible on Mac (I'm on M1 Macbook) almost anywhere that uses an input field. 

This PR partially reverts #1617 to restore the invalidation painting to use `piet.fill` instead of `piet.clear`. 
 
I traced down the issue by bisecting but I don't know why this fixes the issue or if the invalidation painting should have ever used `clear` in the first place. Perhaps there is a bug with the `clear` method. 