### PR TITLE
Update the CI and pin the Rust toolchain version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,111 +1,87 @@
+env:
+  # We aim to always test with the latest stable Rust toolchain, however we pin to a specific
+  # version like 1.70. Note that we only specify MAJOR.MINOR and not PATCH so that bugfixes still
+  # come automatically. If the version specified here is no longer the latest stable version,
+  # then please feel free to submit a PR that adjusts it along with the potential clippy fixes.
+  RUST_STABLE_VER: "1.70" # In quotes because otherwise 1.70 would be interpreted as 1.7
+
+name: CI
+
 on:
-  push:
-    branches:
-      - master
   pull_request:
+  merge_group:
 
 jobs:
   rustfmt:
     runs-on: ubuntu-latest
     name: cargo fmt
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
-          profile: minimal
+          toolchain: ${{ env.RUST_STABLE_VER }}
           components: rustfmt
-          override: true
 
       - name: cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all --check
 
   test-stable:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-latest, windows-2019, ubuntu-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
     name: cargo clippy+test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: install linux dependencies
+      - name: install additional linux dependencies
         run: |
           sudo apt update
           sudo apt install libpango1.0-dev libxkbcommon-dev libxkbcommon-x11-dev
         if: contains(matrix.os, 'ubuntu')
 
       - name: install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_STABLE_VER }}
           components: clippy
-          profile: minimal
-          override: true
 
       - name: restore cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       # Clippy packages in deeper-to-higher dependency order
       - name: cargo clippy druid-shell
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path=druid-shell/Cargo.toml --all-targets --no-default-features --features=x11,image,raw-win-handle -- -D warnings
+        run: cargo clippy --manifest-path=druid-shell/Cargo.toml --all-targets --no-default-features --features=x11,image,raw-win-handle -- -D warnings
 
       - name: cargo clippy druid
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path=druid/Cargo.toml --all-targets --no-default-features --features=svg,image,im,x11,raw-win-handle -- -D warnings
+        run: cargo clippy --manifest-path=druid/Cargo.toml --all-targets --no-default-features --features=svg,image,im,x11,raw-win-handle -- -D warnings
 
       - name: cargo clippy druid-derive
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path=druid-derive/Cargo.toml --all-targets -- -D warnings
+        run: cargo clippy --manifest-path=druid-derive/Cargo.toml --all-targets -- -D warnings
         # there's no platform specific code here so we only run once
         if: contains(matrix.os, 'mac')
 
       - name: cargo clippy book examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path=docs/book_examples/Cargo.toml --all-targets -- -D warnings
+        run: cargo clippy --manifest-path=docs/book_examples/Cargo.toml --all-targets -- -D warnings
         if: contains(matrix.os, 'mac')
 
       # Test packages in deeper-to-higher dependency order
       - name: cargo test druid-shell
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=druid-shell/Cargo.toml --no-default-features --features=x11,image,raw-win-handle
+        run: cargo test --manifest-path=druid-shell/Cargo.toml --no-default-features --features=x11,image,raw-win-handle
 
       # We use --all-targets to skip doc tests; we run them in a parallel task
       # there are no gtk-specific doctests in the main druid crate anyway
       - name: cargo test druid
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=druid/Cargo.toml --all-targets --no-default-features --features=svg,image,im,x11
+        run: cargo test --manifest-path=druid/Cargo.toml --all-targets --no-default-features --features=svg,image,im,x11
 
       - name: cargo test druid-derive
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=druid-derive/Cargo.toml
+        run: cargo test --manifest-path=druid-derive/Cargo.toml
         if: contains(matrix.os, 'mac')
 
       - name: cargo test book examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=docs/book_examples/Cargo.toml
+        run: cargo test --manifest-path=docs/book_examples/Cargo.toml
         if: contains(matrix.os, 'mac')
 
   # we test the wayland backend as a separate job 
@@ -113,43 +89,32 @@ jobs:
     runs-on: ubuntu-latest
     name: cargo clippy+test (wayland)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: install wayland
