### PR TITLE
```self.value.push('.')``` calculator . fix __display

### DIFF
--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -88,7 +88,7 @@ impl CalcState {
             }
             '.' => {
                 if !self.in_num {
-                    self.value = "0".to_string();
+                    self.value.push('.');
                     self.in_num = true;
                 }
                 if self.value.find('.').is_none() {


### PR DESCRIPTION
 ex )
36. 3

If you press 36.3, 36 is followed by 3. I think this is better.


```rust
89            '.' => {
90                if !self.in_num {
91                    self.value.push('.');
92                    self.in_num = true;
93                }
```