### PR TITLE
Remove deprecated `text::format` export.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ You can find its changes [documented below](#083---2023-02-28).
 
 ### Removed
 
+- `text::format` module which was previously deprecated. ([#2413] by [@xStrom])
+
 ### Fixed
 
 - `syn` feature `extra-traits` is now always enabled. ([#2375] by [@AtomicGamer9523])
@@ -1244,6 +1246,7 @@ Last release without a changelog :(
 [#2380]: https://github.com/linebender/druid/pull/2380
 [#2402]: https://github.com/linebender/druid/pull/2402
 [#2409]: https://github.com/linebender/druid/pull/2409
+[#2413]: https://github.com/linebender/druid/pull/2413
 
 [Unreleased]: https://github.com/linebender/druid/compare/v0.8.3...master
 [0.8.3]: https://github.com/linebender/druid/compare/v0.8.2...v0.8.3

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -139,7 +139,6 @@
 )]
 #![warn(missing_docs)]
 #![allow(clippy::new_ret_no_self, clippy::needless_doctest_main)]
-#![allow(clippy::duplicate_mod)] // TODO: Remove this after the text/mod.rs format_priv hack has been removed (0.8.0+)
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/linebender/druid/screenshots/images/doc_logo.png"

--- a/druid/src/text/mod.rs
+++ b/druid/src/text/mod.rs
@@ -7,14 +7,7 @@ mod attribute;
 mod backspace;
 mod editable_text;
 mod font_descriptor;
-
-#[deprecated(since = "0.8.0", note = "use types from druid::text module instead")]
-#[doc(hidden)]
-pub mod format;
-// a hack to let us deprecate the format module; we can remove this when we make
-// format private
-#[path = "format.rs"]
-mod format_priv;
+mod format;
 mod input_component;
 mod input_methods;
 mod layout;
@@ -32,7 +25,7 @@ pub use self::attribute::{Attribute, AttributeSpans, Link};
 pub use self::backspace::offset_for_delete_backwards;
 pub use self::editable_text::{EditableText, EditableTextCursor, StringCursor};
 pub use self::font_descriptor::FontDescriptor;
-pub use self::format_priv::{Formatter, ParseFormatter, Validation, ValidationError};
+pub use self::format::{Formatter, ParseFormatter, Validation, ValidationError};
 pub use self::layout::{LayoutMetrics, TextLayout};
 pub use self::movement::movement;
 pub use input_component::{EditSession, TextComponent};


### PR DESCRIPTION
Clean up the code from this confusing hack which also disabled a clippy lint.