### PR TITLE
Do not propagate_to_hidden RouteFocusChanged events

### DIFF
--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -500,9 +500,9 @@ impl InternalLifeCycle {
     pub fn should_propagate_to_hidden(&self) -> bool {
         match self {
             InternalLifeCycle::RouteWidgetAdded
-            | InternalLifeCycle::RouteFocusChanged { .. }
             | InternalLifeCycle::RouteDisabledChanged => true,
-            InternalLifeCycle::RouteViewContextChanged { .. } => false,
+            InternalLifeCycle::RouteViewContextChanged { .. }
+            | InternalLifeCycle::RouteFocusChanged { .. } => false,
             InternalLifeCycle::DebugRequestState { .. }
             | InternalLifeCycle::DebugRequestDebugState { .. }
             | InternalLifeCycle::DebugInspectState(_) => true,


### PR DESCRIPTION
This fixes a bug I've been having when trying to update https://github.com/smmalis37/sudoku_rust from Druid v0.7 to v0.8. To reproduce the bug:
* Checkout the repo at commit dd9d368141005663b8ce99fa40e491dc3df48340
* Update Druid in Cargo.toml to v0.8
* Change line 14 in main.rs to call make_grid instead of passing it
* Change line 235 in grid_space.rs to look for the new BuildFocusChain instead of WidgetAdded
* Run the app
* Click on multiple boxes and type in them

On my system this results in bizarrely inconsistent behavior, where some boxes will accept text input, but other boxes won't, seemingly randomly. I've done a bunch of debugging and this PR is my conclusion.

The root of the problem seems to be that BuildFocusChain isn't routed to hidden widgets but RouteFocusChanged is. When combining this with an Either, I seem to get into a state where every RouteFocusChanged event gets routed to both sides of the Either, resulting in merge_up seeing the hidden child having child_state.update_focus_chain be true, which leads to a BuildFocusChain event getting sent, which doesn't go to the hidden side, meaning that side's update_focus_chain never gets cleared. This means we're rebuilding the focus chain in the middle of handling every focus change, which I imagine can cause weirdness and doesn't feel right to me. 

Some spot checking of other areas in the code also makes me feel that this is the right thing to be doing. For example RouteDisabledChanged already handles resigning focus if it previously had it, so RouteFocusChanged still going to a newly disabled widget shouldn't be necessary I think.