### PR TITLE
RadioGroup size and padding

### DIFF
--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -128,7 +128,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
         bc.debug_check("Radio");
 
         let label_size = self.child_label.layout(ctx, bc, data, env);
-        let radio_diam = self.button_size; //env.get(theme::BASIC_WIDGET_HEIGHT);
+        let radio_diam = env.get(theme::BASIC_WIDGET_HEIGHT);
         let x_padding = env.get(theme::WIDGET_CONTROL_COMPONENT_PADDING);
 
         let desired_size = Size::new(
@@ -165,7 +165,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
             env.get(theme::BORDER_DARK)
         };
         
-        ctx.stroke(circle, &border_color, 2.);
+        ctx.stroke(circle, &border_color, 1.);
 
         // Check if data enum matches our variant
         if *data == self.variant {

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -133,7 +133,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
 
         let desired_size = Size::new(
             label_size.width + radio_diam + x_padding,
-            radio_diam.max(label_size.height),
+            label_size.height//radio_diam.max(label_size.height),
         );
         let size = bc.constrain(desired_size);
         trace!("Computed size: {}", size);

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -183,7 +183,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
         }
 
         // Paint the text label
-        self.child_label.draw_at(ctx, (size + x_padding, 0.0));
+        self.child_label.draw_at(ctx, (size + x_padding, -2.0));
     }
 
     fn debug_state(&self, data: &T) -> DebugState {

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -183,7 +183,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
         }
 
         // Paint the text label
-        self.child_label.draw_at(ctx, (size + x_padding, (size/(size/2.0)*-1.0-1.0).ceil()));
+        self.child_label.draw_at(ctx, (size + x_padding, (size/(size/2.0)*-1.0+(size/(size/2.0)/2.0).ceil())));
     }
 
     fn debug_state(&self, data: &T) -> DebugState {

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -183,7 +183,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
         }
 
         // Paint the text label
