### PR TITLE
Fix book 404 page.

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -4,3 +4,6 @@ language = "en"
 multilingual = false
 src = "src"
 title = "Druid"
+
+[output.html]
+site-url = "/druid/"


### PR DESCRIPTION
The book currently has a broken 404 because it thinks it's running from the site root. This PR should fix this.

Issue discovered and solution proposed by @DJMcNab.