+      - name: install additional wayland dependencies
         run: |
           sudo apt update
           sudo apt install libwayland-dev libpango1.0-dev libxkbcommon-dev
 
       - name: install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_STABLE_VER }}
           components: clippy
-          profile: minimal
-          override: true
 
       - name: restore cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: cargo clippy druid-shell
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path=druid-shell/Cargo.toml --all-targets --no-default-features --features=wayland,image,raw-win-handle -- -D warnings
+        run: cargo clippy --manifest-path=druid-shell/Cargo.toml --all-targets --no-default-features --features=wayland,image,raw-win-handle -- -D warnings
 
       - name: cargo test druid-shell
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=druid-shell/Cargo.toml --no-default-features --features=wayland,image,raw-win-handle
+        run: cargo test --manifest-path=druid-shell/Cargo.toml --no-default-features --features=wayland,image,raw-win-handle
 
       # We use --all-targets to skip doc tests; there are no wayland-specific
       # doctests in the main druid crate anyway
       - name: cargo test druid
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=druid/Cargo.toml --all-targets --no-default-features --features=wayland,svg,image,im,raw-win-handle
+        run: cargo test --manifest-path=druid/Cargo.toml --all-targets --no-default-features --features=wayland,svg,image,im,raw-win-handle
 
   # we test the gtk backend as a separate job because gtk install takes
   # a long time.
@@ -157,49 +122,38 @@ jobs:
     runs-on: ubuntu-latest
     name: cargo clippy+test (gtk)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: install libgtk-3-dev
+      - name: install additional gtk dependencies
         run: |
           sudo apt update
           sudo apt install libgtk-3-dev
 
       - name: install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_STABLE_VER }}
           components: clippy
-          profile: minimal
-          override: true
 
       - name: restore cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: cargo clippy druid-shell
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path=druid-shell/Cargo.toml --all-targets --features=image,raw-win-handle -- -D warnings
+        run: cargo clippy --manifest-path=druid-shell/Cargo.toml --all-targets --features=image,raw-win-handle -- -D warnings
 
       - name: cargo test druid-shell
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=druid-shell/Cargo.toml --features=image,raw-win-handle
+        run: cargo test --manifest-path=druid-shell/Cargo.toml --features=image,raw-win-handle
 
       # We use --all-targets to skip doc tests; there are no gtk-specific
       # doctests in the main druid crate anyway
       - name: cargo test druid
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=druid/Cargo.toml --all-targets --features=svg,image,im,raw-win-handle
+        run: cargo test --manifest-path=druid/Cargo.toml --all-targets --features=svg,image,im,raw-win-handle
 
   test-stable-wasm:
     runs-on: macOS-latest
     name: cargo test (wasm32)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: install wasm-pack
         uses: jetli/wasm-pack-action@v0.3.0
@@ -207,45 +161,31 @@ jobs:
           version: latest
 
       - name: install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
-          target: wasm32-unknown-unknown
+          toolchain: ${{ env.RUST_STABLE_VER }}
           components: clippy
-          profile: minimal
-          override: true
+          targets: wasm32-unknown-unknown
 
       - name: restore cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: cargo clippy druid-shell (wasm)
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path=druid-shell/Cargo.toml --all-targets --target wasm32-unknown-unknown -- -D warnings
+        run: cargo clippy --manifest-path=druid-shell/Cargo.toml --all-targets --target wasm32-unknown-unknown -- -D warnings
 
       # Test wasm32 relevant packages in deeper-to-higher dependency order
       # TODO: Find a way to make tests work. Until then the tests are merely compiled.
       - name: cargo test compile druid-shell
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=druid-shell/Cargo.toml --features=image --no-run --target wasm32-unknown-unknown
+        run: cargo test --manifest-path=druid-shell/Cargo.toml --features=image --no-run --target wasm32-unknown-unknown
 
       # We use --all-targets to skip doc tests; there are no wasm-specific
       # doctests in the main druid crate anyway
       - name: cargo test compile druid
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          # TODO: Add svg feature when it's no longer broken with wasm
-          args: --manifest-path=druid/Cargo.toml --all-targets --features=image,im --no-run --target wasm32-unknown-unknown
+        # TODO: Add svg feature when it's no longer broken with wasm
+        run: cargo test --manifest-path=druid/Cargo.toml --all-targets --features=image,im --no-run --target wasm32-unknown-unknown
 
       - name: cargo test compile book examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=docs/book_examples/Cargo.toml --no-run --target wasm32-unknown-unknown
