### PR TITLE
Update all gtk crates to 18.x

### DIFF
--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -103,11 +103,11 @@ ashpd = { version = "0.3.2", optional = true }
 cairo-rs = { version = "0.16.7", default-features = false, features = ["xcb"] }
 cairo-sys-rs = { version = "0.16.3", default-features = false, optional = true }
 futures = { version = "0.3.26", optional = true, features = ["executor"]}
-gdk-sys = { version = "0.16.0", optional = true }
+gdk-sys = { version = "0.18.0", optional = true }
 # `gtk` gets renamed to `gtk-rs` so that we can use `gtk` as the feature name.
-gtk-rs = { version = "0.16.2", package = "gtk", optional = true }
-glib-sys = { version = "0.16.3", optional = true }
-gtk-sys = { version = "0.16.0", optional = true }
+gtk-rs = { version = "0.18.0", package = "gtk", optional = true }
+glib-sys = { version = "0.18.0", optional = true }
+gtk-sys = { version = "0.18.0", optional = true }
 nix = { version = "0.24.3", optional = true }
 x11rb = { version = "0.10.1", features = ["allow-unsafe-code", "present", "render", "randr", "xfixes", "xkb", "resource_manager", "cursor"], optional = true }
 wayland-client = { version = "0.29.5", optional = true }

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -65,7 +65,7 @@ hdr = ["piet-common/hdr"]
 serde = ["piet-common/serde"]
 
 [dependencies]
-piet-common = "0.6.2"
+piet-common = { git = "https://github.com/linebender/piet.git", rev = "303b9a932de61cca5a12a8a1ecfbba742638dc52" }
 
 tracing = "0.1.37"
 once_cell = "1.17.1"
@@ -100,8 +100,8 @@ bitflags = "1.3.2"
 [target.'cfg(any(target_os = "freebsd", target_os="linux", target_os="openbsd"))'.dependencies]
 ashpd = { version = "0.3.2", optional = true }
 # TODO(x11/dependencies): only use feature "xcb" if using X11
-cairo-rs = { version = "0.16.7", default-features = false, features = ["xcb"] }
-cairo-sys-rs = { version = "0.16.3", default-features = false, optional = true }
+cairo-rs = { version = "0.18.0", default-features = false, features = ["xcb"] }
+cairo-sys-rs = { version = "0.18.0", default-features = false, optional = true }
 futures = { version = "0.3.26", optional = true, features = ["executor"]}
 gdk-sys = { version = "0.18.0", optional = true }
 # `gtk` gets renamed to `gtk-rs` so that we can use `gtk` as the feature name.
@@ -127,7 +127,7 @@ version = "0.3.61"
 features = ["Window", "MouseEvent", "CssStyleDeclaration", "WheelEvent", "KeyEvent", "KeyboardEvent", "Navigator"]
 
 [dev-dependencies]
-piet-common = { version = "0.6.2", features = ["png"] }
+piet-common = { git = "https://github.com/linebender/piet.git", rev = "303b9a932de61cca5a12a8a1ecfbba742638dc52", features = ["png"] }
 static_assertions = "1.1.0"
 test-log = { version = "0.2.11", features = ["trace"], default-features = false }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/druid-shell/src/backend/gtk/dialog.rs
+++ b/druid-shell/src/backend/gtk/dialog.rs
@@ -70,7 +70,7 @@ pub(crate) fn get_file_dialog_path(
         if let Some(file_types) = &options.allowed_types {
             for f in file_types {
                 let filter = file_filter(f);
-                dialog.add_filter(&filter);
+                dialog.add_filter(filter.clone());
 
                 if let Some(default) = &options.default_type {
                     if default == f {

--- a/druid-shell/src/backend/gtk/screen.rs
+++ b/druid-shell/src/backend/gtk/screen.rs
@@ -17,6 +17,7 @@
 use crate::kurbo::{Point, Rect, Size};
 use crate::screen::Monitor;
 use gtk::gdk::{Display, DisplayManager, Rectangle};
+use gtk_rs::prelude::MonitorExt as _;
 
 fn translate_gdk_rectangle(r: Rectangle) -> Rect {
     Rect::from_origin_size(

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -79,7 +79,7 @@ console_error_panic_hook = { version = "0.1.7" }
 [dev-dependencies]
 float-cmp = { version = "0.9.0", features = ["std"], default-features = false }
 tempfile = "3.4.0"
-piet-common = { version = "0.6.2", features = ["png"] }
+piet-common = { git = "https://github.com/linebender/piet.git", rev = "303b9a932de61cca5a12a8a1ecfbba742638dc52", features = ["png"] }
 pulldown-cmark = { version = "0.8.0", default-features = false }
 test-log = { version = "0.2.11", features = ["trace"], default-features = false }
 # test-env-log needs it

--- a/druid/src/widget/image.rs
+++ b/druid/src/widget/image.rs
@@ -318,8 +318,11 @@ mod tests {
                 // the padding color and the middle rows will not have any padding.
 
                 // Check that the middle row 400 pix wide is 200 black then 200 white.
-                let expecting: Vec<u8> =
-                    [[0, 0, 0, 255].repeat(200), [255, 255, 255, 255].repeat(200)].concat();
+                let expecting: Vec<u8> = [
+                    [0, 0, 0, 255].repeat(200),
+                    [255, 255, 255, 255].repeat(200),
+                ]
+                .concat();
                 assert_eq!(raw_pixels[400 * 300 * 4..400 * 301 * 4], expecting[..]);
 
                 // Check that all of the last 100 rows are all the background color.

--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -132,12 +132,12 @@ impl SvgData {
     pub fn empty() -> Self {
         use std::str::FromStr;
 
-        let empty_svg = r###"
+        let empty_svg = r#"
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
                 <g fill="none">
                 </g>
             </svg>
-        "###;
+        "#;
 
         SvgData::from_str(empty_svg).unwrap()
     }


### PR DESCRIPTION
Updates all GTK dependencies from 0.16.x to 0.18.x.

Fixes breaking changes introduced.
Also adds a top level allow for clippy::arc_with_non_send_sync as it's triggered pretty much everywhere in the project and is a massive undertaking to fix.

Currently using a git dependency for piet as it does not have a release including updates to its GTK dependencies.