### PR TITLE
implement compute max intrinsic on env scope

### DIFF
--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -113,6 +113,19 @@ impl<T: Data, W: Widget<T>> Widget<T> for EnvScope<T, W> {
             ..Default::default()
         }
     }
+
+    fn compute_max_intrinsic(
+        &mut self,
+        axis: super::Axis,
+        ctx: &mut LayoutCtx,
+        bc: &BoxConstraints,
+        data: &T,
+        env: &Env,
+    ) -> f64 {
+        self.child
+            .widget_mut()
+            .compute_max_intrinsic(axis, ctx, bc, data, env)
+    }
 }
 
 impl<T, W: Widget<T>> WidgetWrapper for EnvScope<T, W> {


### PR DESCRIPTION
Opening this PR for a discussion on the Widget API. 

A little bit of context: I've built a special scroll element that has its own implementation of `compute_max_intrinsic` (I do this so that I can call compute_max_intrinsic on the child instead of defaulting to the default implementation of calling layout on the scroll element. The motivation for my component-specific implementation isn't super important to this discussion, though. What's important is that certain widgets may have a good reason to implement their own version of `compute_max_intrinsics`. 

Because the default implementation calls layout (instead of `compute_max_instrinsic`), the `compute_max_intrinsic` call chain is broken whenever an intermediate child uses the blanket implementation. This sucks and makes the `compute_max_intrinsic` method pretty useless in ancestor components when `descendants` have their own implementations. 

This PR adds the necessary implementation to the `env_scope` component as a partial patch for my use case. 

A better fix would remove the default implementation in favor of implementors being required to implement the compute_max_intrinsic (and thus call the correct method on children). This pattern is used for event, lifecycle, update, layout, and paint. 

Naturally, removing the default implementation would be breaking so thought I'd bring it up here. But at the moment, the default implementation makes compute max intrinsic pretty useless/broken since any intermediate components that use the default implementation wipe out any widget-specific implementations downstream. 