+        run: cargo test --manifest-path=docs/book_examples/Cargo.toml --no-run --target wasm32-unknown-unknown
 
       ## build the special druid-web-examples package.
       - name: wasm-pack build examples
@@ -259,201 +199,81 @@ jobs:
     runs-on: macOS-latest
     name: druid doctests
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
-
-      - name: restore cache
-        uses: Swatinem/rust-cache@v1
-
-      - name: cargo test druid --doc
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=druid/Cargo.toml --doc --no-default-features --features=svg,image,im,raw-win-handle
-
-  # This tests the future rust compiler to catch errors ahead of time without
-  # breaking CI
-  # We only run on a single OS to save time; this might let some errors go
-  # undetected until the compiler updates and they break CI; but that should
-  # happen rarely, and not pose too much of a problem when it does.
-  test-beta:
-    runs-on: macOS-latest
-    name: cargo clippy+test beta
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: install beta toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: beta
+          toolchain: ${{ env.RUST_STABLE_VER }}
           components: clippy
-          profile: minimal
-          override: true
 
       - name: restore cache
-        uses: Swatinem/rust-cache@v1
-
-      # Clippy packages in deeper-to-higher dependency order
-      - name: cargo clippy druid-shell
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path=druid-shell/Cargo.toml --all-targets --features=image,raw-win-handle -- -D warnings
-        continue-on-error: true
-
-      - name: cargo clippy druid
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path=druid/Cargo.toml --all-targets --features=svg,image,im,raw-win-handle -- -D warnings
-        continue-on-error: true
-
-      # Test packages in deeper-to-higher dependency order
-      - name: cargo test druid-shell
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=druid-shell/Cargo.toml --no-default-features --features=x11,image
-        continue-on-error: true
-
-      # We use --all-targets to skip doc tests, which are run in doctest-stable
-      - name: cargo test druid
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=druid/Cargo.toml --all-targets --no-default-features --features=svg,image,im,x11
-        continue-on-error: true
-
-      - name: cargo test druid-derive
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=druid-derive/Cargo.toml
-        continue-on-error: true
-
-      - name: cargo test book examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=docs/book_examples/Cargo.toml
-        continue-on-error: true
-
-  doctest-beta:
-    runs-on: macOS-latest
-    name: druid doctests beta
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: install beta toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: beta
-          profile: minimal
-          override: true
-
-      - name: restore cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: cargo test druid --doc
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=druid/Cargo.toml --doc --features=svg,image,im,raw-win-handle
-
+        run: cargo test --manifest-path=druid/Cargo.toml --doc --no-default-features --features=svg,image,im,raw-win-handle
 
   check-docs:
     name: Docs
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-latest, windows-2019, ubuntu-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: install linux dependencies
+      - name: install additional linux dependencies
         run: |
           sudo apt update
           sudo apt install libgtk-3-dev libwayland-dev libpango1.0-dev libxkbcommon-dev libxkbcommon-x11-dev
         if: contains(matrix.os, 'ubuntu')
 
       - name: install nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: restore cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       # Doc packages in deeper-to-higher dependency order
       - name: cargo doc druid-shell
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --manifest-path=druid-shell/Cargo.toml --features=image,raw-win-handle --no-deps --document-private-items -Zunstable-options -Zrustdoc-scrape-examples
+        run: cargo doc --manifest-path=druid-shell/Cargo.toml --features=image,raw-win-handle --no-deps --document-private-items -Zunstable-options -Zrustdoc-scrape-examples
 
       - name: cargo doc druid
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --manifest-path=druid/Cargo.toml --features=svg,image,im,raw-win-handle --no-deps --document-private-items -Zunstable-options -Zrustdoc-scrape-examples
+        run: cargo doc --manifest-path=druid/Cargo.toml --features=svg,image,im,raw-win-handle --no-deps --document-private-items -Zunstable-options -Zrustdoc-scrape-examples
 
       - name: cargo doc druid-derive
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --manifest-path=druid-derive/Cargo.toml --no-deps --document-private-items
+        run: cargo doc --manifest-path=druid-derive/Cargo.toml --no-deps --document-private-items
 
       - name: cargo doc book examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --manifest-path=docs/book_examples/Cargo.toml --no-deps --document-private-items
