### PR TITLE
Update GitHub Pages tools.

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,14 +7,14 @@ on:
 
 jobs:
   build-deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
 
     - name: Setup mdBook
       uses: peaceiris/actions-mdbook@v1
       with:
-        mdbook-version: '0.4.5'
+        mdbook-version: '0.4.30'
 
     - run: mdbook build docs
 


### PR DESCRIPTION
Ubuntu 18.04 in GitHub Actions was apparently [removed in April](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/). That's why our GitHub Pages job has been failing.

This PR updates the Ubuntu version which should make things run again.

I also took the opportunity to do a minor mdBook upgrade. Hopefully it works, we'll see once the job runs.