-        self.child_label.draw_at(ctx, (size + x_padding, size/2.));
+        self.child_label.draw_at(ctx, (size + x_padding, size));
     }
 
     fn debug_state(&self, data: &T) -> DebugState {

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -142,10 +142,11 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
 
     #[instrument(name = "Radio", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
-        let size = self.button_size; //env.get(theme::BASIC_WIDGET_HEIGHT);
+        let size =  env.get(theme::BASIC_WIDGET_HEIGHT);
+        let radius = self.button_size;
         let x_padding = env.get(theme::WIDGET_CONTROL_COMPONENT_PADDING);
 
-        let circle = Circle::new((size / 2., size / 2.), size);
+        let circle = Circle::new((size / 2., size / 2.), radius);
 
         // Paint the background
         let background_gradient = LinearGradient::new(
@@ -169,7 +170,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
 
         // Check if data enum matches our variant
         if *data == self.variant {
-            let inner_circle = Circle::new((size / 2., size / 2.), (size/3.0).ceil());
+            let inner_circle = Circle::new((size / 2., size / 2.), (radius/3.0).ceil());
 
             let fill = if ctx.is_disabled() {
                 env.get(theme::DISABLED_TEXT_COLOR)

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -17,7 +17,7 @@
 use crate::debug_state::DebugState;
 use crate::kurbo::Circle;
 use crate::widget::prelude::*;
-use crate::widget::{Axis, CrossAxisAlignment, Flex, Label};
+use crate::widget::{Axis, CrossAxisAlignment, Flex, SizedBox};
 use crate::{theme, Data, LinearGradient, UnitPoint};
 use tracing::{instrument, trace};
 
@@ -31,7 +31,7 @@ impl RadioGroup {
     /// Given a vector of `(label_text, enum_variant)` tuples, create a group of Radio buttons
     /// along the vertical axis.
     pub fn column<T: Data + PartialEq>(
-        variants: impl IntoIterator<Item = (Label<T>, T)>,
+        variants: impl IntoIterator<Item = (SizedBox<T>, T)>,
     ) -> impl Widget<T> {
         RadioGroup::for_axis(Axis::Vertical, variants)
     }
@@ -39,7 +39,7 @@ impl RadioGroup {
     /// Given a vector of `(label_text, enum_variant)` tuples, create a group of Radio buttons
     /// along the horizontal axis.
     pub fn row<T: Data + PartialEq>(
-        variants: impl IntoIterator<Item = (Label<T>, T)>,
+        variants: impl IntoIterator<Item = (SizedBox<T>, T)>,
     ) -> impl Widget<T> {
         RadioGroup::for_axis(Axis::Horizontal, variants)
     }
@@ -48,7 +48,7 @@ impl RadioGroup {
     /// along the specified axis.
     pub fn for_axis<T: Data + PartialEq>(
         axis: Axis,
-        variants: impl IntoIterator<Item = (Label<T>, T)>,
+        variants: impl IntoIterator<Item = (SizedBox<T>, T)>,
     ) -> impl Widget<T> {
         let mut col = Flex::for_axis(axis).cross_axis_alignment(CrossAxisAlignment::Start);
         let mut is_first = true;
@@ -67,12 +67,12 @@ impl RadioGroup {
 /// A single radio button
 pub struct Radio<T> {
     variant: T,
-    child_label: Label<T>,
+    child_label: SizedBox<T>,
 }
 
 impl<T: Data> Radio<T> {
     /// Create a lone Radio button from label text and an enum variant
-    pub fn new(label: Label<T>, variant: T) -> Radio<T> {
+    pub fn new(label: SizedBox<T>, variant: T) -> Radio<T> {
         Radio {
             variant,
             child_label: label,

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -21,8 +21,8 @@ use crate::widget::{Axis, CrossAxisAlignment, Flex, Label};
 use crate::{theme, Data, LinearGradient, UnitPoint};
 use tracing::{instrument, trace};
 
-const DEFAULT_RADIO_RADIUS: f64 = 7.0;
-const INNER_CIRCLE_RADIUS: f64 = 2.0;
+//const DEFAULT_RADIO_RADIUS: f64 = 7.0;
+//const INNER_CIRCLE_RADIUS: f64 = 2.0;
 /// A group of radio buttons
 #[derive(Debug, Clone)]
 pub struct RadioGroup;
@@ -182,7 +182,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
         }
 
         // Paint the text label
-        self.child_label.draw_at(ctx, (size + x_padding, 0.0));
+        self.child_label.draw_at(ctx, (size/2. + x_padding, 0.0));
     }
 
     fn debug_state(&self, data: &T) -> DebugState {

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -127,13 +127,13 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         bc.debug_check("Radio");
 
-        //let label_size = self.child_label.layout(ctx, bc, data, env);
+        let label_size = self.child_label.layout(ctx, bc, data, env);
         let radio_diam = self.button_size; //env.get(theme::BASIC_WIDGET_HEIGHT);
         let x_padding = env.get(theme::WIDGET_CONTROL_COMPONENT_PADDING);
 
         let desired_size = Size::new(
-            /*label_size.width + */radio_diam + x_padding,
-            radio_diam.max(self.button_size/*label_size.height*/),
+            label_size.width + radio_diam + x_padding,
+            radio_diam.max(label_size.height),
         );
         let size = bc.constrain(desired_size);
         trace!("Computed size: {}", size);
@@ -145,7 +145,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
         let size = self.button_size; //env.get(theme::BASIC_WIDGET_HEIGHT);
         let x_padding = env.get(theme::WIDGET_CONTROL_COMPONENT_PADDING);
 
-        let circle = Circle::new((size / 2., size / 2.), /*DEFAULT_RADIO_RADIUS*/ size);
+        let circle = Circle::new((size / 2., size / 2.), size);
 
         // Paint the background
         let background_gradient = LinearGradient::new(

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -183,7 +183,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
         }
 
         // Paint the text label
-        self.child_label.draw_at(ctx, (size + x_padding, -2.0));
+        self.child_label.draw_at(ctx, (size + x_padding, (size/(size/2.0)*-1.0-1.0).ceil()));
     }
 
     fn debug_state(&self, data: &T) -> DebugState {

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -17,7 +17,7 @@
 use crate::debug_state::DebugState;
 use crate::kurbo::Circle;
 use crate::widget::prelude::*;
-use crate::widget::{Axis, CrossAxisAlignment, Flex, Label, LabelText};
+use crate::widget::{Axis, CrossAxisAlignment, Flex, Label};
 use crate::{theme, Data, LinearGradient, UnitPoint};
 use tracing::{instrument, trace};
 
@@ -31,7 +31,7 @@ impl RadioGroup {
     /// Given a vector of `(label_text, enum_variant)` tuples, create a group of Radio buttons
     /// along the vertical axis.
     pub fn column<T: Data + PartialEq>(
-        variants: impl IntoIterator<Item = (impl Into<LabelText<T>> + 'static, T)>,
+        variants: impl IntoIterator<Item = (Label<T>, T)>,
     ) -> impl Widget<T> {
         RadioGroup::for_axis(Axis::Vertical, variants)
     }
@@ -39,7 +39,7 @@ impl RadioGroup {
     /// Given a vector of `(label_text, enum_variant)` tuples, create a group of Radio buttons
     /// along the horizontal axis.
     pub fn row<T: Data + PartialEq>(
-        variants: impl IntoIterator<Item = (impl Into<LabelText<T>> + 'static, T)>,
+        variants: impl IntoIterator<Item = (Label<T>, T)>,
     ) -> impl Widget<T> {
         RadioGroup::for_axis(Axis::Horizontal, variants)
     }
@@ -48,7 +48,7 @@ impl RadioGroup {
     /// along the specified axis.
     pub fn for_axis<T: Data + PartialEq>(
         axis: Axis,
-        variants: impl IntoIterator<Item = (impl Into<LabelText<T>> + 'static, T)>,
+        variants: impl IntoIterator<Item = (Label<T>, T)>,
     ) -> impl Widget<T> {
         let mut col = Flex::for_axis(axis).cross_axis_alignment(CrossAxisAlignment::Start);
         let mut is_first = true;
@@ -72,10 +72,10 @@ pub struct Radio<T> {
 
 impl<T: Data> Radio<T> {
     /// Create a lone Radio button from label text and an enum variant
-    pub fn new(label: impl Into<LabelText<T>>, variant: T) -> Radio<T> {
+    pub fn new(label: Label<T>, variant: T) -> Radio<T> {
         Radio {
             variant,
-            child_label: Label::new(label).with_text_size(10.0),
+            child_label: label,
         }
     }
 }

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -75,7 +75,7 @@ impl<T: Data> Radio<T> {
     pub fn new(label: impl Into<LabelText<T>>, variant: T) -> Radio<T> {
         Radio {
             variant,
-            child_label: Label::new(label),
+            child_label: Label::new(label).with_text_size(10.0),
         }
     }
 }

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -183,7 +183,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
         }
 
         // Paint the text label
-        self.child_label.draw_at(ctx, (size + x_padding, size));
+        self.child_label.draw_at(ctx, (size + x_padding, 0.0));
     }
 
     fn debug_state(&self, data: &T) -> DebugState {

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -183,7 +183,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
         }
 
         // Paint the text label
-        self.child_label.draw_at(ctx, (size + x_padding, 0.0));
+        self.child_label.draw_at(ctx, (size + x_padding, size/2.));
     }
 
     fn debug_state(&self, data: &T) -> DebugState {

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -127,13 +127,13 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         bc.debug_check("Radio");
 
-        let label_size = self.child_label.layout(ctx, bc, data, env);
+        //let label_size = self.child_label.layout(ctx, bc, data, env);
         let radio_diam = self.button_size; //env.get(theme::BASIC_WIDGET_HEIGHT);
         let x_padding = env.get(theme::WIDGET_CONTROL_COMPONENT_PADDING);
 
         let desired_size = Size::new(
-            label_size.width + radio_diam + x_padding,
-            radio_diam.max(label_size.height),
+            /*label_size.width + */radio_diam + x_padding,
+            radio_diam.max(self.button_size/*label_size.height*/),
         );
         let size = bc.constrain(desired_size);
         trace!("Computed size: {}", size);
@@ -145,7 +145,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
         let size = self.button_size; //env.get(theme::BASIC_WIDGET_HEIGHT);
         let x_padding = env.get(theme::WIDGET_CONTROL_COMPONENT_PADDING);
 
-        let circle = Circle::new((size / 2., size / 2.), DEFAULT_RADIO_RADIUS);
+        let circle = Circle::new((size / 2., size / 2.), /*DEFAULT_RADIO_RADIUS*/ size);
 
         // Paint the background
         let background_gradient = LinearGradient::new(

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -147,7 +147,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
         let size = self.size;//env.get(theme::BASIC_WIDGET_HEIGHT);
         let x_padding = self.padding;//env.get(theme::WIDGET_CONTROL_COMPONENT_PADDING);
 
-        let circle = Circle::new((size / 2., size / 2.), size);
+        let circle = Circle::new((size / 2., size / 2.), size/2.);
 
         // Paint the background
         let background_gradient = LinearGradient::new(
@@ -171,7 +171,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
 
         // Check if data enum matches our variant
         if *data == self.variant {
-            let inner_circle = Circle::new((size / 2., size / 2.), size);
+            let inner_circle = Circle::new((size / 2., size / 2.), (size/3.).ceil());
 
             let fill = if ctx.is_disabled() {
                 env.get(theme::DISABLED_TEXT_COLOR)

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -164,12 +164,12 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
         } else {
             env.get(theme::BORDER_DARK)
         };
-
-        ctx.stroke(circle, &border_color, 1.);
+        
+        ctx.stroke(circle, &border_color, 2.);
 
         // Check if data enum matches our variant
         if *data == self.variant {
-            let inner_circle = Circle::new((size / 2., size / 2.), INNER_CIRCLE_RADIUS);
+            let inner_circle = Circle::new((size / 2., size / 2.), (size/3.0).ceil());
 
             let fill = if ctx.is_disabled() {
                 env.get(theme::DISABLED_TEXT_COLOR)

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -21,8 +21,8 @@ use crate::widget::{Axis, CrossAxisAlignment, Flex, Label, LabelText};
 use crate::{theme, Data, LinearGradient, UnitPoint};
 use tracing::{instrument, trace};
 
-const DEFAULT_RADIO_RADIUS: f64 = 7.0;
-const INNER_CIRCLE_RADIUS: f64 = 2.0;
+//const DEFAULT_RADIO_RADIUS: f64 = 7.0;
+//const INNER_CIRCLE_RADIUS: f64 = 2.0;
 /// A group of radio buttons
 #[derive(Debug, Clone)]
 pub struct RadioGroup;
@@ -171,7 +171,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
 
         // Check if data enum matches our variant
         if *data == self.variant {
-            let inner_circle = Circle::new((size / 2., size / 2.), (size/3.).ceil());
+            let inner_circle = Circle::new((size / 2., size / 2.), (size/4.).ceil());
 
             let fill = if ctx.is_disabled() {
                 env.get(theme::DISABLED_TEXT_COLOR)


### PR DESCRIPTION
With this you can change the size of the radio group's radios by passing 'size' and 'padding'.
The 'size' adjusts the scaling generally for the button and the label. Padding sets the distance from the button to the label.