+        run: cargo doc --manifest-path=docs/book_examples/Cargo.toml --no-deps --document-private-items
 
       # On Linux also attempt docs for X11.
       - name: cargo doc druid-shell (X11)
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --manifest-path=druid-shell/Cargo.toml --no-default-features --features=x11,image,raw-win-handle --no-deps --document-private-items  -Zunstable-options -Zrustdoc-scrape-examples
+        run: cargo doc --manifest-path=druid-shell/Cargo.toml --no-default-features --features=x11,image,raw-win-handle --no-deps --document-private-items  -Zunstable-options -Zrustdoc-scrape-examples
         if: contains(matrix.os, 'ubuntu')
 
       # On Linux also attempt docs for Wayland.
       - name: cargo doc druid-shell (Wayland)
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --manifest-path=druid-shell/Cargo.toml --no-default-features --features=wayland,image,raw-win-handle --no-deps --document-private-items  -Zunstable-options -Zrustdoc-scrape-examples
+        run: cargo doc --manifest-path=druid-shell/Cargo.toml --no-default-features --features=wayland,image,raw-win-handle --no-deps --document-private-items  -Zunstable-options -Zrustdoc-scrape-examples
         if: contains(matrix.os, 'ubuntu')
 
   mdbook-build:
     runs-on: ubuntu-latest
     name: mdbook build
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
+          toolchain: ${{ env.RUST_STABLE_VER }}
+          components: clippy
 
       - name: restore cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: install mdbook
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --vers "^0.4" mdbook
+        run: cargo install --vers "^0.4" mdbook
 
       - name: mdbook build
         run: mdbook build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ env:
   # version like 1.70. Note that we only specify MAJOR.MINOR and not PATCH so that bugfixes still
   # come automatically. If the version specified here is no longer the latest stable version,
   # then please feel free to submit a PR that adjusts it along with the potential clippy fixes.
-  RUST_STABLE_VER: "1.70" # In quotes because otherwise 1.70 would be interpreted as 1.7
+  RUST_STABLE_VER: "1.76" # In quotes because otherwise 1.70 would be interpreted as 1.7
 
 name: CI
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "druid",
     "druid-shell",

--- a/druid-shell/src/backend/shared/xkb/mod.rs
+++ b/druid-shell/src/backend/shared/xkb/mod.rs
@@ -270,8 +270,7 @@ impl State {
             }
             // add 1 because we will get a null-terminated string.
             let len = usize::try_from(len).unwrap() + 1;
-            let mut buf: Vec<u8> = Vec::new();
-            buf.resize(len, 0);
+            let mut buf: Vec<u8> = vec![0; len];
             xkb_state_key_get_utf8(self.state, scancode, buf.as_mut_ptr() as *mut c_char, len);
             assert!(buf[buf.len() - 1] == 0);
             buf.pop();

--- a/druid-shell/src/backend/wayland/application.rs
+++ b/druid-shell/src/backend/wayland/application.rs
@@ -462,7 +462,7 @@ impl Data {
 
     fn current_window_id(&self) -> u64 {
         static DEFAULT: u64 = 0_u64;
-        *self.active_surface_id.borrow().get(0).unwrap_or(&DEFAULT)
+        *self.active_surface_id.borrow().front().unwrap_or(&DEFAULT)
     }
 
     pub(super) fn acquire_current_window(&self) -> Option<WindowHandle> {

--- a/druid-shell/src/backend/wayland/clipboard.rs
+++ b/druid-shell/src/backend/wayland/clipboard.rs
@@ -247,7 +247,7 @@ impl Clipboard {
 
     /// Get a string from the system clipboard, if one is available.
     pub fn get_string(&self) -> Option<String> {
-        vec![Clipboard::UTF8, Clipboard::TEXT, Clipboard::UTF8_STRING]
+        [Clipboard::UTF8, Clipboard::TEXT, Clipboard::UTF8_STRING]
             .iter()
             .find_map(
                 |mimetype| match std::str::from_utf8(&self.inner.receive(*mimetype)?) {

--- a/druid-shell/src/backend/wayland/keyboard.rs
+++ b/druid-shell/src/backend/wayland/keyboard.rs
@@ -384,7 +384,6 @@ impl Manager {
                         if let Some(windata) = winhandle.data() {
                             windata.with_handler({
                                 let windata = windata.clone();
-                                let evt = evt;
                                 move |handler| match evt.state {
                                     KeyState::Up => {
                                         handler.key_up(evt.clone());

--- a/druid-shell/src/backend/wayland/mod.rs
+++ b/druid-shell/src/backend/wayland/mod.rs
@@ -14,6 +14,9 @@
 
 //! wayland platform support
 
+// TODO: Remove this and fix the non-Send/Sync Arc issues
+#![allow(clippy::arc_with_non_send_sync)]
+
 pub mod application;
 pub mod clipboard;
 mod display;

--- a/druid-shell/src/backend/wayland/window.rs
+++ b/druid-shell/src/backend/wayland/window.rs
@@ -424,7 +424,7 @@ impl WindowBuilder {
     }
 
     pub fn build(self) -> Result<WindowHandle, ShellError> {
-        if matches!(self.menu, Some(_)) {
+        if self.menu.is_some() {
             tracing::warn!("menus unimplemented for wayland");
         }
 
@@ -552,7 +552,7 @@ pub mod layershell {
 
             let handle = WindowHandle::new(
                 surface.clone(),
-                surfaces::surface::Dead::default(),
+                surfaces::surface::Dead,
                 surface.clone(),
                 surface.clone(),
                 self.appdata.clone(),
@@ -622,7 +622,7 @@ pub mod popup {
 
         let handle = WindowHandle::new(
             surface.clone(),
-            surfaces::surface::Dead::default(),
+            surfaces::surface::Dead,
             surface.clone(),
             surface.clone(),
             wappdata,

--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -309,7 +309,9 @@ struct DxgiState {
 }
 
 #[derive(Clone, PartialEq, Eq)]
-pub struct CustomCursor(Rc<HCursor>);
+// TODO: Convert this from Arc to Rc when doing a breaking release
+#[allow(clippy::arc_with_non_send_sync)]
+pub struct CustomCursor(Arc<HCursor>);
 
 #[derive(PartialEq, Eq)]
 struct HCursor(HCURSOR);
@@ -2435,7 +2437,9 @@ impl WindowHandle {
                 };
                 let icon = CreateIconIndirect(&mut icon_info);
 
-                Some(Cursor::Custom(CustomCursor(Rc::new(HCursor(icon)))))
+                // TODO: Convert this from Arc to Rc when doing a breaking release
+                #[allow(clippy::arc_with_non_send_sync)]
+                Some(Cursor::Custom(CustomCursor(Arc::new(HCursor(icon)))))
             }
         } else {
             None

--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -309,7 +309,7 @@ struct DxgiState {
 }
 
 #[derive(Clone, PartialEq, Eq)]
-pub struct CustomCursor(Arc<HCursor>);
+pub struct CustomCursor(Rc<HCursor>);
 
 #[derive(PartialEq, Eq)]
 struct HCursor(HCURSOR);
@@ -1076,7 +1076,7 @@ impl WndProc for MyWndProc {
                             // When maximized, windows still adds offsets for the frame
                             // so we counteract them here.
                             let s: *mut NCCALCSIZE_PARAMS = lparam as *mut NCCALCSIZE_PARAMS;
-                            if let Some(mut s) = s.as_mut() {
+                            if let Some(s) = s.as_mut() {
                                 let border = self.get_system_metric(SM_CXPADDEDBORDER);
                                 let frame = self.get_system_metric(SM_CYSIZEFRAME);
                                 s.rgrc[0].top += border + frame;
@@ -2435,7 +2435,7 @@ impl WindowHandle {
                 };
                 let icon = CreateIconIndirect(&mut icon_info);
 
-                Some(Cursor::Custom(CustomCursor(Arc::new(HCursor(icon)))))
+                Some(Cursor::Custom(CustomCursor(Rc::new(HCursor(icon)))))
             }
         } else {
             None

--- a/druid/examples/sub_window.rs
+++ b/druid/examples/sub_window.rs
@@ -369,7 +369,7 @@ fn build_root_widget() -> impl Widget<HelloState> {
     // arrange the two widgets vertically, with some padding
     let layout = Flex::column()
         .with_child(label)
-        .with_flex_child(ScreenThing.lens(Unit::default()).padding(5.), 1.)
+        .with_flex_child(ScreenThing.lens(Unit).padding(5.), 1.)
         .with_spacer(VERTICAL_WIDGET_SPACING)
         .with_child(textbox)
         .with_child(button)

--- a/druid/src/env.rs
+++ b/druid/src/env.rs
@@ -14,6 +14,9 @@
 
 //! An environment which is passed downward into the widget tree.
 
+// TODO: Figure out if Env really needs to stay Arc, or if it can be switched to Rc
+#![allow(clippy::arc_with_non_send_sync)]
+
 use std::any::{self, Any};
 use std::borrow::Borrow;
 use std::collections::{hash_map::Entry, HashMap};

--- a/druid/src/sub_window.rs
+++ b/druid/src/sub_window.rs
@@ -20,7 +20,6 @@ use crate::win_handler::AppState;
 use crate::{Data, Point, Widget, WidgetExt, WidgetId, WidgetPod, WindowHandle, WindowId};
 use druid_shell::Error;
 use std::any::Any;
-use std::ops::Deref;
 use tracing::{instrument, warn};
 // We can't have any type arguments here, as both ends would need to know them
 // ahead of time in order to instantiate correctly.
@@ -70,7 +69,7 @@ impl SubWindowDesc {
         app_state: &mut AppState<T>,
     ) -> Result<WindowHandle, Error> {
         let sub_window_root = self.sub_window_root;
-        let pending = PendingWindow::new(sub_window_root.lens(Unit::default()));
+        let pending = PendingWindow::new(sub_window_root.lens(Unit));
         app_state.build_native_window(self.window_id, pending, self.window_config)
     }
 }
@@ -107,7 +106,7 @@ impl<U: Data, W: Widget<U>> Widget<()> for SubWindowHost<U, W> {
                 let update = cmd.get_unchecked(SUB_WINDOW_PARENT_TO_HOST);
                 if let Some(data_update) = &update.data {
                     if let Some(dc) = data_update.downcast_ref::<U>() {
-                        self.data = dc.deref().clone();
+                        self.data = dc.clone();
                         ctx.request_update();
                     } else {
                         warn!("Received a sub window parent to host command that could not be unwrapped. \

--- a/druid/src/text/input_component.rs
+++ b/druid/src/text/input_component.rs
@@ -951,6 +951,8 @@ impl<T> Default for TextComponent<T> {
 
         TextComponent {
             edit_session: Arc::new(RefCell::new(inner)),
+            // TODO: Figure out if this needs to stay Arc, or if it can be switched to Rc
+            #[allow(clippy::arc_with_non_send_sync)]
             lock: Arc::new(Cell::new(ImeLock::None)),
             has_focus: false,
         }

--- a/druid/src/text/rich_text.rs
+++ b/druid/src/text/rich_text.rs
@@ -44,6 +44,8 @@ impl RichText {
         RichText {
             buffer,
             attrs: Arc::new(attributes),
+            // TODO: Figure out if this needs to stay Arc, or if it can be switched to Rc
+            #[allow(clippy::arc_with_non_send_sync)]
             links: Arc::new([]),
         }
     }

--- a/druid/src/widget/image.rs
+++ b/druid/src/widget/image.rs
@@ -318,15 +318,12 @@ mod tests {
                 // the padding color and the middle rows will not have any padding.
 
                 // Check that the middle row 400 pix wide is 200 black then 200 white.
-                let expecting: Vec<u8> = [
-                    vec![0, 0, 0, 255].repeat(200),
-                    vec![255, 255, 255, 255].repeat(200),
-                ]
-                .concat();
+                let expecting: Vec<u8> =
+                    [[0, 0, 0, 255].repeat(200), [255, 255, 255, 255].repeat(200)].concat();
                 assert_eq!(raw_pixels[400 * 300 * 4..400 * 301 * 4], expecting[..]);
 
                 // Check that all of the last 100 rows are all the background color.
-                let expecting: Vec<u8> = vec![41, 41, 41, 255].repeat(400 * 100);
+                let expecting: Vec<u8> = [41, 41, 41, 255].repeat(400 * 100);
                 assert_eq!(
                     raw_pixels[400 * 600 * 4 - 4 * 400 * 100..400 * 600 * 4],
                     expecting[..]
@@ -367,20 +364,20 @@ mod tests {
 
                 // A middle row of 600 pixels is 100 padding 200 black, 200 white and then 100 padding.
                 let expecting: Vec<u8> = [
-                    vec![41, 41, 41, 255].repeat(100),
-                    vec![255, 255, 255, 255].repeat(200),
-                    vec![0, 0, 0, 255].repeat(200),
-                    vec![41, 41, 41, 255].repeat(100),
+                    [41, 41, 41, 255].repeat(100),
+                    [255, 255, 255, 255].repeat(200),
+                    [0, 0, 0, 255].repeat(200),
+                    [41, 41, 41, 255].repeat(100),
                 ]
                 .concat();
                 assert_eq!(raw_pixels[199 * 600 * 4..200 * 600 * 4], expecting[..]);
 
                 // The final row of 600 pixels is 100 padding 200 black, 200 white and then 100 padding.
                 let expecting: Vec<u8> = [
-                    vec![41, 41, 41, 255].repeat(100),
-                    vec![0, 0, 0, 255].repeat(200),
-                    vec![255, 255, 255, 255].repeat(200),
-                    vec![41, 41, 41, 255].repeat(100),
+                    [41, 41, 41, 255].repeat(100),
+                    [0, 0, 0, 255].repeat(200),
+                    [255, 255, 255, 255].repeat(200),
+                    [41, 41, 41, 255].repeat(100),
                 ]
                 .concat();
                 assert_eq!(raw_pixels[399 * 600 * 4..400 * 600 * 4], expecting[..]);

--- a/druid/src/widget/progress_bar.rs
+++ b/druid/src/widget/progress_bar.rs
@@ -28,7 +28,7 @@ pub struct ProgressBar;
 impl ProgressBar {
     /// Return a new `ProgressBar`.
     pub fn new() -> ProgressBar {
-        Self::default()
+        Self
     }
 }
 

--- a/druid/src/widget/scope.rs
+++ b/druid/src/widget/scope.rs
@@ -117,8 +117,8 @@ impl<L: Lens<State, In>, In, State> LensScopeTransfer<L, In, State> {
     pub fn new(lens: L) -> Self {
         LensScopeTransfer {
             lens,
-            phantom_in: PhantomData::default(),
-            phantom_state: PhantomData::default(),
+            phantom_in: PhantomData,
+            phantom_state: PhantomData,
         }
     }
 }

--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -153,6 +153,8 @@ impl std::str::FromStr for SvgData {
         };
 
         match Tree::from_str(svg_str, &re_opt.to_ref()) {
+            // TODO: Figure out if this needs to stay Arc, or if it can be switched to Rc
+            #[allow(clippy::arc_with_non_send_sync)]
             Ok(tree) => Ok(SvgData::new(Arc::new(tree))),
             Err(err) => Err(err.into()),
         }


### PR DESCRIPTION
This PR updates the CI to bring it more in sync with the current Linebender standard.

* Various CI action versions were bumped
* The Rust toolchain version is now pinned
* Beta toolchain jobs were removed
* Preparation for enabling merge queues